### PR TITLE
fix: broken oauth2_proxy flags; change the behavior of oauth2_proxy to be used as proxy

### DIFF
--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{ $global := . }}
+{{- $global := . -}}
 {{ range $serviceName, $serviceValues := .Values.services }}
   {{- $globalValuesDict := $global.Values.global | toYaml -}}
   {{- $values := fromYaml $globalValuesDict -}}
@@ -7,25 +7,18 @@
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}
 
+{{- if .Values.ingress.enabled -}}
 ---
-{{ if .Values.ingress.enabled }}
-{{- $fullName := include "service.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "service.fullname" .  }}
   labels:
     {{- include "service.labels" . | nindent 4 }}
-  {{- $nginxAuthAnnotations := dict}}
-    {{- if .Values.ingress.oidcProtected }}
-    {{- $nginxAuthAnnotations = (fromYaml (include "oidcProxy.nginxAuthAnnotations" . )) -}}
-    {{- end}}
     {{- $certManagerAnnotations := (fromYaml (include "certManagerAnnotations" . )) }}
   annotations:
     {{- with (mergeOverwrite 
                 (dict)
-                ($nginxAuthAnnotations)
                 ($certManagerAnnotations)
                 (.Values.annotations) 
                 (.Values.ingress.annotations)
@@ -45,15 +38,13 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
+                {{- include "service.backend" $service | nindent 16}}
           {{- end }}
-    {{ $customHosts := list}}
-    {{ range $i, $rule := .Values.ingress.rules }}
+    {{- $customHosts := list -}}
+    {{- range $i, $rule := .Values.ingress.rules -}}
     {{- $ruleValues := mergeOverwrite (dict "host" $service.Values.ingress.host "paths" $service.Values.ingress.paths) $rule -}}
     {{ $customHosts = append $customHosts $ruleValues.host }}
-    - host: {{ $ruleValues.host | quote }}
+    - host: {{ $ruleValues.host }}
       http:
         paths:
           {{- range $ruleValues.paths }} 
@@ -63,11 +54,9 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-          {{- end }}
-    {{ end }}
+                {{- (include "service.backend" $service) | nindent 16 -}}
+          {{ end -}}
+    {{- end }}
   tls:
     - hosts:
       - {{ $service.Values.ingress.host  }}
@@ -83,8 +72,7 @@ spec:
       {{- toYaml $customHosts | nindent 6 }}
       {{- $secretName := printf "%s-%s-%s" "custom-hosts" (include "stack.fullname" .) "tls-secret" }}
       secretName: {{  regexReplaceAll "[^a-zA-Z0-9-]" $secretName "-" }}
-    {{- end -}}
-{{- end }}
----
+    {{ end }}
+{{ end }}
 {{- end }}
 {{- end }}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -60,7 +60,11 @@ spec:
             - --reverse-proxy
             - --skip-jwt-bearer-tokens
             {{- range .Values.oidcProxy.skipAuth }}
+            {{ if contains "*" .method }}
+            - --skip-auth-route={{ .path }}
+            {{- else -}}
             - --skip-auth-route={{ .method }}={{ .path }}
+            {{- end -}}
             {{- end -}}
             {{- range $allHosts -}}
             {{- printf "- --whitelist-domain=%s" . | nindent 12 -}}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -59,6 +59,9 @@ spec:
             - --pass-authorization-header=true
             - --reverse-proxy
             - --skip-jwt-bearer-tokens
+            {{- range .Values.oidcProxy.skipAuth }}
+            - --skip-auth-route={{ .method }}={{ .path }}
+            {{- end -}}
             {{- range $allHosts -}}
             {{- printf "- --whitelist-domain=%s" . | nindent 12 -}}
             {{- printf "- --cookie-domain=%s" . | nindent 12 -}}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -1,5 +1,6 @@
 {{ $global := . }}
 {{- $allHosts := list -}}
+{{- $allOIDCProtectedServces := list -}}
 {{ range $serviceName, $serviceValues := .Values.services }}
   {{- $globalValuesDict := $global.Values.global | toYaml -}}
   {{- $values := fromYaml $globalValuesDict -}}
@@ -7,10 +8,19 @@
   {{- $values := mergeOverwrite $values $serviceValues -}}
 
   {{- with $values -}}
+  {{ $serviceScope := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" .}}
   {{- if .ingress.oidcProtected -}}
+    {{ range $i, $path := .ingress.paths }}
+      {{- $allOIDCProtectedServces = append 
+        $allOIDCProtectedServces 
+        (printf "http://%s.%s.svc.cluster.local:%d%s" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
+      -}}
+    {{- end -}}
+
   {{ range $i, $rule := .ingress.rules }}
   {{- $allHosts = append $allHosts $rule.host }}
   {{- end -}}
+
   {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -51,7 +61,6 @@ spec:
             - --provider=oidc
             - --email-domain=*
             - --cookie-secure=true
-            - --set-authorization-header
             - --set-xauthrequest
             - --cookie-domain={{- include "baseDomain" . }}
             - --whitelist-domain=.{{- include "baseDomain" . }}
@@ -59,13 +68,20 @@ spec:
             - --pass-authorization-header=true
             - --reverse-proxy
             - --skip-jwt-bearer-tokens
+
+            {{- range $allOIDCProtectedServces }}
+            - --upstream={{ . }}
+            {{- end -}}
+
             {{- range .Values.oidcProxy.skipAuth }}
+            # for backwards compatibility, could also just be provided using extraArgs
             {{ if contains "*" .method }}
             - --skip-auth-route={{ .path }}
             {{- else -}}
             - --skip-auth-route={{ .method }}={{ .path }}
             {{- end -}}
             {{- end -}}
+
             {{- range $allHosts -}}
             {{- printf "- --whitelist-domain=%s" . | nindent 12 -}}
             {{- printf "- --cookie-domain=%s" . | nindent 12 -}}
@@ -115,6 +131,7 @@ spec:
     {{- include "oidcProxy.selectorLabels" . | nindent 4 }}
 
 ---
+
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/stack/tests/ingress_test.yaml
+++ b/stack/tests/ingress_test.yaml
@@ -17,18 +17,6 @@ tests:
     asserts:
       - isKind:
           of: Ingress
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
-          value: "http://release-name-stack-oidc-proxy.NAMESPACE.svc.cluster.local:4180/oauth2/auth"
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
-          value: "https://$host/oauth2/sign_in?rd=https://$host$escaped_request_uri"
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
-          value: "Authorization,X-Auth-Request-User,X-Auth-Request-Groups,X-Auth-Request-Email,X-Auth-Request-Preferred-Username"
   - it: adds additional nginx auth headers when using additionalHeaders
     set:
       global:
@@ -46,10 +34,6 @@ tests:
     asserts:
       - isKind:
           of: Ingress
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
-          value: "Authorization,X-Auth-Request-User,X-Auth-Request-Groups,X-Auth-Request-Email,X-Auth-Request-Preferred-Username,X-Forwarded-User,blahblahblah"
   - it: adds auth-snippet with using skipAuth
     set:
       global:
@@ -69,49 +53,6 @@ tests:
     asserts:
       - isKind:
           of: Ingress
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-snippet"]
-          value: |
-            set $skip_auth_get_healthz 1;
-
-            if ( $request_uri !~ "/healthz" ) {
-                set $skip_auth_get_healthz  0;
-            }
-
-            if ( $request_method !~ "GET" ) {
-                set $skip_auth_get_healthz  0;
-            }
-
-            if ( $skip_auth_get_healthz ) {
-                return 200;
-            }
-            set $skip_auth___api_ 1;
-
-            if ( $request_uri !~ "/api/*" ) {
-                set $skip_auth___api_  0;
-            }
-
-            if ( $request_method !~ "*" ) {
-                set $skip_auth___api_  0;
-            }
-
-            if ( $skip_auth___api_ ) {
-                return 200;
-            }
-            set $skip_auth_get__well_known_ 1;
-
-            if ( $request_uri !~ "/.well-known/*" ) {
-                set $skip_auth_get__well_known_  0;
-            }
-
-            if ( $request_method !~ "GET" ) {
-                set $skip_auth_get__well_known_  0;
-            }
-
-            if ( $skip_auth_get__well_known_ ) {
-                return 200;
-            }
   - it: adds adds certManager annotations
     set:
       global:
@@ -132,6 +73,9 @@ tests:
             rules:
               - host: cellxgene.cziscience.com
               - host: api.cellxgene.cziscience.com
+        unprotected-service:
+          ingress:
+            oidcProtected: false
     asserts:
       - isKind:
           of: Ingress
@@ -194,3 +138,19 @@ tests:
         lengthEqual:
           path: spec.tls[1].hosts
           count: 2
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: missing-otter-oidc-proxy
+      - documentIndex: 0
+        equal:
+          path: spec.rules[1].http.paths[0].backend.service.name
+          value: missing-otter-oidc-proxy
+      - documentIndex: 0
+        equal:
+          path: spec.rules[2].http.paths[0].backend.service.name
+          value: missing-otter-oidc-proxy
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: missing-otter-unprotected-service

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -101,26 +101,39 @@ tests:
       global:
         oidcProxy:
           enabled: true
+          skipAuth:
+            - method: GET
+              path: "/v1/api/docs2"
+            - method: POST
+              path: "/v1/api/docs3"
           extraArgs:
             - "--skip-auth-route=/v1/api/docs"
             - "--skip-auth-route=/v1/api/security/access_token"
     asserts:
       - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-auth-route=GET=/v1/api/docs2"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-auth-route=POST=/v1/api/docs3"
+      - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args
-          count: 15
+          count: 17
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[12]
-          value: "--skip-jwt-bearer-tokens"
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-jwt-bearer-tokens"
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[13]
-          value: "--skip-auth-route=/v1/api/docs"
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-auth-route=/v1/api/docs"
       - documentIndex: 0
-        equal:
-          path: spec.template.spec.containers[0].args[14]
-          value: "--skip-auth-route=/v1/api/security/access_token"
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-auth-route=/v1/api/security/access_token"
   - it: overwrites the name
     set:
       global:

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -106,10 +106,16 @@ tests:
               path: "/v1/api/docs2"
             - method: POST
               path: "/v1/api/docs3"
+            - path: "/v1/api/llm/*"
+              method: ".*"
           extraArgs:
             - "--skip-auth-route=/v1/api/docs"
             - "--skip-auth-route=/v1/api/security/access_token"
     asserts:
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-auth-route=/v1/api/llm/.*"
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
@@ -121,7 +127,7 @@ tests:
       - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args
-          count: 17
+          count: 19
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -106,7 +106,7 @@ tests:
               path: "/v1/api/docs2"
             - method: POST
               path: "/v1/api/docs3"
-            - path: "/v1/api/llm/*"
+            - path: "/v1/api/llm/.*"
               method: ".*"
           extraArgs:
             - "--skip-auth-route=/v1/api/docs"
@@ -127,7 +127,7 @@ tests:
       - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args
-          count: 19
+          count: 17
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
@@ -188,6 +188,8 @@ tests:
   - it: oidc proxy has volumes mounted
     set:
       global:
+        service:
+          port: 2222
         ingress:
           host: "stack.play.dev.czi.team"
         oidcProxy:
@@ -202,13 +204,32 @@ tests:
               name: oauth2-proxy-sign-in-template
       services:
         service1:
+          service:
+            port: 4123
           ingress:
             oidcProtected: true
+            paths:
+              - path: /test1
+                pathType: Prefix
+        service2:
+          ingress:
+            oidcProtected: true
+            paths:
+              - path: /test2
+                pathType: Prefix
     asserts:
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].volumeMounts[0].mountPath
           value: /templates/oauth2-proxy/sign_in.html
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --upstream=http://release-name-stack-service1.NAMESPACE.svc.cluster.local:4123/test1
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --upstream=http://release-name-stack-service2.NAMESPACE.svc.cluster.local:2222/test2
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
@@ -313,15 +334,24 @@ tests:
         service1:
           ingress:
             oidcProtected: true
+            paths:
+              - path: "/service1"
+                pathType: Prefix
             rules:
               - host: "service1.stack2.com"
         service2:
           ingress:
             oidcProtected: true
+            paths:
+              - path: "/service2"
+                pathType: Prefix
             rules:
               - host: "service2.stack2.com"
         service3:
           ingress:
+            paths:
+              - path: "/service3"
+                pathType: Prefix
             oidcProtected: true
         service4:
           ingress:
@@ -356,7 +386,7 @@ tests:
       - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args
-          count: 19
+          count: 21
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -125,7 +125,6 @@ global:
     rules: []
     oidcProtected: false
     annotations:
-      infra: "true"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "60"


### PR DESCRIPTION
## Summary

Added for backwards compatability. When we remove the nginx annotations in the next PRs, we will need the skipAuth values.yaml to still work with the oauth2_proxy flags.

## References

* #150 
* #152 