### PR TITLE
fix: make default conversionStrategy and decodingStrategy explicit to prevent ArgoCD showing diff/out-of-sync

### DIFF
--- a/argus-config/templates/external_secrets_env.yaml
+++ b/argus-config/templates/external_secrets_env.yaml
@@ -25,6 +25,8 @@ spec:
     - secretKey: {{ $secretValue.secretName }}
       remoteRef:
         key: {{ $secretValue.secretKey }}
+        conversionStrategy: Default
+        decodingStrategy: None
 {{end}}
 {{end}}
 {{end}}


### PR DESCRIPTION
Explicitly add default values so ArgoCD doesn't think there's a diff that is needs to sync.

https://chanzuckerbergteam.slack.com/archives/C073N4PGFAN/p1723136709006189