### PR TITLE
fix: trailing slash on upstreams

### DIFF
--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -13,7 +13,7 @@
     {{ range $i, $path := .ingress.paths }}
       {{- $allOIDCProtectedServces = append 
         $allOIDCProtectedServces 
-        (printf "http://%s.%s.svc.cluster.local:%d%s" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
+        (printf "http://%s.%s.svc.cluster.local:%d%s/" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
       -}}
     {{- end -}}
 

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -11,10 +11,17 @@
   {{ $serviceScope := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" .}}
   {{- if .ingress.oidcProtected -}}
     {{ range $i, $path := .ingress.paths }}
+      {{- if (eq $path.pathType "Exact") -}}
+      {{- $allOIDCProtectedServces = append 
+        $allOIDCProtectedServces 
+        (printf "http://%s.%s.svc.cluster.local:%d%s" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
+      -}}
+      {{- else -}}
       {{- $allOIDCProtectedServces = append 
         $allOIDCProtectedServces 
         (printf "http://%s.%s.svc.cluster.local:%d%s/" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
       -}}
+      {{- end -}}
     {{- end -}}
 
   {{ range $i, $rule := .ingress.rules }}

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -216,7 +216,13 @@ tests:
             oidcProtected: true
             paths:
               - path: /test2
-                pathType: Prefix
+                pathType: Exact
+        service3:
+          ingress:
+            oidcProtected: true
+            paths:
+              - path: /test3
+                pathType: ImplementationSpecific
     asserts:
       - documentIndex: 0
         equal:
@@ -225,11 +231,15 @@ tests:
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
-          content: --upstream=http://release-name-stack-service1.NAMESPACE.svc.cluster.local:4123/test1
+          content: --upstream=http://release-name-stack-service1.NAMESPACE.svc.cluster.local:4123/test1/
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].args
           content: --upstream=http://release-name-stack-service2.NAMESPACE.svc.cluster.local:2222/test2
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --upstream=http://release-name-stack-service3.NAMESPACE.svc.cluster.local:2222/test3/
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
@@ -434,7 +444,7 @@ tests:
             oidcProtected: true
             paths:
               - path: "/service2"
-                pathType: Prefix
+                pathType: Exact
             rules:
               - host: "app2.someparent.domain"
     asserts:


### PR DESCRIPTION
## Summary

All the upstreams need a trailing slash to simulate the pathprefix routing type. Checks if it is using "Exact" path type and omits the trailing slash.

## Reference

* https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#upstreams-configuration