### PR TITLE
feat: add support for tcp probes

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -104,6 +104,10 @@ image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.App
 {{- end }}
 {{- end }}
 
+{{/*
+The default values in this chart adds httpGet probes to the deployment.
+Container probes cannot have both httpGet and tcpSocket fields, so we use omit to remove one of them.
+*/}}
 {{- define "container.probe" -}}
 {{- if .tcpSocket -}}
 {{- toYaml (omit . "httpGet") }}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -103,3 +103,11 @@ image: {{ .Values.image }}
 image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
 {{- end }}
 {{- end }}
+
+{{- define "container.probe" -}}
+{{- if .tcpSocket -}}
+{{- toYaml (omit . "httpGet") }}
+{{- else }}
+{{- toYaml (omit . "tcpSocket") }}
+{{- end }}
+{{- end }}

--- a/stack/templates/deployment.yaml
+++ b/stack/templates/deployment.yaml
@@ -62,12 +62,12 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- include "container.probe" .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- include "container.probe" .Values.readinessProbe | nindent 12 }}
           {{- if eq .Values.startupProbe.enabled true }}
           startupProbe:
-            {{- toYaml (omit .Values.startupProbe "enabled") | nindent 12 }}
+            {{- include "container.probe" (omit .Values.startupProbe "enabled") | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Adds support for `tcpSocket` container probes

The default values sets up `httpGet` probes and the default merging means configuring a `tcpSocket` probe puts both `httpGet` and `tcpSocket` keys in the probe sub-object. This leads to invalid Deployment K8s manifests, so we have to use the `omit` functionality of Helm to achieve desired manifest.