### PR TITLE
fix: make extra args an array

### DIFF
--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -31,13 +31,9 @@ spec:
             - --skip-provider-button=true
             - --pass-authorization-header=true
             - --reverse-proxy
-            {{- range $key, $value := .Values.global.oidcProxy.extraArgs }}
-              {{- if not (kindIs "invalid" $value) }}
-            - --{{ $key }}={{ tpl ($value | toString) $ }}
-              {{- else -}}
-            - --{{ $key }}
-              {{- end -}}
-            {{- end -}}
+            {{- if gt (len .Values.global.oidcProxy.extraArgs) 0 }}
+            {{- toYaml .Values.global.oidcProxy.extraArgs | nindent 12}}
+            {{- end }}
           {{- include "image" .Values.global.oidcProxy  | nindent 10 }}
           {{- if gt (len (fromYamlArray (include "oidcProxy.envFrom" .))) 0 }}
           envFrom: 

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -89,3 +89,24 @@ tests:
         equal:
           path: spec.template.spec.containers[0].envFrom
           value: []
+  - it: sets extraArgs properly
+    set:
+      global:
+        oidcProxy:
+          enabled: true
+          extraArgs:
+            - "--skip-auth-route=/v1/api/docs"
+            - "--skip-auth-route=/v1/api/security/access_token"
+    asserts:
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.template.spec.containers[0].args
+          count: 14
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[12]
+          value: "--skip-auth-route=/v1/api/docs"
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[13]
+          value: "--skip-auth-route=/v1/api/security/access_token"

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -191,8 +191,10 @@ global:
       tag: v7.6.0
     replicaCount: 2
     additionalSecrets: []
+    extraArgs: []
     # extraArgs:
-    #   key1: "{{add 1 1}}"
+    #   - --flag
+    #   - --another-flag=2
     resources:
       limits:
         cpu: 2


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `extraArgs` values. Before, it was expected to be a map[string]string. However, many of the flags are non-unique, so being able to specify two identical flags twice wasn't possible. Changing it so that the extraArgs value is an array and the raw strings are injected as flags.