### PR TITLE
feat: allow volumes and volume mounts in oidc proxy

### DIFF
--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -52,7 +52,10 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.oidcProxy.resources | nindent 12 }}
-
+          volumeMounts:
+            {{- toYaml .Values.oidcProxy.volumeMounts| nindent 12 }}
+          volumes:
+            {{- toYaml .Values.oidcProxy.volumes | nindent 12 }}
 ---
 apiVersion: v1
 kind: Service

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -54,8 +54,8 @@ spec:
             {{- toYaml .Values.oidcProxy.resources | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.oidcProxy.volumeMounts| nindent 12 }}
-          volumes:
-            {{- toYaml .Values.oidcProxy.volumes | nindent 12 }}
+      volumes:
+        {{- toYaml .Values.volumes | nindent 12 }}
 ---
 apiVersion: v1
 kind: Service

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -166,3 +166,43 @@ tests:
         equal:
           path: spec.rules[0].host
           value: stack.play.dev.czi.team
+  - it: oidc proxy has volumes mounted
+    set:
+      global:
+        ingress:
+          host: "stack.play.dev.czi.team"
+        oidcProxy:
+          enabled: true
+          volumeMounts:
+            - name: oauth2-proxy-sign-in-template
+              mountPath: /templates/oauth2-proxy/sign_in.html
+              subPath: sign_in.html
+          volumes:
+            - name: oauth2-proxy-sign-in-template
+              configMap:
+                name: oauth2-proxy-sign-in-template
+      services:
+        service1:
+          ingress:
+            oidcProtected: true
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /templates/oauth2-proxy/sign_in.html
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: oauth2-proxy-sign-in-template
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+          value: sign_in.html
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].volumes[0].name
+          value: oauth2-proxy-sign-in-template
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].volumes[0].configMap.name
+          value: oauth2-proxy-sign-in-template

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -177,10 +177,10 @@ tests:
             - name: oauth2-proxy-sign-in-template
               mountPath: /templates/oauth2-proxy/sign_in.html
               subPath: sign_in.html
-          volumes:
-            - name: oauth2-proxy-sign-in-template
-              configMap:
-                name: oauth2-proxy-sign-in-template
+        volumes:
+          - name: oauth2-proxy-sign-in-template
+            configMap:
+              name: oauth2-proxy-sign-in-template
       services:
         service1:
           ingress:
@@ -200,9 +200,9 @@ tests:
           value: sign_in.html
       - documentIndex: 0
         equal:
-          path: spec.template.spec.containers[0].volumes[0].name
+          path: spec.template.spec.volumes[0].name
           value: oauth2-proxy-sign-in-template
       - documentIndex: 0
         equal:
-          path: spec.template.spec.containers[0].volumes[0].configMap.name
+          path: spec.template.spec.volumes[0].configMap.name
           value: oauth2-proxy-sign-in-template

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -192,6 +192,8 @@ global:
     replicaCount: 2
     additionalSecrets: []
     additionalHeaders: []
+    volumes: []
+    volumeMounts: []
     skipAuth: []
     # skipAuth:
     #   - path: "/healthz"

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -192,7 +192,6 @@ global:
     replicaCount: 2
     additionalSecrets: []
     additionalHeaders: []
-    volumes: []
     volumeMounts: []
     skipAuth: []
     # skipAuth:


### PR DESCRIPTION
## Summary

Allow for the oidc proxy containers to have volumes and volume mounts specified in their configuration. Helpful for when folks want to customize the HTML templates that are loaded for sign_in and sign_out.