### PR TITLE
feat: conditional logic around the ingress point to the service or the oauth2 proxy service

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -181,11 +181,3 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "oidcProxy.authDomain" -}}
 {{ .Values.ingress.host }}
 {{- end -}}
-
-{{- define "oidcProxy.skipAuthConfig" -}}
-
-{{- end -}}
-
-{{- define "oidcProxy.nginxAuthAnnotations" -}}
-
-{{- end -}}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -205,21 +205,21 @@ if ( ${{ $var_name }} ) {
 {{- end -}}
 
 {{- define "oidcProxy.nginxAuthAnnotations" -}}
-nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oidcProxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:4180/oauth2/auth"
-nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/sign_in?rd=https://$host$escaped_request_uri"
-nginx.ingress.kubernetes.io/auth-response-headers: {{join "," (concat (list "Authorization" "X-Auth-Request-User" "X-Auth-Request-Groups" "X-Auth-Request-Email" "X-Auth-Request-Preferred-Username") .Values.oidcProxy.additionalHeaders) }}
-nginx.ingress.kubernetes.io/auth-snippet: |
-{{- include "oidcProxy.skipAuthConfig" . | nindent 4 }}
-nginx.ingress.kubernetes.io/configuration-snippet: |
-    auth_request_set $email $upstream_http_x_auth_request_email;
-    auth_request_set $user $upstream_http_x_auth_request_user;
-    auth_request_set $groups $upstream_http_x_auth_request_groups;
-    auth_request_set $preferred_username $upstream_http_x_auth_request_preferred_username;
+# nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oidcProxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:4180/oauth2/auth"
+# nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/sign_in?rd=https://$host$escaped_request_uri"
+# nginx.ingress.kubernetes.io/auth-response-headers: {{join "," (concat (list "Authorization" "X-Auth-Request-User" "X-Auth-Request-Groups" "X-Auth-Request-Email" "X-Auth-Request-Preferred-Username") .Values.oidcProxy.additionalHeaders) }}
+# nginx.ingress.kubernetes.io/auth-snippet: |
+# {{- include "oidcProxy.skipAuthConfig" . | nindent 4 }}
+# nginx.ingress.kubernetes.io/configuration-snippet: |
+# auth_request_set $email $upstream_http_x_auth_request_email;
+# auth_request_set $user $upstream_http_x_auth_request_user;
+# auth_request_set $groups $upstream_http_x_auth_request_groups;
+# auth_request_set $preferred_username $upstream_http_x_auth_request_preferred_username;
 
-    proxy_set_header X-Forwarded-Email $email;
-    proxy_set_header X-Forwarded-User $user;
-    proxy_set_header X-Forwarded-Groups $groups;
-    proxy_set_header X-Forwarded-Preferred-Username $preferred_username;
-    proxy_set_header Authorization $http_authorization;
-    proxy_pass_header Authorization;
+# proxy_set_header X-Forwarded-Email $email;
+# proxy_set_header X-Forwarded-User $user;
+# proxy_set_header X-Forwarded-Groups $groups;
+# proxy_set_header X-Forwarded-Preferred-Username $preferred_username;
+# proxy_set_header Authorization $http_authorization;
+# proxy_pass_header Authorization;
 {{- end -}}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -3,11 +3,24 @@ Expand the name of the chart.
 */}}
 {{- define "stack.name" -}}
 {{- default .Chart.Name .nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- end -}}
 
 {{- define "service.name" -}}
 {{- .Values.name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- end -}}
+
+{{- define "service.backend" -}}
+{{- if .Values.ingress.oidcProtected -}}
+name: {{ include "oidcProxy.name" . }}
+port:
+    number:  {{ include "oidcProxy.port" .}}
+{{- else }}
+name: {{ include "service.fullname" . }}
+port:
+    number: {{  .Values.service.port | int}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Create a default fully qualified app name.

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -147,7 +147,7 @@ Container probes cannot have both httpGet and tcpSocket fields, so we use omit t
 
 {{- define "oidcProxy.name" -}}
 {{ include "stack.fullname" . | lower }}-oidc-proxy
-{{- end }}
+{{- end -}}
 
 {{- define "oidcProxy.port" -}}
 {{ .Values.oidcProxy.port | default 4180 | int  }}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -183,43 +183,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "oidcProxy.skipAuthConfig" -}}
