### PR TITLE
fix: missing headers set by oauth2_proxy

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -189,5 +189,5 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "oidcProxy.nginxAuthAnnotations" -}}
 nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oidcProxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:4180/oauth2/auth"
 nginx.ingress.kubernetes.io/auth-signin: "https://{{- include "oidcProxy.authDomain" . }}/oauth2/start?rd=https://$host$escaped_request_uri"
-nginx.ingress.kubernetes.io/auth-response-headers: Authorization
+nginx.ingress.kubernetes.io/auth-response-headers: {{join "," (concat (list "Authorization" "X-Forwarded-Email") .Values.global.oidcProxy.additionalHeaders) }}
 {{- end -}}

--- a/stack/tests/ingress_test.yaml
+++ b/stack/tests/ingress_test.yaml
@@ -28,4 +28,25 @@ tests:
       - documentIndex: 0
         equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
-          value: "Authorization"
+          value: "Authorization,X-Forwarded-Email"
+  - it: adds additional nginx auth headers when using additionalHeaders
+    set:
+      global:
+        ingress:
+          host: "stack.play.dev.czi.team"
+        oidcProxy:
+          enabled: true
+          additionalHeaders:
+            - X-Forwarded-User
+            - blahblahblah
+      services:
+        service1:
+          ingress:
+            oidcProtected: true
+    asserts:
+      - isKind:
+          of: Ingress
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
+          value: "Authorization,X-Forwarded-Email,X-Forwarded-User,blahblahblah"

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -193,6 +193,7 @@ global:
       tag: v7.6.0
     replicaCount: 2
     additionalSecrets: []
+    additionalHeaders: []
     extraArgs: []
     # extraArgs:
     #   - --flag


### PR DESCRIPTION
## Summary

This oauth2_proxy can set headers on successful authentication response from the OIDC provider. Nginx uses the auth-url to trigger the oauth2_proxy, so it also needs to forward these headers. This PR changes the behavior of the helm chart tom by default, pass along the "Authorization" and "X-Forwarded-Email" headers and additionally allowing the user to add additional headers to pass along from the oauth2_proxy with `.Values.global.oidcProxy.additionalHeaders`.

## References

* https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#external-authentication