### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/chart-dependency-update.yaml
+++ b/.github/workflows/chart-dependency-update.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update_chart_locks:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   check-chart-released:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
     if: ${{ needs.check-chart-released.outputs.chart_released == 'true' }}
     needs:
       - check-chart-released
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Parse Tag
         id: parse_tag

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -14,6 +14,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   conventional_commit_title:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.4.0

--- a/.github/workflows/generate-schemas.yaml
+++ b/.github/workflows/generate-schemas.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_schema_and_readme:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,7 +8,7 @@ concurrency:
 name: release-please
 jobs:
   release-please:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       # For why we need to generate a token and not use the default


### PR DESCRIPTION
This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.