### PR TITLE
feat: helm chart for argocd projects

### DIFF
--- a/argo-project/.helmignore
+++ b/argo-project/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# testing
+tests

--- a/argo-project/Chart.yaml
+++ b/argo-project/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: argo-project
+description: A Helm chart for an Argo project
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/argo-project/Makefile
+++ b/argo-project/Makefile
@@ -1,0 +1,3 @@
+
+include ../common.mk
+include ../schema.mk

--- a/argo-project/README.md
+++ b/argo-project/README.md
@@ -1,3 +1,163 @@
-## Summary
+# argo-project
 
-Makes an ArgoCD project. Helpful in combindation with an ApplicationSet so we can dynamically make a project for all clusters we deploy.
+**Title:** argo-project
+
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
+
+| Property                       | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [namespace](#namespace )     | No      | string | No         | -          | -                 |
+| - [projectName](#projectName ) | No      | string | No         | -          | -                 |
+| - [spec](#spec )               | No      | object | No         | -          | -                 |
+
+## <a name="namespace"></a>1. Property `argo-project > namespace`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="projectName"></a>2. Property `argo-project > projectName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="spec"></a>3. Property `argo-project > spec`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                      | Pattern | Type            | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ----------------- |
+| - [clusterResourceWhitelist](#spec_clusterResourceWhitelist ) | No      | array of object | No         | -          | -                 |
+| - [destinations](#spec_destinations )                         | No      | array of object | No         | -          | -                 |
+| - [sourceRepos](#spec_sourceRepos )                           | No      | array of string | No         | -          | -                 |
+
+### <a name="spec_clusterResourceWhitelist"></a>3.1. Property `argo-project > spec > clusterResourceWhitelist`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                                        | Description |
+| ---------------------------------------------------------------------- | ----------- |
+| [clusterResourceWhitelist items](#spec_clusterResourceWhitelist_items) | -           |
+
+#### <a name="spec_clusterResourceWhitelist_items"></a>3.1.1. argo-project > spec > clusterResourceWhitelist > clusterResourceWhitelist items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                               | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [group](#spec_clusterResourceWhitelist_items_group ) | No      | string | No         | -          | -                 |
+| - [kind](#spec_clusterResourceWhitelist_items_kind )   | No      | string | No         | -          | -                 |
+
+##### <a name="spec_clusterResourceWhitelist_items_group"></a>3.1.1.1. Property `argo-project > spec > clusterResourceWhitelist > clusterResourceWhitelist items > group`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="spec_clusterResourceWhitelist_items_kind"></a>3.1.1.2. Property `argo-project > spec > clusterResourceWhitelist > clusterResourceWhitelist items > kind`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="spec_destinations"></a>3.2. Property `argo-project > spec > destinations`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [destinations items](#spec_destinations_items) | -           |
+
+#### <a name="spec_destinations_items"></a>3.2.1. argo-project > spec > destinations > destinations items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                           | Pattern | Type   | Deprecated | Definition | Title/Description |
+| -------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [namespace](#spec_destinations_items_namespace ) | No      | string | No         | -          | -                 |
+| - [server](#spec_destinations_items_server )       | No      | string | No         | -          | -                 |
+
+##### <a name="spec_destinations_items_namespace"></a>3.2.1.1. Property `argo-project > spec > destinations > destinations items > namespace`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="spec_destinations_items_server"></a>3.2.1.2. Property `argo-project > spec > destinations > destinations items > server`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="spec_sourceRepos"></a>3.3. Property `argo-project > spec > sourceRepos`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of string` |
+| **Required** | No                |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be              | Description |
+| -------------------------------------------- | ----------- |
+| [sourceRepos items](#spec_sourceRepos_items) | -           |
+
+#### <a name="spec_sourceRepos_items"></a>3.3.1. argo-project > spec > sourceRepos > sourceRepos items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+----------------------------------------------------------------------------------------------------------------------------

--- a/argo-project/README.md
+++ b/argo-project/README.md
@@ -1,0 +1,3 @@
+## Summary
+
+Makes an ArgoCD project. Helpful in combindation with an ApplicationSet so we can dynamically make a project for all clusters we deploy.

--- a/argo-project/templates/project.yaml
+++ b/argo-project/templates/project.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {{ .Values.projectName}}
+  namespace: {{ .Values.namespace }}
+spec:
+  {{ toYaml .Values.project.spec | indent 2 }}

--- a/argo-project/tests/project.yaml
+++ b/argo-project/tests/project.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test cronjobs
+templates:
+  - project.yaml
+tests:
+  - it: should work
+    set:
+      projectName: test-addons
+      namespace: argocd
+      spec:
+        clusterResourceWhitelist:
+          - group: "*"
+            kind: "*"
+        destinations:
+          - namespace: "cw-loki"
+            server: "*"
+        sourceRepos:
+          - "*"
+    asserts:
+      - isKind:
+          of: AppProject

--- a/argo-project/tests/project.yaml
+++ b/argo-project/tests/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
-suite: test cronjobs
+suite: test argocd project
 templates:
   - project.yaml
 tests:

--- a/argo-project/values.schema.json
+++ b/argo-project/values.schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "argo.helm.charts/argo-project",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "namespace": {
+      "type": "string"
+    },
+    "projectName": {
+      "type": "string"
+    },
+    "spec": {
+      "properties": {
+        "clusterResourceWhitelist": {
+          "items": {
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "destinations": {
+          "items": {
+            "properties": {
+              "namespace": {
+                "type": "string"
+              },
+              "server": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sourceRepos": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "argo-project",
+  "type": "object"
+}

--- a/argo-project/values.yaml
+++ b/argo-project/values.yaml
@@ -1,0 +1,11 @@
+projectName: my-cluster-addons
+namespace: argocd
+spec:
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  destinations:
+    - namespace: "cw-loki"
+      server: "*"
+  sourceRepos:
+    - "*"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,9 @@
     },
     "sso-secret": {
       "package-name": "sso-secret"
+    },
+    "argo-project": {
+      "package-name": "argo-project"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a helm chart for an ArgoCD project. This will be used in conjunction with an ApplicationSet in argus-infra-stacks so we have a project to deploy all our cluster-specific addons through Argo applicationsets.

## References

* https://github.com/chanzuckerberg/argus-infra-stacks/pull/674