### PR TITLE
Fix pvc manifest

### DIFF
--- a/stack/templates/pvc.yaml
+++ b/stack/templates/pvc.yaml
@@ -6,7 +6,7 @@
   {{- $values := mergeOverwrite $values $serviceValues -}}
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service -}}
----
+
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1


### PR DESCRIPTION
When defining more than one services, the rendered pvc manifests ends up containing two `---` lines which throws an error. This appears to fix the issue.