### PR TITLE
fix: Remove grafana.ini key

### DIFF
--- a/grafana/templates/grafana.yaml
+++ b/grafana/templates/grafana.yaml
@@ -43,9 +43,8 @@ spec:
       role_attribute_path: {{ .Values.roleAttributePath | quote }}
     server:
       root_url: "https://{{ .Values.grafanaSubdomain }}.{{ .Values.baseDomain }}"
-    grafana.ini:
-      security: |
-        allow_embedding = {{ .Values.allow_embedding | default "false" | quote }}
+    security:
+      allow_embedding: {{ .Values.allow_embedding | default "false" | quote }}
   deployment:
     spec:
       replicas: {{ .Values.replicas }}


### PR DESCRIPTION
This is the current manifest:
```
apiVersion: v1
data:
  grafana.ini: >+
...
    [grafana.ini]
    security = allow_embedding = "true"
...
```
I want `security` to be the section and `allow_embedding` to be the key.