-{{- $letsEncryptVerifySkip := (dict "path" "/.well-known/*" "method" "GET") -}}
-{{- range  $k, $v := append .Values.oidcProxy.skipAuth $letsEncryptVerifySkip -}}
-{{- $id := printf "%s_%s" ($v.method |lower) ($v.path | replace "/" "")}}
-{{- $id := regexReplaceAll "\\W+" $id "_" -}}
-{{- $var_name := printf "%s_%s" "skip_auth" $id }}
-set ${{ $var_name }} 1;
 
-if ( $request_uri !~ "{{$v.path}}" ) {
-    set ${{ $var_name }}  0;
-}
-
-if ( $request_method !~ "{{$v.method}}" ) {
-    set ${{ $var_name }}  0;
-}
-
-if ( ${{ $var_name }} ) {
-    return 200;
-}
-{{- end -}}
 {{- end -}}
 
 {{- define "oidcProxy.nginxAuthAnnotations" -}}
-# nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oidcProxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:4180/oauth2/auth"
-# nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/sign_in?rd=https://$host$escaped_request_uri"
-# nginx.ingress.kubernetes.io/auth-response-headers: {{join "," (concat (list "Authorization" "X-Auth-Request-User" "X-Auth-Request-Groups" "X-Auth-Request-Email" "X-Auth-Request-Preferred-Username") .Values.oidcProxy.additionalHeaders) }}
-# nginx.ingress.kubernetes.io/auth-snippet: |
-# {{- include "oidcProxy.skipAuthConfig" . | nindent 4 }}
-# nginx.ingress.kubernetes.io/configuration-snippet: |
-# auth_request_set $email $upstream_http_x_auth_request_email;
-# auth_request_set $user $upstream_http_x_auth_request_user;
-# auth_request_set $groups $upstream_http_x_auth_request_groups;
-# auth_request_set $preferred_username $upstream_http_x_auth_request_preferred_username;
 
-# proxy_set_header X-Forwarded-Email $email;
-# proxy_set_header X-Forwarded-User $user;
-# proxy_set_header X-Forwarded-Groups $groups;
-# proxy_set_header X-Forwarded-Preferred-Username $preferred_username;
-# proxy_set_header Authorization $http_authorization;
-# proxy_pass_header Authorization;
 {{- end -}}

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{ $global := . }}
+{{- $global := . -}}
 {{ range $serviceName, $serviceValues := .Values.services }}
   {{- $globalValuesDict := $global.Values.global | toYaml -}}
   {{- $values := fromYaml $globalValuesDict -}}
@@ -7,10 +7,10 @@
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}
 
+{{- if .Values.ingress.enabled -}}
 ---
