### PR TITLE
feat: allow specifying init container tag in Stack helm chart

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -125,9 +125,9 @@ env: []
 {{- end }}
 
 {{- define "initContainer.image" -}}
-{{- if typeIs "string" .image }}
-string-img
+{{- if typeIs "string" .Values.image }}
+image: {{ .Values.image }}
 {{ else }}
-repo:tag
+image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
 {{- end }}
 {{- end }}

--- a/stack/templates/deployment.yaml
+++ b/stack/templates/deployment.yaml
@@ -88,8 +88,8 @@ spec:
         {{- end }}
       initContainers:
       {{- range $i, $container := .Values.initContainers }}
-      {{- $image := (include "initContainer.image" $container) }}
-      {{- $container = set $container "image" $image }}
+      {{- $imageDict := fromYaml (include "initContainer.image" (dict "Chart" $global.Chart "Values" $container)) }}
+      {{- $container = mergeOverwrite $container $imageDict }}
       {{- with omit $container "envFrom" }}
         - {{- toYaml . | nindent 10 }}
           {{- include "service.configuration" $service | nindent 10}}


### PR DESCRIPTION
This change allows us to continue specifying the image as a string formatted like `<repo>:<tag>` and also adds support to allow us to specify repo and tag as separate tags, allowing the `argus-docker-builder` action to replace the tag with the sha that it just built. 

## Specifying as a string
<img width="302" alt="Screenshot 2024-06-14 at 8 18 00 AM" src="https://github.com/chanzuckerberg/argo-helm-charts/assets/105455169/1ba2f2cb-bb07-4498-b502-068ee73d21cc">

Rendered manifest:
<img width="234" alt="Screenshot 2024-06-14 at 8 20 11 AM" src="https://github.com/chanzuckerberg/argo-helm-charts/assets/105455169/6a5259f6-3b0d-4f47-a0a5-88d846eefb19">

## Specifying as an object
<img width="297" alt="Screenshot 2024-06-14 at 8 20 54 AM" src="https://github.com/chanzuckerberg/argo-helm-charts/assets/105455169/04beaba3-86de-477d-be66-3771679130f1">

Rendered manifest:
<img width="256" alt="Screenshot 2024-06-14 at 8 21 40 AM" src="https://github.com/chanzuckerberg/argo-helm-charts/assets/105455169/3984244c-5656-4ddd-a489-882800687759">
