### PR TITLE
feat: share wildcard certificate for czi.team domains

### DIFF
--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -49,10 +49,10 @@ spec:
                 port:
                   number: {{ $svcPort }}
           {{- end }}
-    {{ $hosts := list}}
+    {{ $customHosts := list}}
     {{ range $i, $rule := .Values.ingress.rules }}
     {{- $ruleValues := mergeOverwrite (dict "host" $service.Values.ingress.host "paths" $service.Values.ingress.paths) $rule -}}
-    {{ $hosts = append $hosts $ruleValues.host }}
+    {{ $customHosts = append $customHosts $ruleValues.host }}
     - host: {{ $ruleValues.host | quote }}
       http:
         paths:
@@ -69,17 +69,22 @@ spec:
           {{- end }}
     {{ end }}
   tls:
+    - hosts:
+      - {{ $service.Values.ingress.host  }}
+      secretName: letsencrypt-prod-dns-cluster-wildcard
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ .  }}
         {{- end }}
       secretName: {{ .secretName }}
-   {{- end }}
+    {{- end }}
+   {{ if gt (len $customHosts) 0 }}
     - hosts:
-      {{- toYaml (append $hosts .Values.ingress.host) | nindent 6 }}
-      {{- $secretName := printf "%s-%s" .Values.ingress.host "tls-secret" }}
+      {{- toYaml $customHosts | nindent 6 }}
+      {{- $secretName := printf "%s-%s-%s" "custom-hosts" (include "stack.fullname" .) "tls-secret" }}
       secretName: {{  regexReplaceAll "[^a-zA-Z0-9-]" $secretName "-" }}
+    {{- end -}}
 {{- end }}
 ---
 {{- end }}

--- a/stack/tests/ingress_test.yaml
+++ b/stack/tests/ingress_test.yaml
@@ -102,6 +102,7 @@ tests:
   - it: adds adds certManager annotations
     set:
       global:
+        fullnameOverride: missing-otter
         ingress:
           host: stack.play.dev.czi.team
         oidcProxy:
@@ -146,18 +147,38 @@ tests:
           path: spec.tls[0].hosts
           content: stack.play.dev.czi.team
       - documentIndex: 0
-        contains:
+        notContains:
           path: spec.tls[0].hosts
           content: api.cellxgene.cziscience.com
       - documentIndex: 0
-        contains:
+        notContains:
           path: spec.tls[0].hosts
           content: cellxgene.cziscience.com
       - documentIndex: 0
         equal:
           path: spec.tls[0].secretName
-          value: stack-play-dev-czi-team-tls-secret
+          value: letsencrypt-prod-dns-cluster-wildcard
+      - documentIndex: 0
+        notContains:
+          path: spec.tls[1].hosts
+          content: stack.play.dev.czi.team
+      - documentIndex: 0
+        contains:
+          path: spec.tls[1].hosts
+          content: api.cellxgene.cziscience.com
+      - documentIndex: 0
+        contains:
+          path: spec.tls[1].hosts
+          content: cellxgene.cziscience.com
+      - documentIndex: 0
+        equal:
+          path: spec.tls[1].secretName
+          value: custom-hosts-missing-otter-tls-secret
       - documentIndex: 0
         lengthEqual:
           path: spec.tls[0].hosts
-          count: 3
+          count: 1
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.tls[1].hosts
+          count: 2


### PR DESCRIPTION
## Summary

This change splits the TLS sections of the ingress so that all *.czi.team domains reuse the cluster-wide TLS certificates. Custom hosts still will issue new certificates. This will help with development environments from blowing through our letsencrypt rate limit.

## References

* https://github.com/chanzuckerberg/argus-infra-stacks/pull/204