### PR TITLE
fix: fullname override to work

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -15,8 +15,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "stack.fullname" -}}
-{{- if .fullnameOverride }}
-{{- .fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .nameOverride }}
 {{- if contains $name .Release.Name }}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -18,7 +18,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .nameOverride }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/stack/tests/deployment_test.yaml
+++ b/stack/tests/deployment_test.yaml
@@ -157,3 +157,30 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: "node:20.0.0"
+  - it: overwrites the name
+    set:
+      global:
+        fullnameOverride: "overwrittenfull"
+      services:
+        service1:
+          args: ["arg1", "arg2"]
+          command: ["command1", "command2"]
+          autoscaling:
+            enabled: true
+            minReplicas: 2
+            maxReplicas: 10
+            maxUnavailable: 1
+          replicaCount: 2
+          sidecars:
+            - name: sidecar1
+              image: "sidecar1:latest"
+            - name: sidecar2
+              image: "sidecar2:latest"
+          initContainers:
+            - name: initContainer1
+              image: "alpine:latest"
+              command: ["echo", "Hello World"]
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "overwrittenfull-service1"


### PR DESCRIPTION
## Summary

Allows users to change the names of their CRDs to not include random pet names.