### PR TITLE
fix: double slash when users add a trailing slash

### DIFF
--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -14,12 +14,20 @@
       {{- if (eq $path.pathType "Exact") -}}
       {{- $allOIDCProtectedServces = append 
         $allOIDCProtectedServces 
-        (printf "http://%s.%s.svc.cluster.local:%d%s" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
+        (printf "http://%s.%s.svc.cluster.local:%d%s" 
+          (include "service.fullname" $serviceScope) 
+          $global.Release.Namespace 
+          ($values.service.port | int) 
+          ($path.path)) 
       -}}
       {{- else -}}
       {{- $allOIDCProtectedServces = append 
         $allOIDCProtectedServces 
-        (printf "http://%s.%s.svc.cluster.local:%d%s/" (include "service.fullname" $serviceScope) $global.Release.Namespace ($values.service.port | int) ($path.path)) 
+        (printf "http://%s.%s.svc.cluster.local:%d%s" 
+          (include "service.fullname" $serviceScope) 
+          $global.Release.Namespace 
+          ($values.service.port | int)
+          (printf "%s/" $path.path | replace "//" "/"))
       -}}
       {{- end -}}
     {{- end -}}

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -223,6 +223,14 @@ tests:
             paths:
               - path: /test3
                 pathType: ImplementationSpecific
+        service4:
+          service:
+            port: 4123
+          ingress:
+            oidcProtected: true
+            paths:
+              - path: /
+                pathType: Prefix
     asserts:
       - documentIndex: 0
         equal:
@@ -240,6 +248,10 @@ tests:
         contains:
           path: spec.template.spec.containers[0].args
           content: --upstream=http://release-name-stack-service3.NAMESPACE.svc.cluster.local:2222/test3/
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --upstream=http://release-name-stack-service4.NAMESPACE.svc.cluster.local:4123/
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name


### PR DESCRIPTION
## Summary

Fixes a bug where if people used `/` as their PathPrefix, it would lead to a double trailing slash in the upstream flag.