### PR TITLE
fix: terraform and helm fighting over which values to use

### DIFF
--- a/argus-config/templates/external_secrets_env.yaml
+++ b/argus-config/templates/external_secrets_env.yaml
@@ -1,6 +1,9 @@
 {{ $global := . }}
 {{- with $global.Values.global }}
-{{ range $secretsKey, $secretValue := .appSecrets }}
+
+# omit the clusterSecret because the clusterSecret ExternalSecret is created automatically
+# by the ClusterExternalSecret in argus-infra-stacks.
+{{ range $secretsKey, $secretValue := (omit .appSecrets "clusterSecret") }}
 {{- if ne (trim $secretValue.secretName) "" }}
 ---
 apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
## Summary

Terraform in argus-infra-stacks creates the ClusterExternalSecret resource which is used to make ExternalSecrets in all of the cluster. This PR fixes a bug where this helm chart was trying to overwrite the values in that ExternalSecret, causing conflicts and the argo application to show up in a not-synced state.