### PR TITLE
fix: issue where oidc proxy is configured on disabled ingresses

### DIFF
--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -9,7 +9,7 @@
 
   {{- with $values -}}
   {{ $serviceScope := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" .}}
-  {{- if .ingress.oidcProtected -}}
+  {{- if and .ingress.oidcProtected .ingress.enabled -}}
     {{ range $i, $path := .ingress.paths }}
       {{- if (eq $path.pathType "Exact") -}}
       {{- $allOIDCProtectedServces = append 


### PR DESCRIPTION
## Summary

Fixes an issue with the OIDC proxy being configured for ingresses that are marked as disabled. OIDC proxy shouldn't use upstreams for disabled ingresses to avoid path collisions by accident.