### PR TITLE
feat: Support shareProcessNamespace (defaults to false)

### DIFF
--- a/stack/templates/deployment.yaml
+++ b/stack/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       serviceAccountName: {{ include "service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -113,6 +113,8 @@ global:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  shareProcessNamespace: false
+
   ingress:
     enabled: true
     className: nginx


### PR DESCRIPTION
This is needed to allow OTEL to retrieve spans from an application running in a different container; shareProcessNamespace will have to be set to `true`.