-{{ if .Values.ingress.enabled }}
-{{- $fullName := include "service.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{ $fullName := include "service.fullname" . -}}
+{{ $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -42,9 +42,9 @@ spec:
               service:
                 {{- if $service.Values.ingress.oidcProtected }}
                 name: {{ include "oidcProxy.name" $service }}
-                {{ else -}}
+                {{- else }}
                 name: {{ $fullName }}
-                {{- end -}}
+                {{- end }}
                 port:
                   number: {{ $svcPort | int}}
           {{- end }}
@@ -64,9 +64,9 @@ spec:
               service:
                 {{- if $service.Values.ingress.oidcProtected }}
                 name: {{ include "oidcProxy.name" $service }}
-                {{ else -}}
+                {{- else }}
                 name: {{ $fullName }}
-                {{- end -}}
+                {{- end }}
                 port:
                   number: {{ $svcPort | int}}
           {{ end -}}
@@ -86,8 +86,7 @@ spec:
       {{- toYaml $customHosts | nindent 6 }}
       {{- $secretName := printf "%s-%s-%s" "custom-hosts" (include "stack.fullname" .) "tls-secret" }}
       secretName: {{  regexReplaceAll "[^a-zA-Z0-9-]" $secretName "-" }}
-    {{- end -}}
-{{- end }}
----
+    {{ end }}
+{{ end }}
 {{- end }}
 {{- end }}

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -43,7 +43,7 @@ spec:
                 {{- if $service.Values.ingress.oidcProtected }}
                 name: {{ include "oidcProxy.name" $service }}
                 port:
-                  number:  {{ include "oidcProxy.port" . }}
+                  number:  {{ include "oidcProxy.port" $service }}
                 {{- else }}
                 name: {{ $fullName }}
                 port:

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -9,12 +9,10 @@
 
 {{- if .Values.ingress.enabled -}}
 ---
-{{ $fullName := include "service.fullname" . -}}
-{{ $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "service.fullname" .  }}
   labels:
     {{- include "service.labels" . | nindent 4 }}
     {{- $certManagerAnnotations := (fromYaml (include "certManagerAnnotations" . )) }}
@@ -40,15 +38,7 @@ spec:
             {{- end }}
             backend:
               service:
-                {{- if $service.Values.ingress.oidcProtected }}
-                name: {{ include "oidcProxy.name" $service }}
-                port:
-                  number:  {{ include "oidcProxy.port" $service }}
-                {{- else }}
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort | int}}
-                {{- end }}
+                {{- include "service.backend" $service | nindent 16}}
           {{- end }}
     {{- $customHosts := list -}}
     {{- range $i, $rule := .Values.ingress.rules -}}
@@ -64,15 +54,7 @@ spec:
             {{- end }}
             backend:
               service:
-                {{- if $service.Values.ingress.oidcProtected }}
-                name: {{ include "oidcProxy.name" $service }}
-                port:
-                  number:  {{ include "oidcProxy.port" $service  }}
-                {{- else }}
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort | int}}
-                {{- end }}
+                {{- (include "service.backend" $service) | nindent 16 -}}
           {{ end -}}
     {{- end }}
   tls:

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -42,11 +42,13 @@ spec:
               service:
                 {{- if $service.Values.ingress.oidcProtected }}
                 name: {{ include "oidcProxy.name" $service }}
+                port:
+                  number:  {{ include "oidcProxy.port" . }}
                 {{- else }}
                 name: {{ $fullName }}
-                {{- end }}
                 port:
                   number: {{ $svcPort | int}}
+                {{- end }}
           {{- end }}
     {{- $customHosts := list -}}
     {{- range $i, $rule := .Values.ingress.rules -}}
@@ -64,11 +66,13 @@ spec:
               service:
                 {{- if $service.Values.ingress.oidcProtected }}
                 name: {{ include "oidcProxy.name" $service }}
+                port:
+                  number:  {{ include "oidcProxy.port" . }}
                 {{- else }}
                 name: {{ $fullName }}
-                {{- end }}
                 port:
                   number: {{ $svcPort | int}}
+                {{- end }}
           {{ end -}}
     {{- end }}
   tls:

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -67,7 +67,7 @@ spec:
                 {{- if $service.Values.ingress.oidcProtected }}
                 name: {{ include "oidcProxy.name" $service }}
                 port:
-                  number:  {{ include "oidcProxy.port" . }}
+                  number:  {{ include "oidcProxy.port" $service  }}
                 {{- else }}
                 name: {{ $fullName }}
                 port:

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -45,15 +45,19 @@ spec:
             {{- end }}
             backend:
               service:
+                {{- if $service.Values.ingress.oidcProtected }}
+                name: {{ include "oidcProxy.name" $service }}
+                {{ else -}}
                 name: {{ $fullName }}
+                {{- end -}}
                 port:
                   number: {{ $svcPort }}
           {{- end }}
-    {{ $customHosts := list}}
-    {{ range $i, $rule := .Values.ingress.rules }}
+    {{- $customHosts := list -}}
+    {{- range $i, $rule := .Values.ingress.rules -}}
     {{- $ruleValues := mergeOverwrite (dict "host" $service.Values.ingress.host "paths" $service.Values.ingress.paths) $rule -}}
     {{ $customHosts = append $customHosts $ruleValues.host }}
-    - host: {{ $ruleValues.host | quote }}
+    - host: {{ $ruleValues.host }}
       http:
         paths:
           {{- range $ruleValues.paths }} 
