### PR TITLE
fix: 10 min is too long to wait

### DIFF
--- a/argus-config/templates/external_secrets_env.yaml
+++ b/argus-config/templates/external_secrets_env.yaml
@@ -14,7 +14,7 @@ spec:
   secretStoreRef:
     name: aws-secretsmanager
     kind: ClusterSecretStore
-  refreshInterval: "10m"
+  refreshInterval: "30s"
   target:
     deletionPolicy: Delete
   dataFrom:


### PR DESCRIPTION
People often set secrets and then want to test their secrets are working properly. 10 min default wait time is a lot and has causes a lot of support tickets that resolve themselves after time.