### PR TITLE
feat: Argo workflows RBAC chart

### DIFF
--- a/argo-workflows-rbac/Chart.yaml
+++ b/argo-workflows-rbac/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: argo-workflows-rbac
+description: A Helm chart for creating an Argo Workflows rbac resources to allow access to workflow templates.
+
+type: application
+
+version: 0.0.1
+
+appVersion: "0.0.1"

--- a/argo-workflows-rbac/README.md
+++ b/argo-workflows-rbac/README.md
@@ -1,0 +1,6 @@
+# Argo Workflows RBAC helm chart
+
+A Helm chart for creating an Argo Workflows rbac resources to allow access to workflow templates.
+
+## Parameters
+

--- a/argo-workflows-rbac/templates/rbac.yaml
+++ b/argo-workflows-rbac/templates/rbac.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: czi-argo-workflows-server-cluster-template
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/argo-workflows-rbac/templates/rbac.yaml
+++ b/argo-workflows-rbac/templates/rbac.yaml
@@ -1,17 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: czi-argo-workflows-server-cluster-template
+  name: {{ .Values.clusterRole.name }}
 rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - clusterworkflowtemplates
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+{{ toYaml .Values.clusterRole.rules | indent 2 }}

--- a/argo-workflows-rbac/values.schema.json
+++ b/argo-workflows-rbac/values.schema.json
@@ -2,6 +2,45 @@
     "title": "Chart Values",
     "type": "object",
     "properties": {
-       
+        "clusterRole": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Cluster Role name to create",
+                    "default": "czi-argo-workflows-server-cluster-template"
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "ApiGroups API groups to apply the rules to",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "apiGroups": {
+                                "type": "array",
+                                "description": "ApiGroups API groups to apply the rules to",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "resources": {
+                                "type": "array",
+                                "description": "Resources to apply the rules to",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "verbs": {
+                                "type": "array",
+                                "description": "Verbs to apply the rules to",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/argo-workflows-rbac/values.schema.json
+++ b/argo-workflows-rbac/values.schema.json
@@ -1,0 +1,7 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+       
+    }
+}

--- a/argo-workflows-rbac/values.yaml
+++ b/argo-workflows-rbac/values.yaml
@@ -1,0 +1,19 @@
+clusterRole:
+## @param clusterRole.name Cluster Role name to create
+  name: czi-argo-workflows-server-cluster-template
+  rules:
+## @param clusterRole.rules[0].apiGroups ApiGroups API groups to apply the rules to
+  - apiGroups:
+    - argoproj.io
+## @param clusterRole.rules[0].resources Resources to apply the rules to
+    resources:
+    - clusterworkflowtemplates
+## @param clusterRole.rules[0].verbs Verbs to apply the rules to
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete


### PR DESCRIPTION
This chart allows us to create a default clusterrole permitting single-namespaced Argo Workflow installation to access Argo Workflow templates (they are cluster scoped)