@@ -65,9 +69,9 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ $svcPort }}
-          {{- end }}
-    {{ end }}
+                  number: {{ $svcPort | int}}
+          {{ end -}}
+    {{- end }}
   tls:
     - hosts:
       - {{ $service.Values.ingress.host  }}

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -17,15 +17,10 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "service.labels" . | nindent 4 }}
-  {{- $nginxAuthAnnotations := dict}}
-    {{- if .Values.ingress.oidcProtected }}
-    {{- $nginxAuthAnnotations = (fromYaml (include "oidcProxy.nginxAuthAnnotations" . )) -}}
-    {{- end}}
     {{- $certManagerAnnotations := (fromYaml (include "certManagerAnnotations" . )) }}
   annotations:
     {{- with (mergeOverwrite 
                 (dict)
-                ($nginxAuthAnnotations)
                 ($certManagerAnnotations)
                 (.Values.annotations) 
                 (.Values.ingress.annotations)
@@ -51,7 +46,7 @@ spec:
                 name: {{ $fullName }}
                 {{- end -}}
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ $svcPort | int}}
           {{- end }}
     {{- $customHosts := list -}}
     {{- range $i, $rule := .Values.ingress.rules -}}
@@ -67,7 +62,11 @@ spec:
             {{- end }}
             backend:
               service:
+                {{- if $service.Values.ingress.oidcProtected }}
+                name: {{ include "oidcProxy.name" $service }}
+                {{ else -}}
                 name: {{ $fullName }}
+                {{- end -}}
                 port:
                   number: {{ $svcPort | int}}
           {{ end -}}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -9,11 +9,12 @@
 
   {{- with $values -}}
   {{- if .ingress.oidcProtected -}}
-
-  {{- $allOIDCProtectedServces = append 
-    $allOIDCProtectedServces 
-    (printf "http://%s.%s.svc.cluster.local:%d" $serviceName $global.Release.Namespace ($values.service.port | int)) 
-  -}}
+    {{ range $i, $path := .ingress.paths }}
+      {{- $allOIDCProtectedServces = append 
+        $allOIDCProtectedServces 
+        (printf "http://%s.%s.svc.cluster.local:%d%s" $serviceName $global.Release.Namespace ($values.service.port | int) ($path.path)) 
+      -}}
+    {{- end -}}
 
   {{ range $i, $rule := .ingress.rules }}
   {{- $allHosts = append $allHosts $rule.host }}
@@ -70,7 +71,7 @@ spec:
 
             {{- range $allOIDCProtectedServces }}
             - --upstream={{ . }}
-            {{ end -}}
+            {{- end -}}
 
             {{- range .Values.oidcProxy.skipAuth }}
             # for backwards compatibility, could also just be provided using extraArgs

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -61,7 +61,6 @@ spec:
             - --provider=oidc
             - --email-domain=*
             - --cookie-secure=true
-            - --set-authorization-header
             - --set-xauthrequest
             - --cookie-domain={{- include "baseDomain" . }}
             - --whitelist-domain=.{{- include "baseDomain" . }}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -131,5 +131,48 @@ spec:
     {{- include "oidcProxy.selectorLabels" . | nindent 4 }}
 
 ---
+
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "oidcProxy.name" . }}
+  {{- $certManagerAnnotations := (fromYaml (include "certManagerAnnotations" . )) }}
+  annotations:
+  {{- with (mergeOverwrite 
+              (dict)
+              ($certManagerAnnotations)
+              (.Values.annotations)
+              (.Values.oidcProxy.annotations)
+      ) -}}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ include "oidcProxy.authDomain" . }}
+      http:
+        paths:
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "oidcProxy.name" . }}
+                port:
+                  number: {{ include "oidcProxy.port" . }}
+    {{- $scope := . }}
+    {{- range $i, $host := $allHosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "oidcProxy.name" $scope }}
+                port:
+                  number: {{ include "oidcProxy.port" $scope }}
+    {{- end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -8,11 +8,12 @@
   {{- $values := mergeOverwrite $values $serviceValues -}}
 
   {{- with $values -}}
+  {{ $serviceScope := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" .}}
   {{- if .ingress.oidcProtected -}}
     {{ range $i, $path := .ingress.paths }}
       {{- $allOIDCProtectedServces = append 
         $allOIDCProtectedServces 
-        (printf "http://%s.%s.svc.cluster.local:%d%s" $serviceName $global.Release.Namespace ($values.service.port | int) ($path.path)) 
+        (printf "http://%s.%s.svc.cluster.local:%d%s" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
       -}}
     {{- end -}}
 

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -130,47 +130,5 @@ spec:
     {{- include "oidcProxy.selectorLabels" . | nindent 4 }}
 
 ---
-{{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ include "oidcProxy.name" . }}
-  {{- $certManagerAnnotations := (fromYaml (include "certManagerAnnotations" . )) }}
-  annotations:
-  {{- with (mergeOverwrite 
-              (dict)
-              ($certManagerAnnotations)
-              (.Values.annotations)
-              (.Values.oidcProxy.annotations)
-      ) -}}
-    {{ toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: {{ include "oidcProxy.authDomain" . }}
-      http:
-        paths:
-          - path: /oauth2
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "oidcProxy.name" . }}
-                port:
-                  number: {{ include "oidcProxy.port" . }}
-    {{- $scope := . }}
-    {{- range $i, $host := $allHosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: /oauth2
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "oidcProxy.name" $scope }}
-                port:
-                  number: {{ include "oidcProxy.port" $scope }}
-    {{- end }}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stack/tests/ingress_test.yaml
+++ b/stack/tests/ingress_test.yaml
@@ -73,6 +73,9 @@ tests:
             rules:
               - host: cellxgene.cziscience.com
               - host: api.cellxgene.cziscience.com
+        unprotected-service:
+          ingress:
+            oidcProtected: false
     asserts:
       - isKind:
           of: Ingress
@@ -135,3 +138,19 @@ tests:
         lengthEqual:
           path: spec.tls[1].hosts
           count: 2
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: missing-otter-oidc-proxy
+      - documentIndex: 0
+        equal:
+          path: spec.rules[1].http.paths[0].backend.service.name
+          value: missing-otter-oidc-proxy
+      - documentIndex: 0
+        equal:
+          path: spec.rules[2].http.paths[0].backend.service.name
+          value: missing-otter-oidc-proxy
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: missing-otter-unprotected-service

--- a/stack/tests/ingress_test.yaml
+++ b/stack/tests/ingress_test.yaml
@@ -17,18 +17,6 @@ tests:
     asserts:
       - isKind:
           of: Ingress
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
-          value: "http://release-name-stack-oidc-proxy.NAMESPACE.svc.cluster.local:4180/oauth2/auth"
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
-          value: "https://$host/oauth2/sign_in?rd=https://$host$escaped_request_uri"
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
-          value: "Authorization,X-Auth-Request-User,X-Auth-Request-Groups,X-Auth-Request-Email,X-Auth-Request-Preferred-Username"
   - it: adds additional nginx auth headers when using additionalHeaders
     set:
       global:
@@ -46,10 +34,6 @@ tests:
     asserts:
       - isKind:
           of: Ingress
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
-          value: "Authorization,X-Auth-Request-User,X-Auth-Request-Groups,X-Auth-Request-Email,X-Auth-Request-Preferred-Username,X-Forwarded-User,blahblahblah"
   - it: adds auth-snippet with using skipAuth
     set:
       global:
@@ -69,49 +53,6 @@ tests:
     asserts:
       - isKind:
           of: Ingress
-      - documentIndex: 0
-        equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-snippet"]
-          value: |
-            set $skip_auth_get_healthz 1;
-
-            if ( $request_uri !~ "/healthz" ) {
-                set $skip_auth_get_healthz  0;
-            }
-
-            if ( $request_method !~ "GET" ) {
-                set $skip_auth_get_healthz  0;
-            }
-
-            if ( $skip_auth_get_healthz ) {
-                return 200;
-            }
-            set $skip_auth___api_ 1;
-
-            if ( $request_uri !~ "/api/*" ) {
-                set $skip_auth___api_  0;
-            }
-
-            if ( $request_method !~ "*" ) {
-                set $skip_auth___api_  0;
-            }
-
-            if ( $skip_auth___api_ ) {
-                return 200;
-            }
-            set $skip_auth_get__well_known_ 1;
-
-            if ( $request_uri !~ "/.well-known/*" ) {
-                set $skip_auth_get__well_known_  0;
-            }
-
-            if ( $request_method !~ "GET" ) {
-                set $skip_auth_get__well_known_  0;
-            }
-
-            if ( $skip_auth_get__well_known_ ) {
-                return 200;
-            }
   - it: adds adds certManager annotations
     set:
       global:

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -169,6 +169,22 @@ tests:
       - equal:
           path: metadata.name
           value: "overwrittenfull-oidc-proxy"
+  - it: oidc proxy ingress matches the ingress host domain
+    set:
+      global:
+        ingress:
+          host: "stack.play.dev.czi.team"
+        oidcProxy:
+          enabled: true
+      services:
+        service1:
+          ingress:
+            oidcProtected: true
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: spec.rules[0].host
+          value: stack.play.dev.czi.team
   - it: oidc proxy has volumes mounted
     set:
       global:
@@ -289,6 +305,22 @@ tests:
         equal:
           path: .metadata.annotations.test3
           value: test3
+      - documentIndex: 2
+        containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+          name: release-name-stack-oidc-proxy
+      - documentIndex: 2
+        equal:
+          path: .metadata.annotations.test1
+          value: test1
+      - documentIndex: 2
+        notExists:
+          path: .metadata.annotations.test2
+      - documentIndex: 2
+        equal:
+          path: .metadata.annotations.test3
+          value: test3
   - it: should have multiple ingress rules for the stack hosts
     set:
       global:
@@ -327,6 +359,30 @@ tests:
             rules:
               - host: "service4.stack2.com"
     asserts:
+      - documentIndex: 2
+        containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+          name: release-name-stack-oidc-proxy
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[0].host
+          value: stack.play.dev.czi.team
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[1].host
+          value: service1.stack2.com
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[2].host
+          value: service2.stack2.com
+      - documentIndex: 2
+        equal:
+          path: .spec.rules[3].host
+          value: stack2.com
+      - documentIndex: 2
+        notExists:
+          path: .spec.rules[4]
       - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -18,7 +18,7 @@ tests:
           enabled: true
     asserts:
       - hasDocuments:
-          count: 2
+          count: 3
       - documentIndex: 0
         containsDocument:
           kind: Deployment
@@ -28,6 +28,11 @@ tests:
         containsDocument:
           kind: Service
           apiVersion: v1
+          name: release-name-stack-oidc-proxy
+      - documentIndex: 2
+        containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
           name: release-name-stack-oidc-proxy
   - it: disabled by default
     asserts:

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -127,7 +127,7 @@ tests:
       - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args
-          count: 18
+          count: 17
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
@@ -386,7 +386,7 @@ tests:
       - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args
-          count: 22
+          count: 21
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -18,7 +18,7 @@ tests:
           enabled: true
     asserts:
       - hasDocuments:
-          count: 3
+          count: 2
       - documentIndex: 0
         containsDocument:
           kind: Deployment
@@ -28,11 +28,6 @@ tests:
         containsDocument:
           kind: Service
           apiVersion: v1
-          name: release-name-stack-oidc-proxy
-      - documentIndex: 2
-        containsDocument:
-          kind: Ingress
-          apiVersion: networking.k8s.io/v1
           name: release-name-stack-oidc-proxy
   - it: disabled by default
     asserts:
@@ -169,22 +164,6 @@ tests:
       - equal:
           path: metadata.name
           value: "overwrittenfull-oidc-proxy"
-  - it: oidc proxy ingress matches the ingress host domain
-    set:
-      global:
-        ingress:
-          host: "stack.play.dev.czi.team"
-        oidcProxy:
-          enabled: true
-      services:
-        service1:
-          ingress:
-            oidcProtected: true
-    asserts:
-      - documentIndex: 2
-        equal:
-          path: spec.rules[0].host
-          value: stack.play.dev.czi.team
   - it: oidc proxy has volumes mounted
     set:
       global:
@@ -208,9 +187,15 @@ tests:
             port: 4123
           ingress:
             oidcProtected: true
+            paths:
+              - path: /test1
+                pathType: Prefix
         service2:
           ingress:
             oidcProtected: true
+            paths:
+              - path: /test2
+                pathType: Prefix
     asserts:
       - documentIndex: 0
         equal:
@@ -219,11 +204,11 @@ tests:
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
-          content: --upstream=http://service1.NAMESPACE.svc.cluster.local:4123
+          content: --upstream=http://service1.NAMESPACE.svc.cluster.local:4123/test1
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
-          content: --upstream=http://service2.NAMESPACE.svc.cluster.local:2222
+          content: --upstream=http://service2.NAMESPACE.svc.cluster.local:2222/test2
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
@@ -299,22 +284,6 @@ tests:
         equal:
           path: .metadata.annotations.test3
           value: test3
-      - documentIndex: 2
-        containsDocument:
-          kind: Ingress
-          apiVersion: networking.k8s.io/v1
-          name: release-name-stack-oidc-proxy
-      - documentIndex: 2
-        equal:
-          path: .metadata.annotations.test1
-          value: test1
-      - documentIndex: 2
-        notExists:
-          path: .metadata.annotations.test2
-      - documentIndex: 2
-        equal:
-          path: .metadata.annotations.test3
-          value: test3
   - it: should have multiple ingress rules for the stack hosts
     set:
       global:
@@ -328,15 +297,24 @@ tests:
         service1:
           ingress:
             oidcProtected: true
+            paths:
+              - path: "/service1"
+                pathType: Prefix
             rules:
               - host: "service1.stack2.com"
         service2:
           ingress:
             oidcProtected: true
+            paths:
+              - path: "/service2"
+                pathType: Prefix
             rules:
               - host: "service2.stack2.com"
         service3:
           ingress:
+            paths:
+              - path: "/service3"
+                pathType: Prefix
             oidcProtected: true
         service4:
           ingress:
@@ -344,30 +322,6 @@ tests:
             rules:
               - host: "service4.stack2.com"
     asserts:
-      - documentIndex: 2
-        containsDocument:
-          kind: Ingress
-          apiVersion: networking.k8s.io/v1
-          name: release-name-stack-oidc-proxy
-      - documentIndex: 2
-        equal:
-          path: .spec.rules[0].host
-          value: stack.play.dev.czi.team
-      - documentIndex: 2
-        equal:
-          path: .spec.rules[1].host
-          value: service1.stack2.com
-      - documentIndex: 2
-        equal:
-          path: .spec.rules[2].host
-          value: service2.stack2.com
-      - documentIndex: 2
-        equal:
-          path: .spec.rules[3].host
-          value: stack2.com
-      - documentIndex: 2
-        notExists:
-          path: .spec.rules[4]
       - documentIndex: 0
         lengthEqual:
           path: spec.template.spec.containers[0].args

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -225,11 +225,11 @@ tests:
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
-          content: --upstream=http://service1.NAMESPACE.svc.cluster.local:4123/test1
+          content: --upstream=http://release-name-stack-service1.NAMESPACE.svc.cluster.local:4123/test1
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
-          content: --upstream=http://service2.NAMESPACE.svc.cluster.local:2222/test2
+          content: --upstream=http://release-name-stack-service2.NAMESPACE.svc.cluster.local:2222/test2
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -125,7 +125,6 @@ global:
     rules: []
     oidcProtected: false
     annotations:
-      infra: "true"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "60"


### PR DESCRIPTION
## Summary

This PR changes the networking to remove all the custom nginx annotations. This simplifies our networking stack quite a bit. Now, if the service marked with oidcProtected = true, nginx will route the traffic through the oauth2_proxy. However, if oidcProtected = false, nginx will route the traffic directly to the service. Nginx is still in charge of terminating TLS. 

This fixes the bug where people weren't able to control the behavior of the proxy flags very well due to how we were only calling the oauth2_proxy from nginx using the `auth` directive. 

## References

* Tested with https://github.com/chanzuckerberg/core-platform-example-app/pull/105