### PR TITLE
fix: add additional hosts to the oidc proxy ingress

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -205,7 +205,7 @@ if ( ${{ $var_name }} ) {
 
 {{- define "oidcProxy.nginxAuthAnnotations" -}}
 nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oidcProxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:4180/oauth2/auth"
-nginx.ingress.kubernetes.io/auth-signin: "https://{{- include "oidcProxy.authDomain" . }}/oauth2/start?rd=https://$host$escaped_request_uri"
+nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/sign_in?rd=https://$host$escaped_request_uri"
 nginx.ingress.kubernetes.io/auth-response-headers: {{join "," (concat (list "Authorization" "X-Auth-Request-User" "X-Auth-Request-Groups" "X-Auth-Request-Email" "X-Auth-Request-Preferred-Username") .Values.oidcProxy.additionalHeaders) }}
 nginx.ingress.kubernetes.io/auth-snippet: |
 {{- include "oidcProxy.skipAuthConfig" . | nindent 4 }}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -1,4 +1,20 @@
 {{ $global := . }}
+{{- $allHosts := list -}}
+{{ range $serviceName, $serviceValues := .Values.services }}
+  {{- $globalValuesDict := $global.Values.global | toYaml -}}
+  {{- $values := fromYaml $globalValuesDict -}}
+  {{- $values = set $values "name" $serviceName -}}
+  {{- $values := mergeOverwrite $values $serviceValues -}}
+
+  {{- with $values -}}
+  {{- if .ingress.oidcProtected -}}
+  {{ range $i, $rule := .ingress.rules }}
+  {{- $allHosts = append $allHosts $rule.host }}
+  {{- end -}}
+  {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{ $globalValues := .Values.global }}
 {{ $scope := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $globalValues}}
 {{ with $scope }}
@@ -116,6 +132,19 @@ spec:
                 name: {{ include "oidcProxy.name" . }}
                 port:
                   number: {{ include "oidcProxy.port" . }}
+    {{- $scope := . }}
+    {{- range $i, $host := $allHosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "oidcProxy.name" $scope }}
+                port:
+                  number: {{ include "oidcProxy.port" $scope }}
+    {{- end }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -59,6 +59,10 @@ spec:
             - --pass-authorization-header=true
             - --reverse-proxy
             - --skip-jwt-bearer-tokens
+            {{- range $allHosts -}}
+            {{- printf "- --whitelist-domain=%s" . | nindent 12 -}}
+            {{- printf "- --cookie-domain=%s" . | nindent 12 -}}
+            {{- end -}}
             {{- if gt (len .Values.oidcProxy.extraArgs) 0 }}
             {{- toYaml .Values.oidcProxy.extraArgs | nindent 12}}
             {{- end }}

--- a/stack/tests/ingress_test.yaml
+++ b/stack/tests/ingress_test.yaml
@@ -24,7 +24,7 @@ tests:
       - documentIndex: 0
         equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
-          value: "https://stack.play.dev.czi.team/oauth2/start?rd=https://$host$escaped_request_uri"
+          value: "https://$host/oauth2/sign_in?rd=https://$host$escaped_request_uri"
       - documentIndex: 0
         equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
@@ -104,8 +104,6 @@ tests:
       global:
         ingress:
           host: stack.play.dev.czi.team
-          annotations:
-            nginx.ingress.kubernetes.io/auth-signin: "https://upward-crappie.dev-vcp.dev.czi.team/oauth2/sign_in?rd=https://$host$escaped_request_uri"
         oidcProxy:
           enabled: true
           skipAuth:

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -281,3 +281,56 @@ tests:
         equal:
           path: .metadata.annotations.test3
           value: test3
+  - it: should have multiple ingress rules for the stack hosts
+    set:
+      global:
+        ingress:
+          host: "stack.play.dev.czi.team"
+          rules:
+            - host: "stack2.com"
+        oidcProxy:
+          enabled: true
+      services:
+        service1:
+          ingress:
+            oidcProtected: true
+            rules:
+              - host: "service1.stack2.com"
+        service2:
+          ingress:
+            oidcProtected: true
+            rules:
+              - host: "service2.stack2.com"
+        service3:
+          ingress:
+            oidcProtected: true
+        service4:
+          ingress:
+            oidcProtected: false
+            rules:
+              - host: "service4.stack2.com"
+    asserts:
+      - documentIndex: 2
+        containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+          name: release-name-stack-oidc-proxy
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[0].host
+          value: stack.play.dev.czi.team
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[1].host
+          value: service1.stack2.com
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[2].host
+          value: service2.stack2.com
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[3].host
+          value: stack2.com
+      - documentIndex: 2
+        notExists:
+          path: .spec.rules[4]

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -339,26 +339,26 @@ tests:
           path: spec.template.spec.containers[0].args
           count: 19
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[18]
-          value: --cookie-domain=stack2.com
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --whitelist-domain=service1.stack2.com
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[17]
-          value: --whitelist-domain=stack2.com
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --cookie-domain=service1.stack2.com
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[16]
-          value: --cookie-domain=service2.stack2.com
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --whitelist-domain=service2.stack2.com
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[15]
-          value: --whitelist-domain=service2.stack2.com
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --cookie-domain=service2.stack2.com
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[14]
-          value: --cookie-domain=service1.stack2.com
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --whitelist-domain=stack2.com
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[13]
-          value: --whitelist-domain=service1.stack2.com
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --cookie-domain=stack2.com

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -334,3 +334,31 @@ tests:
       - documentIndex: 2
         notExists:
           path: .spec.rules[4]
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.template.spec.containers[0].args
+          count: 19
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[18]
+          value: --cookie-domain=stack2.com
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[17]
+          value: --whitelist-domain=stack2.com
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[16]
+          value: --cookie-domain=service2.stack2.com
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[15]
+          value: --whitelist-domain=service2.stack2.com
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[14]
+          value: --cookie-domain=service1.stack2.com
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].args[13]
+          value: --whitelist-domain=service1.stack2.com


### PR DESCRIPTION
## Summary

The ingress CRD for the oauth2_proxy was missing additional hosts that were specified in the configuration. This change combines all the hosts from the configuration that have `oidcProtected = true` to the list of oauth2_proxy hosts. 

Additionally, it changes the default route to sign in from the Argus URL at "/oauth2/start" to whatever domain you are currently on at "/oauth2/sign_in". Changing to whatever domain you are currently on allows support for logging in through a different domain other than the Argus domain (we don't want to redirect to a different domain like the pet name ones when we are on a production domain when logging in). 

The change to "/oauth2/sign_in" allows people to be able to display the oauth2 landing page if they want to enable it like they do in litqa agent. Otherwise, there is no difference in behavior.