### PR TITLE
feat: allow image tag to be specified separately for sidecars

### DIFF
--- a/stack/templates/deployment.yaml
+++ b/stack/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
           {{- include "service.configuration" . | nindent 10}}
           {{- include "service.nonsensitiveEnvVars" (list $global.Values.global .Values) | nindent 10 }}
         {{- range $i, $container := .Values.sidecars }}
+        {{- $imageDict := fromYaml (include "image" $container) }}
+        {{- $container = mergeOverwrite $container $imageDict }}
         {{- with omit $container "envFrom" "env" }}
         - {{- toYaml . | nindent 10 }}
           {{- include "service.configuration" $service | nindent 10}}

--- a/stack/tests/deployment_test.yaml
+++ b/stack/tests/deployment_test.yaml
@@ -166,18 +166,24 @@ tests:
               image: "alpine:latest"
     asserts:
       - equal:
+          path: spec.template.spec.containers[0].image
+          value: "nginx:latest"
+      - equal:
           path: spec.template.spec.containers[1].image
           value: "alpine:latest"
-  - it: formats supplied initContainer image tag and repo
+  - it: formats supplied sidecar image tag and repo
     set:
       services:
         service1:
-          sidecar:
-            - name: sidecar1
+          sidecars:
+            - name: sidecar2
               image:
                 repository: "node"
                 tag: "20.0.0"
     asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "nginx:latest"
       - equal:
           path: spec.template.spec.containers[1].image
           value: "node:20.0.0"

--- a/stack/tests/deployment_test.yaml
+++ b/stack/tests/deployment_test.yaml
@@ -157,6 +157,30 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: "node:20.0.0"
+  - it: uses supplied sidecar image string value
+    set:
+      services:
+        service1:
+          sidecars:
+            - name: sidecar1
+              image: "alpine:latest"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: "alpine:latest"
+  - it: formats supplied initContainer image tag and repo
+    set:
+      services:
+        service1:
+          sidecar:
+            - name: sidecar1
+              image:
+                repository: "node"
+                tag: "20.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: "node:20.0.0"
   - it: overwrites the name
     set:
       global:


### PR DESCRIPTION
Images for sidecars can only be specified with a full URI string which means the argus docker builder won't change the tag when it updates other image tags. We need to be able to specify it as a separate field like we do for the main container and init containers