### PR TITLE
fix: bump argus dependency

### DIFF
--- a/stack/Chart.yaml
+++ b/stack/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: argus-config
-    version: 1.2.2
+    version: 1.2.3
     repository: https://chanzuckerberg.github.io/argo-helm-charts


### PR DESCRIPTION
This is for fixing the [release](https://github.com/chanzuckerberg/argo-helm-charts/actions/runs/12798869845/job/35684615202). 