### PR TITLE
fix: Fix loki monitoring alertgroup

### DIFF
--- a/loki-monitoring/templates/alert_groups.yaml
+++ b/loki-monitoring/templates/alert_groups.yaml
@@ -125,6 +125,7 @@ spec:
     execErrState: OK
     annotations: {}
     labels: {}
+    for: 5m
     isPaused: false
   - uid: cev3mcuwlz6dcc
     title: Statefulset pods unavailable
@@ -176,6 +177,7 @@ spec:
     execErrState: OK
     annotations: {}
     labels: {}
+    for: 5m
     isPaused: false
   - uid: bev3mo5h2ihogf
     title: Deployment pods unavailable


### PR DESCRIPTION
Addressed: 

```
The GrafanaAlertRuleGroup "cw-loki-alerts" is invalid: 
* spec.rules[1].for: Required value
* spec.rules[2].for: Required value
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```