### PR TITLE
feat: Support multiple grafanas in the same namespace

### DIFF
--- a/grafana/templates/grafana.yaml
+++ b/grafana/templates/grafana.yaml
@@ -45,7 +45,7 @@ spec:
           volumes:
             - name: secrets
               secret:
-                secretName: grafana-sso-secret
+                secretName: {{ .Values.grafanaName }}-sso-secret
                 defaultMode: 0444
           containers:
             - name: grafana

--- a/grafana/templates/grafana.yaml
+++ b/grafana/templates/grafana.yaml
@@ -70,7 +70,7 @@ spec:
                 pathType: Prefix
                 backend:
                   service:
-                    name: grafana-service
+                    name: {{ .Values.grafanaName }}-service
                     port:
                       number: 80
       tls:

--- a/grafana/templates/sso-secret.yaml
+++ b/grafana/templates/sso-secret.yaml
@@ -2,20 +2,20 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: grafana-sso-secret
+  name: {{ .Values.grafanaName }}-sso-secret
 spec:
   refreshInterval: 1m
   secretStoreRef:
     name: {{ .Values.secretStoreRef}}
     kind: ClusterSecretStore
   target:
-    name: grafana-sso-secret
+    name: {{ .Values.grafanaName }}-sso-secret
     creationPolicy: Owner
   data:
   - secretKey: client-id
     remoteRef:
-      key: {{ .Values.clusterName }}/grafana/oauth/client-id
+      key: {{ .Values.clusterName }}/{{ .Values.grafanaName }}/oauth/client-id
   - secretKey: client-secret
     remoteRef:
-      key: {{ .Values.clusterName }}/grafana/oauth/client-secret
+      key: {{ .Values.clusterName }}/{{ .Values.grafanaName }}/oauth/client-secret
 {{ end }}


### PR DESCRIPTION
Current configuration is limited to one, due to a single grafana-sso-secret. This PR ties the name of the secret to the name of the grafana deployed. Default grafanaName is `grafana`, so existing installs are not affected.