### PR TITLE
fix: Remove if statement for allow_embedding

### DIFF
--- a/grafana/templates/grafana.yaml
+++ b/grafana/templates/grafana.yaml
@@ -43,11 +43,9 @@ spec:
       role_attribute_path: {{ .Values.roleAttributePath | quote }}
     server:
       root_url: "https://{{ .Values.grafanaSubdomain }}.{{ .Values.baseDomain }}"
-    {{- if .Values.allow_embedding }}
     grafana.ini:
       security:
         allow_embedding: {{ .Values.allow_embedding | default "false" | quote }}
-    {{- end }}
   deployment:
     spec:
       replicas: {{ .Values.replicas }}


### PR DESCRIPTION
Since there's a default, we don't need the if statement anymore