### PR TITLE
fix: fixed whitespace for adding annotations

### DIFF
--- a/stack/templates/cronjob.yaml
+++ b/stack/templates/cronjob.yaml
@@ -55,7 +55,7 @@ metadata:
             .Values.annotations
             .Values.serviceAccount.annotations
   }}
-annotations:
+  annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/stack/tests/cronjob_test.yaml
+++ b/stack/tests/cronjob_test.yaml
@@ -11,6 +11,8 @@ tests:
           schedule: "*/3 * * * *"
           serviceAccount:
             create: true
+            annotations:
+              "eks.amazonaws.com/role-arn": some-role
           image:
             repository: my-repo
             tag: sha-mytag
@@ -58,6 +60,10 @@ tests:
         equal:
           path: metadata.name
           value: "release-name-stack-job1"
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "some-role"
       - documentIndex: 1
         equal:
           path: metadata.labels["app.kubernetes.io/name"]


### PR DESCRIPTION
Currently adding annotation for eks role for cronjob is wrong, see [here](https://argo.dev.platform.si.czi.technology/applications/argocd/argus-rdev-e54afa8b?resource=&node=%2FServiceAccount%2Fcore-platform-rdev%2Fargus-rdev-e54afa8b-stack-syncawssecretmanager%2F0).
```
annotations:
  eks.amazonaws.com/role-arn: 'arn:aws:iam::471112759938:role/argo_root_core_platform_infra_dev_eks'
apiVersion: v1
automountServiceAccountToken: true
kind: ServiceAccount
metadata:
  labels:
    app.kubernetes.io/instance: argus-rdev-e54afa8b
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: stack
    app.kubernetes.io/service: argus-rdev-e54afa8b-stack-syncawssecretmanager
    app.kubernetes.io/version: 1.16.0
    argocd.argoproj.io/instance: argus-rdev-e54afa8b
    helm.sh/chart: stack-2.5.2
  name: argus-rdev-e54afa8b-stack-syncawssecretmanager
  namespace: core-platform-rdev
```
Fixed this bug and added new unit tests.