### PR TITLE
fix: increase nginx timeout

### DIFF
--- a/argus-config/tests/configmap_test.yaml
+++ b/argus-config/tests/configmap_test.yaml
@@ -16,7 +16,7 @@ tests:
           appNamespace: "argoCD"
           appRevision: "testSHAAAAAAAAA"
           appRevisionShort: "testSHA"
-          appRevisionShort8: "testSHA8"
+          appRevisionShort8: 12345678
           appSourcePath: "."
           appSourceRepoUrl: "http://github.com/chanzuckerberg/repo"
           appSourceTargetRevision: "main"


### PR DESCRIPTION
At the moment, Argus create stack operation will timeout after 1 minutes even though ArgoCD is still running the operation, see run [here](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/15330354201/job/43136285218), and this doesn't accurately reflect the status of create stack ops.

There are three operations timeout related to nginx:
1. `nginx.ingress.kubernetes.io/proxy-connect-timeout`: this sets the timeout for establishing a connection with the proxied server (your application's pod/service endpoint). So this shouldn't be the culprit of our timeout as its not failing due to inability to establish connection.
2. `nginx.ingress.kubernetes.io/proxy-read-timeout`: this sets the timeout for reading a response from the proxied server. Since git fetch takes roughly 11minutes on a good network connection for single-cell-data-portal, this is probably the culprit. 
3. `nginx.ingress.kubernetes.io/proxy-send-timeout`: this sets the timeout for transmitting a request to the proxied server. Similar to proxy-read-timeout, this timeout is set only between two successive write operations, not for the transmission of the whole request. This has more to do it argo server availability, which is not the culprit to our timeout.