### PR TITLE
feat: Add volume snapshot support for pvc

### DIFF
--- a/schema.mk
+++ b/schema.mk
@@ -4,4 +4,4 @@
 CHART_NAME := $(shell basename $(PWD))
 
 update-schema:
-	helm schema --values values.yaml --indent 2 --no-additional-properties --schema-root.id argo.helm.charts/$(CHART_NAME) --schema-root.title $(CHART_NAME)
+	helm schema --values values.yaml --indent 2 --schema-root.id argo.helm.charts/$(CHART_NAME) --schema-root.title $(CHART_NAME)

--- a/stack/README.md
+++ b/stack/README.md
@@ -1366,11 +1366,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                              | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| --------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
+| Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
+| --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
+| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string | No         | -          | API version of the data source                                  |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | string | No         | -          | Kind of the data source [VolumeSnapshot, PersistentVolumeClaim] |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string | No         | -          | Name of the data source                                         |
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiGroup"></a>2.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiGroup`
 
@@ -1383,16 +1383,12 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_kind"></a>2.1.21.4.2.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > kind`
 
-|              |                    |
-| ------------ | ------------------ |
-| **Type**     | `enum (of string)` |
-| **Required** | No                 |
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
-**Description:** Kind of the data source
-
-Must be one of:
-* "VolumeSnapshot"
-* "PersistentVolumeClaim"
+**Description:** Kind of the data source [VolumeSnapshot, PersistentVolumeClaim]
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_name"></a>2.1.21.4.2.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > name`
 
@@ -3407,11 +3403,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                   | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| ---------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiGroup](#global_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#global_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#global_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
+| Property                                                   | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
+| ---------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
+| - [apiGroup](#global_persistence_pvc_dataSource_apiGroup ) | No      | string | No         | -          | API version of the data source                                  |
+| - [kind](#global_persistence_pvc_dataSource_kind )         | No      | string | No         | -          | Kind of the data source [VolumeSnapshot, PersistentVolumeClaim] |
+| - [name](#global_persistence_pvc_dataSource_name )         | No      | string | No         | -          | Name of the data source                                         |
 
 ###### <a name="global_persistence_pvc_dataSource_apiGroup"></a>3.21.4.2.1. Property `stack > global > persistence > pvc > dataSource > apiGroup`
 
@@ -3424,16 +3420,12 @@ Must be one of:
 
 ###### <a name="global_persistence_pvc_dataSource_kind"></a>3.21.4.2.2. Property `stack > global > persistence > pvc > dataSource > kind`
 
-|              |                    |
-| ------------ | ------------------ |
-| **Type**     | `enum (of string)` |
-| **Required** | No                 |
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
-**Description:** Kind of the data source
-
-Must be one of:
-* "VolumeSnapshot"
-* "PersistentVolumeClaim"
+**Description:** Kind of the data source [VolumeSnapshot, PersistentVolumeClaim]
 
 ###### <a name="global_persistence_pvc_dataSource_name"></a>3.21.4.2.3. Property `stack > global > persistence > pvc > dataSource > name`
 
@@ -5466,11 +5458,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                              | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| --------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
+| Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
+| --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
+| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string | No         | -          | API version of the data source                                  |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | string | No         | -          | Kind of the data source [VolumeSnapshot, PersistentVolumeClaim] |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string | No         | -          | Name of the data source                                         |
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiGroup"></a>4.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiGroup`
 
@@ -5483,16 +5475,12 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_kind"></a>4.1.21.4.2.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > kind`
 
-|              |                    |
-| ------------ | ------------------ |
-| **Type**     | `enum (of string)` |
-| **Required** | No                 |
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
-**Description:** Kind of the data source
-
-Must be one of:
-* "VolumeSnapshot"
-* "PersistentVolumeClaim"
+**Description:** Kind of the data source [VolumeSnapshot, PersistentVolumeClaim]
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_name"></a>4.1.21.4.2.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > name`
 
@@ -7525,11 +7513,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                              | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| --------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
+| Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
+| --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
+| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string | No         | -          | API version of the data source                                  |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | string | No         | -          | Kind of the data source [VolumeSnapshot, PersistentVolumeClaim] |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string | No         | -          | Name of the data source                                         |
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiGroup"></a>5.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiGroup`
 
@@ -7542,16 +7530,12 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_kind"></a>5.1.21.4.2.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > kind`
 
-|              |                    |
-| ------------ | ------------------ |
-| **Type**     | `enum (of string)` |
-| **Required** | No                 |
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
-**Description:** Kind of the data source
-
-Must be one of:
-* "VolumeSnapshot"
-* "PersistentVolumeClaim"
+**Description:** Kind of the data source [VolumeSnapshot, PersistentVolumeClaim]
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_name"></a>5.1.21.4.2.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > name`
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -2,11 +2,11 @@
 
 **Title:** stack
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                         | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                            |
 | -------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
@@ -28,11 +28,11 @@
 
 ## <a name="cronJobs"></a>2. Property `stack > cronJobs`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Cron jobs to deploy
 
@@ -49,7 +49,7 @@ must respect the following conditions
 | ------------------------- | ------------------- |
 | **Type**                  | `object`            |
 | **Required**              | No                  |
-| **Additional properties** | Not allowed         |
+| **Additional properties** | Any type allowed    |
 | **Defined in**            | #/properties/global |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
@@ -118,11 +118,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appContext"></a>2.1.3. Property `stack > cronJobs > ^.*$ > appContext`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -145,11 +145,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appSecrets"></a>2.1.4. Property `stack > cronJobs > ^.*$ > appSecrets`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -159,11 +159,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_clusterSecret"></a>2.1.4.1. Property `stack > cronJobs > ^.*$ > appSecrets > clusterSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -186,11 +186,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_envSecret"></a>2.1.4.2. Property `stack > cronJobs > ^.*$ > appSecrets > envSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -213,11 +213,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_stackSecret"></a>2.1.4.3. Property `stack > cronJobs > ^.*$ > appSecrets > stackSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -268,11 +268,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_autoscaling"></a>2.1.6. Property `stack > cronJobs > ^.*$ > autoscaling`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Autoscaling configuration
 
@@ -401,11 +401,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_env_items"></a>2.1.10.1. stack > cronJobs > ^.*$ > env > env items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -449,11 +449,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_envFrom_items"></a>2.1.11.1. stack > cronJobs > ^.*$ > envFrom > envFrom items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                         | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -495,11 +495,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_image"></a>2.1.13. Property `stack > cronJobs > ^.*$ > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -567,11 +567,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_ingress"></a>2.1.15. Property `stack > cronJobs > ^.*$ > ingress`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Ingress configuration
 
@@ -588,11 +588,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_ingress_annotations"></a>2.1.15.1. Property `stack > cronJobs > ^.*$ > ingress > annotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -704,11 +704,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_ingress_paths_items"></a>2.1.15.6.1. stack > cronJobs > ^.*$ > ingress > paths > paths items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -786,11 +786,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_livenessProbe"></a>2.1.17. Property `stack > cronJobs > ^.*$ > livenessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Liveness probe configuration
 
@@ -814,11 +814,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_livenessProbe_httpGet"></a>2.1.17.2. Property `stack > cronJobs > ^.*$ > livenessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -922,11 +922,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_nodeSelector"></a>2.1.19. Property `stack > cronJobs > ^.*$ > nodeSelector`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                   | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | -------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -943,11 +943,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_oidcProxy"></a>2.1.20. Property `stack > cronJobs > ^.*$ > oidcProxy`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                               | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ---------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -1055,11 +1055,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_image"></a>2.1.20.7. Property `stack > cronJobs > ^.*$ > oidcProxy > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -1095,11 +1095,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_resources"></a>2.1.20.9. Property `stack > cronJobs > ^.*$ > oidcProxy > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -1108,11 +1108,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_limits"></a>2.1.20.9.1. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                          | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -1159,11 +1159,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_requests"></a>2.1.20.9.2. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                            | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -1231,11 +1231,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_skipAuth_items"></a>2.1.20.10.1. stack > cronJobs > ^.*$ > oidcProxy > skipAuth > skipAuth items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -1275,11 +1275,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_persistence"></a>2.1.21. Property `stack > cronJobs > ^.*$ > persistence`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -1317,11 +1317,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_persistence_pvc"></a>2.1.21.4. Property `stack > cronJobs > ^.*$ > persistence > pvc`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                   | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | -------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
@@ -1360,11 +1360,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource"></a>2.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
@@ -1401,11 +1401,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>2.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                             | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | -------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
@@ -1413,11 +1413,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>2.1.21.4.3.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** PVC resource requests
 
@@ -1445,11 +1445,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_podAnnotations"></a>2.1.22. Property `stack > cronJobs > ^.*$ > podAnnotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Annotations to add to pods
 
@@ -1507,11 +1507,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_readinessProbe"></a>2.1.26. Property `stack > cronJobs > ^.*$ > readinessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Readiness probe configuration
 
@@ -1535,11 +1535,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_readinessProbe_httpGet"></a>2.1.26.2. Property `stack > cronJobs > ^.*$ > readinessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -1643,11 +1643,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_resources"></a>2.1.28. Property `stack > cronJobs > ^.*$ > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -1658,11 +1658,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_limits"></a>2.1.28.1. Property `stack > cronJobs > ^.*$ > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource limits
 
@@ -1711,11 +1711,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_requests"></a>2.1.28.2. Property `stack > cronJobs > ^.*$ > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests
 
@@ -1788,11 +1788,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_service"></a>2.1.31. Property `stack > cronJobs > ^.*$ > service`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service configuration
 
@@ -1821,11 +1821,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_serviceAccount"></a>2.1.32. Property `stack > cronJobs > ^.*$ > serviceAccount`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service account configuration
 
@@ -1901,11 +1901,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_startupProbe"></a>2.1.35. Property `stack > cronJobs > ^.*$ > startupProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Startup probe configuration
 
@@ -1930,11 +1930,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_startupProbe_exec"></a>2.1.35.2. Property `stack > cronJobs > ^.*$ > startupProbe > exec`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Exec probe configuration
 
@@ -2083,11 +2083,11 @@ Must be one of:
 
 ## <a name="global"></a>3. Property `stack > global`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
 
@@ -2155,11 +2155,11 @@ Must be one of:
 
 ### <a name="global_appContext"></a>3.3. Property `stack > global > appContext`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                     | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2182,11 +2182,11 @@ Must be one of:
 
 ### <a name="global_appSecrets"></a>3.4. Property `stack > global > appSecrets`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2196,11 +2196,11 @@ Must be one of:
 
 #### <a name="global_appSecrets_clusterSecret"></a>3.4.1. Property `stack > global > appSecrets > clusterSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                     | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2223,11 +2223,11 @@ Must be one of:
 
 #### <a name="global_appSecrets_envSecret"></a>3.4.2. Property `stack > global > appSecrets > envSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                 | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2250,11 +2250,11 @@ Must be one of:
 
 #### <a name="global_appSecrets_stackSecret"></a>3.4.3. Property `stack > global > appSecrets > stackSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                   | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2305,11 +2305,11 @@ Must be one of:
 
 ### <a name="global_autoscaling"></a>3.6. Property `stack > global > autoscaling`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Autoscaling configuration
 
@@ -2438,11 +2438,11 @@ Must be one of:
 
 #### <a name="global_env_items"></a>3.10.1. stack > global > env > env items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2486,11 +2486,11 @@ Must be one of:
 
 #### <a name="global_envFrom_items"></a>3.11.1. stack > global > envFrom > envFrom items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2532,11 +2532,11 @@ Must be one of:
 
 ### <a name="global_image"></a>3.13. Property `stack > global > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                  | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ----------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -2604,11 +2604,11 @@ Must be one of:
 
 ### <a name="global_ingress"></a>3.15. Property `stack > global > ingress`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Ingress configuration
 
@@ -2625,11 +2625,11 @@ Must be one of:
 
 #### <a name="global_ingress_annotations"></a>3.15.1. Property `stack > global > ingress > annotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                                                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2741,11 +2741,11 @@ Must be one of:
 
 ##### <a name="global_ingress_paths_items"></a>3.15.6.1. stack > global > ingress > paths > paths items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2823,11 +2823,11 @@ Must be one of:
 
 ### <a name="global_livenessProbe"></a>3.17. Property `stack > global > livenessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Liveness probe configuration
 
@@ -2851,11 +2851,11 @@ Must be one of:
 
 #### <a name="global_livenessProbe_httpGet"></a>3.17.2. Property `stack > global > livenessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -2959,11 +2959,11 @@ Must be one of:
 
 ### <a name="global_nodeSelector"></a>3.19. Property `stack > global > nodeSelector`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -2980,11 +2980,11 @@ Must be one of:
 
 ### <a name="global_oidcProxy"></a>3.20. Property `stack > global > oidcProxy`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                    | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ----------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -3092,11 +3092,11 @@ Must be one of:
 
 #### <a name="global_oidcProxy_image"></a>3.20.7. Property `stack > global > oidcProxy > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -3132,11 +3132,11 @@ Must be one of:
 
 #### <a name="global_oidcProxy_resources"></a>3.20.9. Property `stack > global > oidcProxy > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -3145,11 +3145,11 @@ Must be one of:
 
 ##### <a name="global_oidcProxy_resources_limits"></a>3.20.9.1. Property `stack > global > oidcProxy > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                               | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------ | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -3196,11 +3196,11 @@ Must be one of:
 
 ##### <a name="global_oidcProxy_resources_requests"></a>3.20.9.2. Property `stack > global > oidcProxy > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                 | Pattern | Type        | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -3268,11 +3268,11 @@ Must be one of:
 
 ##### <a name="global_oidcProxy_skipAuth_items"></a>3.20.10.1. stack > global > oidcProxy > skipAuth > skipAuth items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -3312,11 +3312,11 @@ Must be one of:
 
 ### <a name="global_persistence"></a>3.21. Property `stack > global > persistence`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                              | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ----------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -3354,11 +3354,11 @@ Must be one of:
 
 #### <a name="global_persistence_pvc"></a>3.21.4. Property `stack > global > persistence > pvc`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | --------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
@@ -3397,11 +3397,11 @@ Must be one of:
 
 ##### <a name="global_persistence_pvc_dataSource"></a>3.21.4.2. Property `stack > global > persistence > pvc > dataSource`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                   | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
 | ---------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
@@ -3438,11 +3438,11 @@ Must be one of:
 
 ##### <a name="global_persistence_pvc_resources"></a>3.21.4.3. Property `stack > global > persistence > pvc > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                  | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | --------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
@@ -3450,11 +3450,11 @@ Must be one of:
 
 ###### <a name="global_persistence_pvc_resources_requests"></a>3.21.4.3.1. Property `stack > global > persistence > pvc > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** PVC resource requests
 
@@ -3482,11 +3482,11 @@ Must be one of:
 
 ### <a name="global_podAnnotations"></a>3.22. Property `stack > global > podAnnotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Annotations to add to pods
 
@@ -3544,11 +3544,11 @@ Must be one of:
 
 ### <a name="global_readinessProbe"></a>3.26. Property `stack > global > readinessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Readiness probe configuration
 
@@ -3572,11 +3572,11 @@ Must be one of:
 
 #### <a name="global_readinessProbe_httpGet"></a>3.26.2. Property `stack > global > readinessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -3680,11 +3680,11 @@ Must be one of:
 
 ### <a name="global_resources"></a>3.28. Property `stack > global > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -3695,11 +3695,11 @@ Must be one of:
 
 #### <a name="global_resources_limits"></a>3.28.1. Property `stack > global > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource limits
 
@@ -3748,11 +3748,11 @@ Must be one of:
 
 #### <a name="global_resources_requests"></a>3.28.2. Property `stack > global > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests
 
@@ -3825,11 +3825,11 @@ Must be one of:
 
 ### <a name="global_service"></a>3.31. Property `stack > global > service`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service configuration
 
@@ -3858,11 +3858,11 @@ Must be one of:
 
 ### <a name="global_serviceAccount"></a>3.32. Property `stack > global > serviceAccount`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service account configuration
 
@@ -3938,11 +3938,11 @@ Must be one of:
 
 ### <a name="global_startupProbe"></a>3.35. Property `stack > global > startupProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Startup probe configuration
 
@@ -3967,11 +3967,11 @@ Must be one of:
 
 #### <a name="global_startupProbe_exec"></a>3.35.2. Property `stack > global > startupProbe > exec`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Exec probe configuration
 
@@ -4120,11 +4120,11 @@ Must be one of:
 
 ## <a name="jobs"></a>4. Property `stack > jobs`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Jobs to deploy
 
@@ -4141,7 +4141,7 @@ must respect the following conditions
 | ------------------------- | ------------------- |
 | **Type**                  | `object`            |
 | **Required**              | No                  |
-| **Additional properties** | Not allowed         |
+| **Additional properties** | Any type allowed    |
 | **Defined in**            | #/properties/global |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
@@ -4210,11 +4210,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appContext"></a>4.1.3. Property `stack > cronJobs > ^.*$ > appContext`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4237,11 +4237,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appSecrets"></a>4.1.4. Property `stack > cronJobs > ^.*$ > appSecrets`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4251,11 +4251,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_clusterSecret"></a>4.1.4.1. Property `stack > cronJobs > ^.*$ > appSecrets > clusterSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4278,11 +4278,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_envSecret"></a>4.1.4.2. Property `stack > cronJobs > ^.*$ > appSecrets > envSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4305,11 +4305,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_stackSecret"></a>4.1.4.3. Property `stack > cronJobs > ^.*$ > appSecrets > stackSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4360,11 +4360,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_autoscaling"></a>4.1.6. Property `stack > cronJobs > ^.*$ > autoscaling`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Autoscaling configuration
 
@@ -4493,11 +4493,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_env_items"></a>4.1.10.1. stack > cronJobs > ^.*$ > env > env items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4541,11 +4541,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_envFrom_items"></a>4.1.11.1. stack > cronJobs > ^.*$ > envFrom > envFrom items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                         | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4587,11 +4587,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_image"></a>4.1.13. Property `stack > cronJobs > ^.*$ > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -4659,11 +4659,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_ingress"></a>4.1.15. Property `stack > cronJobs > ^.*$ > ingress`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Ingress configuration
 
@@ -4680,11 +4680,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_ingress_annotations"></a>4.1.15.1. Property `stack > cronJobs > ^.*$ > ingress > annotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4796,11 +4796,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_ingress_paths_items"></a>4.1.15.6.1. stack > cronJobs > ^.*$ > ingress > paths > paths items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4878,11 +4878,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_livenessProbe"></a>4.1.17. Property `stack > cronJobs > ^.*$ > livenessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Liveness probe configuration
 
@@ -4906,11 +4906,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_livenessProbe_httpGet"></a>4.1.17.2. Property `stack > cronJobs > ^.*$ > livenessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -5014,11 +5014,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_nodeSelector"></a>4.1.19. Property `stack > cronJobs > ^.*$ > nodeSelector`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                   | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | -------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -5035,11 +5035,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_oidcProxy"></a>4.1.20. Property `stack > cronJobs > ^.*$ > oidcProxy`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                               | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ---------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -5147,11 +5147,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_image"></a>4.1.20.7. Property `stack > cronJobs > ^.*$ > oidcProxy > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -5187,11 +5187,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_resources"></a>4.1.20.9. Property `stack > cronJobs > ^.*$ > oidcProxy > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -5200,11 +5200,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_limits"></a>4.1.20.9.1. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                          | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -5251,11 +5251,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_requests"></a>4.1.20.9.2. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                            | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -5323,11 +5323,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_skipAuth_items"></a>4.1.20.10.1. stack > cronJobs > ^.*$ > oidcProxy > skipAuth > skipAuth items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -5367,11 +5367,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_persistence"></a>4.1.21. Property `stack > cronJobs > ^.*$ > persistence`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -5409,11 +5409,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_persistence_pvc"></a>4.1.21.4. Property `stack > cronJobs > ^.*$ > persistence > pvc`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                   | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | -------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
@@ -5452,11 +5452,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource"></a>4.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
@@ -5493,11 +5493,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>4.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                             | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | -------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
@@ -5505,11 +5505,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>4.1.21.4.3.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** PVC resource requests
 
@@ -5537,11 +5537,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_podAnnotations"></a>4.1.22. Property `stack > cronJobs > ^.*$ > podAnnotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Annotations to add to pods
 
@@ -5599,11 +5599,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_readinessProbe"></a>4.1.26. Property `stack > cronJobs > ^.*$ > readinessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Readiness probe configuration
 
@@ -5627,11 +5627,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_readinessProbe_httpGet"></a>4.1.26.2. Property `stack > cronJobs > ^.*$ > readinessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -5735,11 +5735,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_resources"></a>4.1.28. Property `stack > cronJobs > ^.*$ > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -5750,11 +5750,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_limits"></a>4.1.28.1. Property `stack > cronJobs > ^.*$ > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource limits
 
@@ -5803,11 +5803,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_requests"></a>4.1.28.2. Property `stack > cronJobs > ^.*$ > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests
 
@@ -5880,11 +5880,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_service"></a>4.1.31. Property `stack > cronJobs > ^.*$ > service`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service configuration
 
@@ -5913,11 +5913,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_serviceAccount"></a>4.1.32. Property `stack > cronJobs > ^.*$ > serviceAccount`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service account configuration
 
@@ -5993,11 +5993,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_startupProbe"></a>4.1.35. Property `stack > cronJobs > ^.*$ > startupProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Startup probe configuration
 
@@ -6022,11 +6022,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_startupProbe_exec"></a>4.1.35.2. Property `stack > cronJobs > ^.*$ > startupProbe > exec`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Exec probe configuration
 
@@ -6175,11 +6175,11 @@ Must be one of:
 
 ## <a name="services"></a>5. Property `stack > services`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Services to deploy
 
@@ -6196,7 +6196,7 @@ must respect the following conditions
 | ------------------------- | ------------------- |
 | **Type**                  | `object`            |
 | **Required**              | No                  |
-| **Additional properties** | Not allowed         |
+| **Additional properties** | Any type allowed    |
 | **Defined in**            | #/properties/global |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
@@ -6265,11 +6265,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appContext"></a>5.1.3. Property `stack > cronJobs > ^.*$ > appContext`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6292,11 +6292,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appSecrets"></a>5.1.4. Property `stack > cronJobs > ^.*$ > appSecrets`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6306,11 +6306,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_clusterSecret"></a>5.1.4.1. Property `stack > cronJobs > ^.*$ > appSecrets > clusterSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6333,11 +6333,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_envSecret"></a>5.1.4.2. Property `stack > cronJobs > ^.*$ > appSecrets > envSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6360,11 +6360,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_stackSecret"></a>5.1.4.3. Property `stack > cronJobs > ^.*$ > appSecrets > stackSecret`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6415,11 +6415,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_autoscaling"></a>5.1.6. Property `stack > cronJobs > ^.*$ > autoscaling`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Autoscaling configuration
 
@@ -6548,11 +6548,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_env_items"></a>5.1.10.1. stack > cronJobs > ^.*$ > env > env items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6596,11 +6596,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_envFrom_items"></a>5.1.11.1. stack > cronJobs > ^.*$ > envFrom > envFrom items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                         | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6642,11 +6642,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_image"></a>5.1.13. Property `stack > cronJobs > ^.*$ > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -6714,11 +6714,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_ingress"></a>5.1.15. Property `stack > cronJobs > ^.*$ > ingress`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Ingress configuration
 
@@ -6735,11 +6735,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_ingress_annotations"></a>5.1.15.1. Property `stack > cronJobs > ^.*$ > ingress > annotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6851,11 +6851,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_ingress_paths_items"></a>5.1.15.6.1. stack > cronJobs > ^.*$ > ingress > paths > paths items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6933,11 +6933,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_livenessProbe"></a>5.1.17. Property `stack > cronJobs > ^.*$ > livenessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Liveness probe configuration
 
@@ -6961,11 +6961,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_livenessProbe_httpGet"></a>5.1.17.2. Property `stack > cronJobs > ^.*$ > livenessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -7069,11 +7069,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_nodeSelector"></a>5.1.19. Property `stack > cronJobs > ^.*$ > nodeSelector`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                   | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | -------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -7090,11 +7090,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_oidcProxy"></a>5.1.20. Property `stack > cronJobs > ^.*$ > oidcProxy`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                               | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ---------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -7202,11 +7202,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_image"></a>5.1.20.7. Property `stack > cronJobs > ^.*$ > oidcProxy > image`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -7242,11 +7242,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_resources"></a>5.1.20.9. Property `stack > cronJobs > ^.*$ > oidcProxy > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -7255,11 +7255,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_limits"></a>5.1.20.9.1. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                          | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -7306,11 +7306,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_requests"></a>5.1.20.9.2. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                            | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -7378,11 +7378,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_skipAuth_items"></a>5.1.20.10.1. stack > cronJobs > ^.*$ > oidcProxy > skipAuth > skipAuth items
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -7422,11 +7422,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_persistence"></a>5.1.21. Property `stack > cronJobs > ^.*$ > persistence`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -7464,11 +7464,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_persistence_pvc"></a>5.1.21.4. Property `stack > cronJobs > ^.*$ > persistence > pvc`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                                   | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | -------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
@@ -7507,11 +7507,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_dataSource"></a>5.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description                                               |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------------------------------------------------- |
@@ -7548,11 +7548,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>5.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property                                                             | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | -------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
@@ -7560,11 +7560,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>5.1.21.4.3.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** PVC resource requests
 
@@ -7592,11 +7592,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_podAnnotations"></a>5.1.22. Property `stack > cronJobs > ^.*$ > podAnnotations`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Annotations to add to pods
 
@@ -7654,11 +7654,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_readinessProbe"></a>5.1.26. Property `stack > cronJobs > ^.*$ > readinessProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Readiness probe configuration
 
@@ -7682,11 +7682,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_readinessProbe_httpGet"></a>5.1.26.2. Property `stack > cronJobs > ^.*$ > readinessProbe > httpGet`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -7790,11 +7790,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_resources"></a>5.1.28. Property `stack > cronJobs > ^.*$ > resources`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -7805,11 +7805,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_limits"></a>5.1.28.1. Property `stack > cronJobs > ^.*$ > resources > limits`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource limits
 
@@ -7858,11 +7858,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_requests"></a>5.1.28.2. Property `stack > cronJobs > ^.*$ > resources > requests`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Resource requests
 
@@ -7935,11 +7935,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_service"></a>5.1.31. Property `stack > cronJobs > ^.*$ > service`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service configuration
 
@@ -7968,11 +7968,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_serviceAccount"></a>5.1.32. Property `stack > cronJobs > ^.*$ > serviceAccount`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Service account configuration
 
@@ -8048,11 +8048,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_startupProbe"></a>5.1.35. Property `stack > cronJobs > ^.*$ > startupProbe`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Startup probe configuration
 
@@ -8077,11 +8077,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_startupProbe_exec"></a>5.1.35.2. Property `stack > cronJobs > ^.*$ > startupProbe > exec`
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 **Description:** Exec probe configuration
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -1366,13 +1366,13 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                  | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| ------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiVersion](#cronJobs_pattern1_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source        |
+| Property                                                              | Pattern | Type             | Deprecated | Definition | Title/Description              |
+| --------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
+| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiVersion"></a>2.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiVersion`
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiGroup"></a>2.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiGroup`
 
 |              |          |
 | ------------ | -------- |
@@ -3407,13 +3407,13 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                       | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| -------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiVersion](#global_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#global_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#global_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source        |
+| Property                                                   | Pattern | Type             | Deprecated | Definition | Title/Description              |
+| ---------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
+| - [apiGroup](#global_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
+| - [kind](#global_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
+| - [name](#global_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
 
-###### <a name="global_persistence_pvc_dataSource_apiVersion"></a>3.21.4.2.1. Property `stack > global > persistence > pvc > dataSource > apiVersion`
+###### <a name="global_persistence_pvc_dataSource_apiGroup"></a>3.21.4.2.1. Property `stack > global > persistence > pvc > dataSource > apiGroup`
 
 |              |          |
 | ------------ | -------- |
@@ -5466,13 +5466,13 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                  | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| ------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiVersion](#cronJobs_pattern1_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source        |
+| Property                                                              | Pattern | Type             | Deprecated | Definition | Title/Description              |
+| --------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
+| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiVersion"></a>4.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiVersion`
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiGroup"></a>4.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiGroup`
 
 |              |          |
 | ------------ | -------- |
@@ -7525,13 +7525,13 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                  | Pattern | Type             | Deprecated | Definition | Title/Description              |
-| ------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
-| - [apiVersion](#cronJobs_pattern1_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | API version of the data source |
-| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source        |
-| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source        |
+| Property                                                              | Pattern | Type             | Deprecated | Definition | Title/Description              |
+| --------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------ |
+| - [apiGroup](#cronJobs_pattern1_persistence_pvc_dataSource_apiGroup ) | No      | string           | No         | -          | API version of the data source |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )         | No      | enum (of string) | No         | -          | Kind of the data source        |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )         | No      | string           | No         | -          | Name of the data source        |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiVersion"></a>5.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiVersion`
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiGroup"></a>5.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiGroup`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/README.md
+++ b/stack/README.md
@@ -28,11 +28,11 @@
 
 ## <a name="cronJobs"></a>2. Property `stack > cronJobs`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Cron jobs to deploy
 
@@ -49,7 +49,7 @@ must respect the following conditions
 | ------------------------- | ------------------- |
 | **Type**                  | `object`            |
 | **Required**              | No                  |
-| **Additional properties** | Any type allowed    |
+| **Additional properties** | Not allowed         |
 | **Defined in**            | #/properties/global |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
@@ -118,11 +118,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appContext"></a>2.1.3. Property `stack > cronJobs > ^.*$ > appContext`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -145,11 +145,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appSecrets"></a>2.1.4. Property `stack > cronJobs > ^.*$ > appSecrets`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -159,11 +159,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_clusterSecret"></a>2.1.4.1. Property `stack > cronJobs > ^.*$ > appSecrets > clusterSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -186,11 +186,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_envSecret"></a>2.1.4.2. Property `stack > cronJobs > ^.*$ > appSecrets > envSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -213,11 +213,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_stackSecret"></a>2.1.4.3. Property `stack > cronJobs > ^.*$ > appSecrets > stackSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -268,11 +268,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_autoscaling"></a>2.1.6. Property `stack > cronJobs > ^.*$ > autoscaling`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Autoscaling configuration
 
@@ -401,11 +401,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_env_items"></a>2.1.10.1. stack > cronJobs > ^.*$ > env > env items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -449,11 +449,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_envFrom_items"></a>2.1.11.1. stack > cronJobs > ^.*$ > envFrom > envFrom items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                         | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -495,11 +495,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_image"></a>2.1.13. Property `stack > cronJobs > ^.*$ > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -567,11 +567,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_ingress"></a>2.1.15. Property `stack > cronJobs > ^.*$ > ingress`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Ingress configuration
 
@@ -588,11 +588,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_ingress_annotations"></a>2.1.15.1. Property `stack > cronJobs > ^.*$ > ingress > annotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -704,11 +704,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_ingress_paths_items"></a>2.1.15.6.1. stack > cronJobs > ^.*$ > ingress > paths > paths items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -786,11 +786,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_livenessProbe"></a>2.1.17. Property `stack > cronJobs > ^.*$ > livenessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Liveness probe configuration
 
@@ -814,11 +814,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_livenessProbe_httpGet"></a>2.1.17.2. Property `stack > cronJobs > ^.*$ > livenessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -922,11 +922,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_nodeSelector"></a>2.1.19. Property `stack > cronJobs > ^.*$ > nodeSelector`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                   | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | -------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -943,11 +943,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_oidcProxy"></a>2.1.20. Property `stack > cronJobs > ^.*$ > oidcProxy`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                               | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ---------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -1055,11 +1055,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_image"></a>2.1.20.7. Property `stack > cronJobs > ^.*$ > oidcProxy > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -1095,11 +1095,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_resources"></a>2.1.20.9. Property `stack > cronJobs > ^.*$ > oidcProxy > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -1108,11 +1108,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_limits"></a>2.1.20.9.1. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                          | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -1159,11 +1159,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_requests"></a>2.1.20.9.2. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                            | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -1231,11 +1231,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_skipAuth_items"></a>2.1.20.10.1. stack > cronJobs > ^.*$ > oidcProxy > skipAuth > skipAuth items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -1275,11 +1275,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_persistence"></a>2.1.21. Property `stack > cronJobs > ^.*$ > persistence`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -1317,15 +1317,16 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_persistence_pvc"></a>2.1.21.4. Property `stack > cronJobs > ^.*$ > persistence > pvc`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                   | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | -------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
 | - [accessModes](#cronJobs_pattern1_persistence_pvc_accessModes )           | No      | array of string | No         | -          | Access modes       |
+| - [dataSource](#cronJobs_pattern1_persistence_pvc_dataSource )             | No      | object          | No         | -          | -                  |
 | - [resources](#cronJobs_pattern1_persistence_pvc_resources )               | No      | object          | No         | -          | -                  |
 | - [storageClassName](#cronJobs_pattern1_persistence_pvc_storageClassName ) | No      | string          | No         | -          | Storage class name |
 
@@ -1357,25 +1358,68 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>2.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource"></a>2.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
+
+| Property                                                                  | Pattern | Type             | Deprecated | Definition | Title/Description       |
+| ------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------------- |
+| - [apiVersion](#cronJobs_pattern1_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | -                       |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source |
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiVersion"></a>2.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiVersion`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_kind"></a>2.1.21.4.2.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > kind`
+
+|              |                    |
+| ------------ | ------------------ |
+| **Type**     | `enum (of string)` |
+| **Required** | No                 |
+
+**Description:** Kind of the data source
+
+Must be one of:
+* "VolumeSnapshot"
+* "PersistentVolumeClaim"
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_name"></a>2.1.21.4.2.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of the data source
+
+###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>2.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
+
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                             | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | -------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
 | - [requests](#cronJobs_pattern1_persistence_pvc_resources_requests ) | No      | object | No         | -          | PVC resource requests |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>2.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
+###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>2.1.21.4.3.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** PVC resource requests
 
@@ -1383,7 +1427,7 @@ Must be one of:
 | --------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------ |
 | - [storage](#cronJobs_pattern1_persistence_pvc_resources_requests_storage ) | No      | string | No         | -          | Storage resource request |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests_storage"></a>2.1.21.4.2.1.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests > storage`
+###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests_storage"></a>2.1.21.4.3.1.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests > storage`
 
 |              |          |
 | ------------ | -------- |
@@ -1392,7 +1436,7 @@ Must be one of:
 
 **Description:** Storage resource request
 
-###### <a name="cronJobs_pattern1_persistence_pvc_storageClassName"></a>2.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > storageClassName`
+###### <a name="cronJobs_pattern1_persistence_pvc_storageClassName"></a>2.1.21.4.4. Property `stack > cronJobs > ^.*$ > persistence > pvc > storageClassName`
 
 |              |          |
 | ------------ | -------- |
@@ -1403,11 +1447,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_podAnnotations"></a>2.1.22. Property `stack > cronJobs > ^.*$ > podAnnotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Annotations to add to pods
 
@@ -1465,11 +1509,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_readinessProbe"></a>2.1.26. Property `stack > cronJobs > ^.*$ > readinessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Readiness probe configuration
 
@@ -1493,11 +1537,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_readinessProbe_httpGet"></a>2.1.26.2. Property `stack > cronJobs > ^.*$ > readinessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -1601,11 +1645,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_resources"></a>2.1.28. Property `stack > cronJobs > ^.*$ > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -1616,11 +1660,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_limits"></a>2.1.28.1. Property `stack > cronJobs > ^.*$ > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource limits
 
@@ -1669,11 +1713,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_requests"></a>2.1.28.2. Property `stack > cronJobs > ^.*$ > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests
 
@@ -1746,11 +1790,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_service"></a>2.1.31. Property `stack > cronJobs > ^.*$ > service`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service configuration
 
@@ -1779,11 +1823,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_serviceAccount"></a>2.1.32. Property `stack > cronJobs > ^.*$ > serviceAccount`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service account configuration
 
@@ -1859,11 +1903,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_startupProbe"></a>2.1.35. Property `stack > cronJobs > ^.*$ > startupProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Startup probe configuration
 
@@ -1888,11 +1932,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_startupProbe_exec"></a>2.1.35.2. Property `stack > cronJobs > ^.*$ > startupProbe > exec`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Exec probe configuration
 
@@ -2041,11 +2085,11 @@ Must be one of:
 
 ## <a name="global"></a>3. Property `stack > global`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
 
@@ -2113,11 +2157,11 @@ Must be one of:
 
 ### <a name="global_appContext"></a>3.3. Property `stack > global > appContext`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                     | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2140,11 +2184,11 @@ Must be one of:
 
 ### <a name="global_appSecrets"></a>3.4. Property `stack > global > appSecrets`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2154,11 +2198,11 @@ Must be one of:
 
 #### <a name="global_appSecrets_clusterSecret"></a>3.4.1. Property `stack > global > appSecrets > clusterSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                     | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2181,11 +2225,11 @@ Must be one of:
 
 #### <a name="global_appSecrets_envSecret"></a>3.4.2. Property `stack > global > appSecrets > envSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                 | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2208,11 +2252,11 @@ Must be one of:
 
 #### <a name="global_appSecrets_stackSecret"></a>3.4.3. Property `stack > global > appSecrets > stackSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                   | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2263,11 +2307,11 @@ Must be one of:
 
 ### <a name="global_autoscaling"></a>3.6. Property `stack > global > autoscaling`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Autoscaling configuration
 
@@ -2396,11 +2440,11 @@ Must be one of:
 
 #### <a name="global_env_items"></a>3.10.1. stack > global > env > env items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2444,11 +2488,11 @@ Must be one of:
 
 #### <a name="global_envFrom_items"></a>3.11.1. stack > global > envFrom > envFrom items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2490,11 +2534,11 @@ Must be one of:
 
 ### <a name="global_image"></a>3.13. Property `stack > global > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                  | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ----------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -2562,11 +2606,11 @@ Must be one of:
 
 ### <a name="global_ingress"></a>3.15. Property `stack > global > ingress`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Ingress configuration
 
@@ -2583,11 +2627,11 @@ Must be one of:
 
 #### <a name="global_ingress_annotations"></a>3.15.1. Property `stack > global > ingress > annotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                                                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2699,11 +2743,11 @@ Must be one of:
 
 ##### <a name="global_ingress_paths_items"></a>3.15.6.1. stack > global > ingress > paths > paths items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -2781,11 +2825,11 @@ Must be one of:
 
 ### <a name="global_livenessProbe"></a>3.17. Property `stack > global > livenessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Liveness probe configuration
 
@@ -2809,11 +2853,11 @@ Must be one of:
 
 #### <a name="global_livenessProbe_httpGet"></a>3.17.2. Property `stack > global > livenessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -2917,11 +2961,11 @@ Must be one of:
 
 ### <a name="global_nodeSelector"></a>3.19. Property `stack > global > nodeSelector`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -2938,11 +2982,11 @@ Must be one of:
 
 ### <a name="global_oidcProxy"></a>3.20. Property `stack > global > oidcProxy`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                    | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ----------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -3050,11 +3094,11 @@ Must be one of:
 
 #### <a name="global_oidcProxy_image"></a>3.20.7. Property `stack > global > oidcProxy > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -3090,11 +3134,11 @@ Must be one of:
 
 #### <a name="global_oidcProxy_resources"></a>3.20.9. Property `stack > global > oidcProxy > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -3103,11 +3147,11 @@ Must be one of:
 
 ##### <a name="global_oidcProxy_resources_limits"></a>3.20.9.1. Property `stack > global > oidcProxy > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                               | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------ | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -3154,11 +3198,11 @@ Must be one of:
 
 ##### <a name="global_oidcProxy_resources_requests"></a>3.20.9.2. Property `stack > global > oidcProxy > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                 | Pattern | Type        | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -3226,11 +3270,11 @@ Must be one of:
 
 ##### <a name="global_oidcProxy_skipAuth_items"></a>3.20.10.1. stack > global > oidcProxy > skipAuth > skipAuth items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -3270,11 +3314,11 @@ Must be one of:
 
 ### <a name="global_persistence"></a>3.21. Property `stack > global > persistence`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                              | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ----------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -3312,15 +3356,16 @@ Must be one of:
 
 #### <a name="global_persistence_pvc"></a>3.21.4. Property `stack > global > persistence > pvc`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | --------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
 | - [accessModes](#global_persistence_pvc_accessModes )           | No      | array of string | No         | -          | Access modes       |
+| - [dataSource](#global_persistence_pvc_dataSource )             | No      | object          | No         | -          | -                  |
 | - [resources](#global_persistence_pvc_resources )               | No      | object          | No         | -          | -                  |
 | - [storageClassName](#global_persistence_pvc_storageClassName ) | No      | string          | No         | -          | Storage class name |
 
@@ -3352,25 +3397,68 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="global_persistence_pvc_resources"></a>3.21.4.2. Property `stack > global > persistence > pvc > resources`
+##### <a name="global_persistence_pvc_dataSource"></a>3.21.4.2. Property `stack > global > persistence > pvc > dataSource`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
+
+| Property                                                       | Pattern | Type             | Deprecated | Definition | Title/Description       |
+| -------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------------- |
+| - [apiVersion](#global_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | -                       |
+| - [kind](#global_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source |
+| - [name](#global_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source |
+
+###### <a name="global_persistence_pvc_dataSource_apiVersion"></a>3.21.4.2.1. Property `stack > global > persistence > pvc > dataSource > apiVersion`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="global_persistence_pvc_dataSource_kind"></a>3.21.4.2.2. Property `stack > global > persistence > pvc > dataSource > kind`
+
+|              |                    |
+| ------------ | ------------------ |
+| **Type**     | `enum (of string)` |
+| **Required** | No                 |
+
+**Description:** Kind of the data source
+
+Must be one of:
+* "VolumeSnapshot"
+* "PersistentVolumeClaim"
+
+###### <a name="global_persistence_pvc_dataSource_name"></a>3.21.4.2.3. Property `stack > global > persistence > pvc > dataSource > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of the data source
+
+##### <a name="global_persistence_pvc_resources"></a>3.21.4.3. Property `stack > global > persistence > pvc > resources`
+
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                  | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | --------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
 | - [requests](#global_persistence_pvc_resources_requests ) | No      | object | No         | -          | PVC resource requests |
 
-###### <a name="global_persistence_pvc_resources_requests"></a>3.21.4.2.1. Property `stack > global > persistence > pvc > resources > requests`
+###### <a name="global_persistence_pvc_resources_requests"></a>3.21.4.3.1. Property `stack > global > persistence > pvc > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** PVC resource requests
 
@@ -3378,7 +3466,7 @@ Must be one of:
 | ---------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------ |
 | - [storage](#global_persistence_pvc_resources_requests_storage ) | No      | string | No         | -          | Storage resource request |
 
-###### <a name="global_persistence_pvc_resources_requests_storage"></a>3.21.4.2.1.1. Property `stack > global > persistence > pvc > resources > requests > storage`
+###### <a name="global_persistence_pvc_resources_requests_storage"></a>3.21.4.3.1.1. Property `stack > global > persistence > pvc > resources > requests > storage`
 
 |              |          |
 | ------------ | -------- |
@@ -3387,7 +3475,7 @@ Must be one of:
 
 **Description:** Storage resource request
 
-##### <a name="global_persistence_pvc_storageClassName"></a>3.21.4.3. Property `stack > global > persistence > pvc > storageClassName`
+##### <a name="global_persistence_pvc_storageClassName"></a>3.21.4.4. Property `stack > global > persistence > pvc > storageClassName`
 
 |              |          |
 | ------------ | -------- |
@@ -3398,11 +3486,11 @@ Must be one of:
 
 ### <a name="global_podAnnotations"></a>3.22. Property `stack > global > podAnnotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Annotations to add to pods
 
@@ -3460,11 +3548,11 @@ Must be one of:
 
 ### <a name="global_readinessProbe"></a>3.26. Property `stack > global > readinessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Readiness probe configuration
 
@@ -3488,11 +3576,11 @@ Must be one of:
 
 #### <a name="global_readinessProbe_httpGet"></a>3.26.2. Property `stack > global > readinessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -3596,11 +3684,11 @@ Must be one of:
 
 ### <a name="global_resources"></a>3.28. Property `stack > global > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -3611,11 +3699,11 @@ Must be one of:
 
 #### <a name="global_resources_limits"></a>3.28.1. Property `stack > global > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource limits
 
@@ -3664,11 +3752,11 @@ Must be one of:
 
 #### <a name="global_resources_requests"></a>3.28.2. Property `stack > global > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests
 
@@ -3741,11 +3829,11 @@ Must be one of:
 
 ### <a name="global_service"></a>3.31. Property `stack > global > service`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service configuration
 
@@ -3774,11 +3862,11 @@ Must be one of:
 
 ### <a name="global_serviceAccount"></a>3.32. Property `stack > global > serviceAccount`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service account configuration
 
@@ -3854,11 +3942,11 @@ Must be one of:
 
 ### <a name="global_startupProbe"></a>3.35. Property `stack > global > startupProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Startup probe configuration
 
@@ -3883,11 +3971,11 @@ Must be one of:
 
 #### <a name="global_startupProbe_exec"></a>3.35.2. Property `stack > global > startupProbe > exec`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Exec probe configuration
 
@@ -4036,11 +4124,11 @@ Must be one of:
 
 ## <a name="jobs"></a>4. Property `stack > jobs`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Jobs to deploy
 
@@ -4057,7 +4145,7 @@ must respect the following conditions
 | ------------------------- | ------------------- |
 | **Type**                  | `object`            |
 | **Required**              | No                  |
-| **Additional properties** | Any type allowed    |
+| **Additional properties** | Not allowed         |
 | **Defined in**            | #/properties/global |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
@@ -4126,11 +4214,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appContext"></a>4.1.3. Property `stack > cronJobs > ^.*$ > appContext`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4153,11 +4241,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appSecrets"></a>4.1.4. Property `stack > cronJobs > ^.*$ > appSecrets`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4167,11 +4255,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_clusterSecret"></a>4.1.4.1. Property `stack > cronJobs > ^.*$ > appSecrets > clusterSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4194,11 +4282,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_envSecret"></a>4.1.4.2. Property `stack > cronJobs > ^.*$ > appSecrets > envSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4221,11 +4309,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_stackSecret"></a>4.1.4.3. Property `stack > cronJobs > ^.*$ > appSecrets > stackSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4276,11 +4364,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_autoscaling"></a>4.1.6. Property `stack > cronJobs > ^.*$ > autoscaling`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Autoscaling configuration
 
@@ -4409,11 +4497,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_env_items"></a>4.1.10.1. stack > cronJobs > ^.*$ > env > env items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4457,11 +4545,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_envFrom_items"></a>4.1.11.1. stack > cronJobs > ^.*$ > envFrom > envFrom items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                         | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4503,11 +4591,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_image"></a>4.1.13. Property `stack > cronJobs > ^.*$ > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -4575,11 +4663,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_ingress"></a>4.1.15. Property `stack > cronJobs > ^.*$ > ingress`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Ingress configuration
 
@@ -4596,11 +4684,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_ingress_annotations"></a>4.1.15.1. Property `stack > cronJobs > ^.*$ > ingress > annotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4712,11 +4800,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_ingress_paths_items"></a>4.1.15.6.1. stack > cronJobs > ^.*$ > ingress > paths > paths items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -4794,11 +4882,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_livenessProbe"></a>4.1.17. Property `stack > cronJobs > ^.*$ > livenessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Liveness probe configuration
 
@@ -4822,11 +4910,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_livenessProbe_httpGet"></a>4.1.17.2. Property `stack > cronJobs > ^.*$ > livenessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -4930,11 +5018,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_nodeSelector"></a>4.1.19. Property `stack > cronJobs > ^.*$ > nodeSelector`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                   | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | -------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -4951,11 +5039,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_oidcProxy"></a>4.1.20. Property `stack > cronJobs > ^.*$ > oidcProxy`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                               | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ---------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -5063,11 +5151,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_image"></a>4.1.20.7. Property `stack > cronJobs > ^.*$ > oidcProxy > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -5103,11 +5191,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_resources"></a>4.1.20.9. Property `stack > cronJobs > ^.*$ > oidcProxy > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -5116,11 +5204,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_limits"></a>4.1.20.9.1. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                          | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -5167,11 +5255,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_requests"></a>4.1.20.9.2. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                            | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -5239,11 +5327,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_skipAuth_items"></a>4.1.20.10.1. stack > cronJobs > ^.*$ > oidcProxy > skipAuth > skipAuth items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -5283,11 +5371,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_persistence"></a>4.1.21. Property `stack > cronJobs > ^.*$ > persistence`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -5325,15 +5413,16 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_persistence_pvc"></a>4.1.21.4. Property `stack > cronJobs > ^.*$ > persistence > pvc`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                   | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | -------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
 | - [accessModes](#cronJobs_pattern1_persistence_pvc_accessModes )           | No      | array of string | No         | -          | Access modes       |
+| - [dataSource](#cronJobs_pattern1_persistence_pvc_dataSource )             | No      | object          | No         | -          | -                  |
 | - [resources](#cronJobs_pattern1_persistence_pvc_resources )               | No      | object          | No         | -          | -                  |
 | - [storageClassName](#cronJobs_pattern1_persistence_pvc_storageClassName ) | No      | string          | No         | -          | Storage class name |
 
@@ -5365,25 +5454,68 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>4.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource"></a>4.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
+
+| Property                                                                  | Pattern | Type             | Deprecated | Definition | Title/Description       |
+| ------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------------- |
+| - [apiVersion](#cronJobs_pattern1_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | -                       |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source |
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiVersion"></a>4.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiVersion`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_kind"></a>4.1.21.4.2.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > kind`
+
+|              |                    |
+| ------------ | ------------------ |
+| **Type**     | `enum (of string)` |
+| **Required** | No                 |
+
+**Description:** Kind of the data source
+
+Must be one of:
+* "VolumeSnapshot"
+* "PersistentVolumeClaim"
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_name"></a>4.1.21.4.2.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of the data source
+
+###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>4.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
+
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                             | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | -------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
 | - [requests](#cronJobs_pattern1_persistence_pvc_resources_requests ) | No      | object | No         | -          | PVC resource requests |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>4.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
+###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>4.1.21.4.3.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** PVC resource requests
 
@@ -5391,7 +5523,7 @@ Must be one of:
 | --------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------ |
 | - [storage](#cronJobs_pattern1_persistence_pvc_resources_requests_storage ) | No      | string | No         | -          | Storage resource request |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests_storage"></a>4.1.21.4.2.1.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests > storage`
+###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests_storage"></a>4.1.21.4.3.1.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests > storage`
 
 |              |          |
 | ------------ | -------- |
@@ -5400,7 +5532,7 @@ Must be one of:
 
 **Description:** Storage resource request
 
-###### <a name="cronJobs_pattern1_persistence_pvc_storageClassName"></a>4.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > storageClassName`
+###### <a name="cronJobs_pattern1_persistence_pvc_storageClassName"></a>4.1.21.4.4. Property `stack > cronJobs > ^.*$ > persistence > pvc > storageClassName`
 
 |              |          |
 | ------------ | -------- |
@@ -5411,11 +5543,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_podAnnotations"></a>4.1.22. Property `stack > cronJobs > ^.*$ > podAnnotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Annotations to add to pods
 
@@ -5473,11 +5605,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_readinessProbe"></a>4.1.26. Property `stack > cronJobs > ^.*$ > readinessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Readiness probe configuration
 
@@ -5501,11 +5633,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_readinessProbe_httpGet"></a>4.1.26.2. Property `stack > cronJobs > ^.*$ > readinessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -5609,11 +5741,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_resources"></a>4.1.28. Property `stack > cronJobs > ^.*$ > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -5624,11 +5756,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_limits"></a>4.1.28.1. Property `stack > cronJobs > ^.*$ > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource limits
 
@@ -5677,11 +5809,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_requests"></a>4.1.28.2. Property `stack > cronJobs > ^.*$ > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests
 
@@ -5754,11 +5886,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_service"></a>4.1.31. Property `stack > cronJobs > ^.*$ > service`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service configuration
 
@@ -5787,11 +5919,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_serviceAccount"></a>4.1.32. Property `stack > cronJobs > ^.*$ > serviceAccount`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service account configuration
 
@@ -5867,11 +5999,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_startupProbe"></a>4.1.35. Property `stack > cronJobs > ^.*$ > startupProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Startup probe configuration
 
@@ -5896,11 +6028,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_startupProbe_exec"></a>4.1.35.2. Property `stack > cronJobs > ^.*$ > startupProbe > exec`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Exec probe configuration
 
@@ -6049,11 +6181,11 @@ Must be one of:
 
 ## <a name="services"></a>5. Property `stack > services`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Services to deploy
 
@@ -6070,7 +6202,7 @@ must respect the following conditions
 | ------------------------- | ------------------- |
 | **Type**                  | `object`            |
 | **Required**              | No                  |
-| **Additional properties** | Any type allowed    |
+| **Additional properties** | Not allowed         |
 | **Defined in**            | #/properties/global |
 
 **Description:** Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs
@@ -6139,11 +6271,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appContext"></a>5.1.3. Property `stack > cronJobs > ^.*$ > appContext`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6166,11 +6298,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_appSecrets"></a>5.1.4. Property `stack > cronJobs > ^.*$ > appSecrets`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6180,11 +6312,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_clusterSecret"></a>5.1.4.1. Property `stack > cronJobs > ^.*$ > appSecrets > clusterSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6207,11 +6339,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_envSecret"></a>5.1.4.2. Property `stack > cronJobs > ^.*$ > appSecrets > envSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6234,11 +6366,11 @@ must respect the following conditions
 
 ##### <a name="cronJobs_pattern1_appSecrets_stackSecret"></a>5.1.4.3. Property `stack > cronJobs > ^.*$ > appSecrets > stackSecret`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6289,11 +6421,11 @@ must respect the following conditions
 
 #### <a name="cronJobs_pattern1_autoscaling"></a>5.1.6. Property `stack > cronJobs > ^.*$ > autoscaling`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Autoscaling configuration
 
@@ -6422,11 +6554,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_env_items"></a>5.1.10.1. stack > cronJobs > ^.*$ > env > env items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6470,11 +6602,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_envFrom_items"></a>5.1.11.1. stack > cronJobs > ^.*$ > envFrom > envFrom items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                         | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6516,11 +6648,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_image"></a>5.1.13. Property `stack > cronJobs > ^.*$ > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description |
 | ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------- |
@@ -6588,11 +6720,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_ingress"></a>5.1.15. Property `stack > cronJobs > ^.*$ > ingress`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Ingress configuration
 
@@ -6609,11 +6741,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_ingress_annotations"></a>5.1.15.1. Property `stack > cronJobs > ^.*$ > ingress > annotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6725,11 +6857,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_ingress_paths_items"></a>5.1.15.6.1. stack > cronJobs > ^.*$ > ingress > paths > paths items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -6807,11 +6939,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_livenessProbe"></a>5.1.17. Property `stack > cronJobs > ^.*$ > livenessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Liveness probe configuration
 
@@ -6835,11 +6967,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_livenessProbe_httpGet"></a>5.1.17.2. Property `stack > cronJobs > ^.*$ > livenessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -6943,11 +7075,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_nodeSelector"></a>5.1.19. Property `stack > cronJobs > ^.*$ > nodeSelector`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                   | Pattern | Type   | Deprecated | Definition | Title/Description              |
 | -------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------ |
@@ -6964,11 +7096,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_oidcProxy"></a>5.1.20. Property `stack > cronJobs > ^.*$ > oidcProxy`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                               | Pattern | Type            | Deprecated | Definition | Title/Description                            |
 | ---------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------- |
@@ -7076,11 +7208,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_image"></a>5.1.20.7. Property `stack > cronJobs > ^.*$ > oidcProxy > image`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -7116,11 +7248,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_oidcProxy_resources"></a>5.1.20.9. Property `stack > cronJobs > ^.*$ > oidcProxy > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -7129,11 +7261,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_limits"></a>5.1.20.9.1. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                          | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -7180,11 +7312,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_resources_requests"></a>5.1.20.9.2. Property `stack > cronJobs > ^.*$ > oidcProxy > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                            | Pattern | Type        | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
@@ -7252,11 +7384,11 @@ Must be one of:
 
 ###### <a name="cronJobs_pattern1_oidcProxy_skipAuth_items"></a>5.1.20.10.1. stack > cronJobs > ^.*$ > oidcProxy > skipAuth > skipAuth items
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | --------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -7296,11 +7428,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_persistence"></a>5.1.21. Property `stack > cronJobs > ^.*$ > persistence`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description      |
 | ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------- |
@@ -7338,15 +7470,16 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_persistence_pvc"></a>5.1.21.4. Property `stack > cronJobs > ^.*$ > persistence > pvc`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                                   | Pattern | Type            | Deprecated | Definition | Title/Description  |
 | -------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------ |
 | - [accessModes](#cronJobs_pattern1_persistence_pvc_accessModes )           | No      | array of string | No         | -          | Access modes       |
+| - [dataSource](#cronJobs_pattern1_persistence_pvc_dataSource )             | No      | object          | No         | -          | -                  |
 | - [resources](#cronJobs_pattern1_persistence_pvc_resources )               | No      | object          | No         | -          | -                  |
 | - [storageClassName](#cronJobs_pattern1_persistence_pvc_storageClassName ) | No      | string          | No         | -          | Storage class name |
 
@@ -7378,25 +7511,68 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>5.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource"></a>5.1.21.4.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
+
+| Property                                                                  | Pattern | Type             | Deprecated | Definition | Title/Description       |
+| ------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ----------------------- |
+| - [apiVersion](#cronJobs_pattern1_persistence_pvc_dataSource_apiVersion ) | No      | string           | No         | -          | -                       |
+| - [kind](#cronJobs_pattern1_persistence_pvc_dataSource_kind )             | No      | enum (of string) | No         | -          | Kind of the data source |
+| - [name](#cronJobs_pattern1_persistence_pvc_dataSource_name )             | No      | string           | No         | -          | Name of the data source |
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_apiVersion"></a>5.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > apiVersion`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_kind"></a>5.1.21.4.2.2. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > kind`
+
+|              |                    |
+| ------------ | ------------------ |
+| **Type**     | `enum (of string)` |
+| **Required** | No                 |
+
+**Description:** Kind of the data source
+
+Must be one of:
+* "VolumeSnapshot"
+* "PersistentVolumeClaim"
+
+###### <a name="cronJobs_pattern1_persistence_pvc_dataSource_name"></a>5.1.21.4.2.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > dataSource > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of the data source
+
+###### <a name="cronJobs_pattern1_persistence_pvc_resources"></a>5.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources`
+
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 | Property                                                             | Pattern | Type   | Deprecated | Definition | Title/Description     |
 | -------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
 | - [requests](#cronJobs_pattern1_persistence_pvc_resources_requests ) | No      | object | No         | -          | PVC resource requests |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>5.1.21.4.2.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
+###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests"></a>5.1.21.4.3.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** PVC resource requests
 
@@ -7404,7 +7580,7 @@ Must be one of:
 | --------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------ |
 | - [storage](#cronJobs_pattern1_persistence_pvc_resources_requests_storage ) | No      | string | No         | -          | Storage resource request |
 
-###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests_storage"></a>5.1.21.4.2.1.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests > storage`
+###### <a name="cronJobs_pattern1_persistence_pvc_resources_requests_storage"></a>5.1.21.4.3.1.1. Property `stack > cronJobs > ^.*$ > persistence > pvc > resources > requests > storage`
 
 |              |          |
 | ------------ | -------- |
@@ -7413,7 +7589,7 @@ Must be one of:
 
 **Description:** Storage resource request
 
-###### <a name="cronJobs_pattern1_persistence_pvc_storageClassName"></a>5.1.21.4.3. Property `stack > cronJobs > ^.*$ > persistence > pvc > storageClassName`
+###### <a name="cronJobs_pattern1_persistence_pvc_storageClassName"></a>5.1.21.4.4. Property `stack > cronJobs > ^.*$ > persistence > pvc > storageClassName`
 
 |              |          |
 | ------------ | -------- |
@@ -7424,11 +7600,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_podAnnotations"></a>5.1.22. Property `stack > cronJobs > ^.*$ > podAnnotations`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Annotations to add to pods
 
@@ -7486,11 +7662,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_readinessProbe"></a>5.1.26. Property `stack > cronJobs > ^.*$ > readinessProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Readiness probe configuration
 
@@ -7514,11 +7690,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_readinessProbe_httpGet"></a>5.1.26.2. Property `stack > cronJobs > ^.*$ > readinessProbe > httpGet`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** HTTP probe configuration (exec & tcpSocket are also available)
 
@@ -7622,11 +7798,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_resources"></a>5.1.28. Property `stack > cronJobs > ^.*$ > resources`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests and limits for the primary container
 
@@ -7637,11 +7813,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_limits"></a>5.1.28.1. Property `stack > cronJobs > ^.*$ > resources > limits`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource limits
 
@@ -7690,11 +7866,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_resources_requests"></a>5.1.28.2. Property `stack > cronJobs > ^.*$ > resources > requests`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Resource requests
 
@@ -7767,11 +7943,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_service"></a>5.1.31. Property `stack > cronJobs > ^.*$ > service`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service configuration
 
@@ -7800,11 +7976,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_serviceAccount"></a>5.1.32. Property `stack > cronJobs > ^.*$ > serviceAccount`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Service account configuration
 
@@ -7880,11 +8056,11 @@ Must be one of:
 
 #### <a name="cronJobs_pattern1_startupProbe"></a>5.1.35. Property `stack > cronJobs > ^.*$ > startupProbe`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Startup probe configuration
 
@@ -7909,11 +8085,11 @@ Must be one of:
 
 ##### <a name="cronJobs_pattern1_startupProbe_exec"></a>5.1.35.2. Property `stack > cronJobs > ^.*$ > startupProbe > exec`
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
 **Description:** Exec probe configuration
 

--- a/stack/tests/deployment_test.yaml
+++ b/stack/tests/deployment_test.yaml
@@ -212,7 +212,7 @@ tests:
     set:
       global:
         oidcProxy:
-          enable: true
+          enabled: true
         fullnameOverride: "overwrittenfull"
       services:
         service1:

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -509,12 +509,8 @@
                       "type": "string"
                     },
                     "kind": {
-                      "description": "Kind of the data source",
-                      "type": "string",
-                      "enum": [
-                        "VolumeSnapshot",
-                        "PersistentVolumeClaim"
-                      ]
+                      "description": "Kind of the data source [VolumeSnapshot, PersistentVolumeClaim]",
+                      "type": "string"
                     },
                     "name": {
                       "description": "Name of the data source",

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -505,7 +505,7 @@
                   "type": "object",
                   "properties": {
                     "apiGroup": {
-                      "description": "API group of the data source",
+                      "description": "API version of the data source",
                       "type": "string"
                     },
                     "kind": {

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -521,6 +521,32 @@
                 "storageClassName": {
                   "description": "Storage class name",
                   "type": "string"
+                },
+                "dataSource": {
+                  "description": "Data source for the PVC (e.g., from snapshot or existing PVC)",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the data source",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the data source",
+                      "enum": [
+                        "VolumeSnapshot",
+                        "PersistentVolumeClaim"
+                      ],
+                      "type": "string"
+                    },
+                    "apiVersion": {
+                      "description": "API version of the data source",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "kind"
+                  ],
+                  "type": "object"
                 }
               },
               "type": "object"

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -504,7 +504,7 @@
                 "dataSource": {
                   "type": "object",
                   "properties": {
-                    "apiVersion": {
+                    "apiGroup": {
                       "type": "string"
                     },
                     "kind": {

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -6,8 +6,7 @@
   "properties": {
     "argus-config": {
       "description": "Allows values for the argus-config Helm chart",
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "cronJobs": {
       "description": "Cron jobs to deploy",
@@ -15,11 +14,9 @@
       "patternProperties": {
         "^.*$": {
           "$ref": "#/properties/global",
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "global": {
       "description": "Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs",
@@ -27,13 +24,11 @@
       "properties": {
         "affinity": {
           "description": "Affinity for the pod",
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "annotations": {
           "description": "Global annotations to add to all resources",
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "appContext": {
           "type": "object",
@@ -44,8 +39,7 @@
             "stackContextConfigMapName": {
               "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "appSecrets": {
           "type": "object",
@@ -59,8 +53,7 @@
                 "secretName": {
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "envSecret": {
               "type": "object",
@@ -71,8 +64,7 @@
                 "secretName": {
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "stackSecret": {
               "type": "object",
@@ -83,11 +75,9 @@
                 "secretName": {
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             }
-          },
-          "additionalProperties": false
+          }
         },
         "args": {
           "description": "Arguments to pass to the command in the primary container",
@@ -120,8 +110,7 @@
               "description": "Target memory utilization percentage",
               "type": "integer"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "command": {
           "description": "Command to run in the primary container",
@@ -154,8 +143,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "additionalProperties": false
+            }
           }
         },
         "envFrom": {
@@ -165,18 +153,15 @@
             "type": "object",
             "properties": {
               "configMapRef": {
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "prefix": {
                 "type": "string"
               },
               "secretRef": {
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
-            },
-            "additionalProperties": false
+            }
           }
         },
         "fullnameOverride": {
@@ -203,8 +188,7 @@
               "description": "Image tag",
               "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "imagePullSecrets": {
           "type": "array",
@@ -237,8 +221,7 @@
                 "nginx.ingress.kubernetes.io/session-cookie-name": {
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "className": {
               "description": "Ingress class name",
@@ -270,8 +253,7 @@
                     "description": "Ingress path type",
                     "type": "string"
                   }
-                },
-                "additionalProperties": false
+                }
               }
             },
             "rules": {
@@ -282,8 +264,7 @@
               "description": "List of ingress TLS configurations",
               "type": "array"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "initContainers": {
           "description": "List of init containers",
@@ -320,8 +301,7 @@
                   "description": "Scheme to use",
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "initialDelaySeconds": {
               "description": "Number of seconds after the container has started before the probe is first initiated",
@@ -339,8 +319,7 @@
               "description": "Timeout for the probe",
               "type": "number"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "nameOverride": {
           "description": "Name to prefix the K8s resources with, combined with the stack name prefix",
@@ -353,8 +332,7 @@
               "description": "Node selector for architecture",
               "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "oidcProxy": {
           "type": "object",
@@ -369,8 +347,7 @@
             },
             "annotations": {
               "description": "Annotations to add to the OIDC proxy",
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "cookieRefresh": {
               "description": "Refresh tokens and cookies after this period",
@@ -398,8 +375,7 @@
                   "description": "Image tag",
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "replicaCount": {
               "description": "Number of replicas",
@@ -426,8 +402,7 @@
                       "description": "Memory limit",
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 },
                 "requests": {
                   "type": "object",
@@ -447,11 +422,9 @@
                       "description": "Memory request",
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "skipAuth": {
               "description": "Paths to skip authentication",
@@ -465,16 +438,14 @@
                   "path": {
                     "type": "string"
                   }
-                },
-                "additionalProperties": false
+                }
               }
             },
             "volumeMounts": {
               "description": "Volume mounts for the OIDC proxy",
               "type": "array"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "persistence": {
           "type": "object",
@@ -516,8 +487,7 @@
                       "description": "Name of the data source",
                       "type": "string"
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 },
                 "resources": {
                   "type": "object",
@@ -530,21 +500,17 @@
                           "description": "Storage resource request",
                           "type": "string"
                         }
-                      },
-                      "additionalProperties": false
+                      }
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 },
                 "storageClassName": {
                   "description": "Storage class name",
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             }
-          },
-          "additionalProperties": false
+          }
         },
         "podAnnotations": {
           "description": "Annotations to add to pods",
@@ -558,18 +524,15 @@
               "description": "Linkerd injection annotation",
               "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "podLabels": {
           "description": "Global labels to add to all pods",
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "podSecurityContext": {
           "description": "Pod security context",
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "progressDeadlineSeconds": {
           "description": "the number of seconds the Deployment controller waits before indicating (in the Deployment status) that the Deployment progress has stalled",
@@ -606,8 +569,7 @@
                   "description": "Scheme to use",
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "initialDelaySeconds": {
               "description": "Number of seconds after the container has started before the probe is first initiated",
@@ -625,8 +587,7 @@
               "description": "Timeout for the probe",
               "type": "number"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "replicaCount": {
           "description": "Number of replicas",
@@ -655,8 +616,7 @@
                   "description": "Memory limit",
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "requests": {
               "description": "Resource requests",
@@ -677,11 +637,9 @@
                   "description": "Memory request",
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             }
-          },
-          "additionalProperties": false
+          }
         },
         "restartPolicy": {
           "description": "Restart policy for the pod",
@@ -694,8 +652,7 @@
         },
         "securityContext": {
           "description": "Security context",
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "service": {
           "description": "Service configuration",
@@ -709,8 +666,7 @@
               "description": "Service type",
               "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "serviceAccount": {
           "description": "Service account configuration",
@@ -718,8 +674,7 @@
           "properties": {
             "annotations": {
               "description": "Annotations to add to the service account",
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "automount": {
               "description": "Specifies whether to automatically mount a ServiceAccount's API credentials",
@@ -733,8 +688,7 @@
               "description": "Name of the service account to use (if not set and create is true, a name is generated using the fullname template)",
               "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "shareProcessNamespace": {
           "description": "Share process namespace",
@@ -762,8 +716,7 @@
                     "type": "string"
                   }
                 }
-              },
-              "additionalProperties": false
+              }
             },
             "failureThreshold": {
               "description": "Number of failures before the probe is considered failed",
@@ -785,8 +738,7 @@
               "description": "Timeout for the probe",
               "type": "integer"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "tolerations": {
           "description": "Tolerations for the pod",
@@ -804,8 +756,7 @@
           "description": "Additional volumes on the output Deployment definition",
           "type": "array"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "jobs": {
       "description": "Jobs to deploy",
@@ -813,11 +764,9 @@
       "patternProperties": {
         "^.*$": {
           "$ref": "#/properties/global",
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "services": {
       "description": "Services to deploy",
@@ -826,12 +775,9 @@
         "^.*$": {
           "$ref": "#/properties/global",
           "type": "object",
-          "additionalProperties": false,
           "unevaluatedProperties": false
         }
-      },
-      "additionalProperties": false
+      }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -1,38 +1,42 @@
 {
-  "$id": "argo.helm.charts/stack",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "additionalProperties": false,
+  "$id": "argo.helm.charts/stack",
+  "title": "stack",
+  "type": "object",
   "properties": {
     "argus-config": {
       "description": "Allows values for the argus-config Helm chart",
-      "properties": {},
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     },
     "cronJobs": {
       "description": "Cron jobs to deploy",
+      "type": "object",
       "patternProperties": {
         "^.*$": {
           "$ref": "#/properties/global",
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
-      "properties": {},
-      "type": "object"
+      "additionalProperties": false
     },
     "global": {
       "description": "Global configuration for the stack - this serves as the default configuration for all services/jobs/cronjobs",
+      "type": "object",
       "properties": {
         "affinity": {
           "description": "Affinity for the pod",
-          "properties": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "annotations": {
           "description": "Global annotations to add to all resources",
-          "properties": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "appContext": {
+          "type": "object",
           "properties": {
             "envContextConfigMapName": {
               "type": "string"
@@ -41,11 +45,13 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "appSecrets": {
+          "type": "object",
           "properties": {
             "clusterSecret": {
+              "type": "object",
               "properties": {
                 "secretKey": {
                   "type": "string"
@@ -54,9 +60,10 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "envSecret": {
+              "type": "object",
               "properties": {
                 "secretKey": {
                   "type": "string"
@@ -65,9 +72,10 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "stackSecret": {
+              "type": "object",
               "properties": {
                 "secretKey": {
                   "type": "string"
@@ -76,22 +84,21 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "args": {
           "description": "Arguments to pass to the command in the primary container",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": [
-            "array"
-          ]
+          }
         },
         "autoscaling": {
           "description": "Autoscaling configuration",
+          "type": "object",
           "properties": {
             "enabled": {
               "description": "Enable autoscaling",
@@ -114,16 +121,14 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "command": {
           "description": "Command to run in the primary container",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": [
-            "array"
-          ]
+          }
         },
         "deploymentStage": {
           "description": "Deployment stage",
@@ -131,15 +136,17 @@
         },
         "dnsPolicy": {
           "description": "DNS policy for the pod",
+          "type": "string",
           "enum": [
             "ClusterFirst",
             "Default",
             "None"
-          ],
-          "type": "string"
+          ]
         },
         "env": {
+          "type": "array",
           "items": {
+            "type": "object",
             "properties": {
               "name": {
                 "type": "string"
@@ -148,46 +155,45 @@
                 "type": "string"
               }
             },
-            "type": "object"
-          },
-          "type": [
-            "array"
-          ]
+            "additionalProperties": false
+          }
         },
         "envFrom": {
           "description": "Environment variables from configmaps or secrets",
+          "type": "array",
           "items": {
+            "type": "object",
             "properties": {
               "configMapRef": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "prefix": {
                 "type": "string"
               },
               "secretRef": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               }
             },
-            "type": "object"
-          },
-          "type": [
-            "array"
-          ]
+            "additionalProperties": false
+          }
         },
         "fullnameOverride": {
           "description": "Name to prefix the K8s resources with, replaces the stack name prefix",
           "type": "string"
         },
         "image": {
+          "type": "object",
           "properties": {
             "pullPolicy": {
               "description": "Image pull policy",
+              "type": "string",
               "enum": [
                 "Always",
                 "IfNotPresent",
                 "Never"
-              ],
-              "type": "string"
+              ]
             },
             "repository": {
               "description": "Image repository",
@@ -198,20 +204,20 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "imagePullSecrets": {
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": [
-            "array"
-          ]
+          }
         },
         "ingress": {
           "description": "Ingress configuration",
+          "type": "object",
           "properties": {
             "annotations": {
+              "type": "object",
               "properties": {
                 "nginx.ingress.kubernetes.io/affinity": {
                   "type": "string"
@@ -232,7 +238,7 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "className": {
               "description": "Ingress class name",
@@ -252,7 +258,9 @@
             },
             "paths": {
               "description": "List of ingress paths",
+              "type": "array",
               "items": {
+                "type": "object",
                 "properties": {
                   "path": {
                     "description": "Ingress path",
@@ -263,9 +271,8 @@
                     "type": "string"
                   }
                 },
-                "type": "object"
-              },
-              "type": "array"
+                "additionalProperties": false
+              }
             },
             "rules": {
               "description": "List of ingress rules",
@@ -276,25 +283,23 @@
               "type": "array"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "initContainers": {
           "description": "List of init containers",
-          "type": [
-            "array"
-          ]
+          "type": "array"
         },
         "livenessProbe": {
           "description": "Liveness probe configuration",
+          "type": "object",
           "properties": {
             "failureThreshold": {
               "description": "Number of failures before the probe is considered failed",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "httpGet": {
               "description": "HTTP probe configuration (exec \u0026 tcpSocket are also available)",
+              "type": "object",
               "properties": {
                 "path": {
                   "description": "Path to probe",
@@ -316,49 +321,43 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "initialDelaySeconds": {
               "description": "Number of seconds after the container has started before the probe is first initiated",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "periodSeconds": {
               "description": "How often to perform the probe",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "successThreshold": {
               "description": "Number of successes before the probe is considered successful",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "timeoutSeconds": {
               "description": "Timeout for the probe",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "nameOverride": {
           "description": "Name to prefix the K8s resources with, combined with the stack name prefix",
           "type": "string"
         },
         "nodeSelector": {
+          "type": "object",
           "properties": {
             "kubernetes.io/arch": {
               "description": "Node selector for architecture",
               "type": "string"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "oidcProxy": {
+          "type": "object",
           "properties": {
             "additionalHeaders": {
               "description": "Additional headers to add",
@@ -370,10 +369,8 @@
             },
             "annotations": {
               "description": "Annotations to add to the OIDC proxy",
-              "properties": {},
-              "type": [
-                "object"
-              ]
+              "type": "object",
+              "additionalProperties": false
             },
             "cookieRefresh": {
               "description": "Refresh tokens and cookies after this period",
@@ -385,14 +382,13 @@
             },
             "extraArgs": {
               "description": "Extra arguments to pass to the OIDC proxy",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": [
-                "array"
-              ]
+              }
             },
             "image": {
+              "type": "object",
               "properties": {
                 "repository": {
                   "description": "Image repository",
@@ -403,15 +399,17 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "replicaCount": {
               "description": "Number of replicas",
               "type": "integer"
             },
             "resources": {
+              "type": "object",
               "properties": {
                 "limits": {
+                  "type": "object",
                   "properties": {
                     "cpu": {
                       "description": "CPU limit",
@@ -429,9 +427,10 @@
                       "type": "string"
                     }
                   },
-                  "type": "object"
+                  "additionalProperties": false
                 },
                 "requests": {
+                  "type": "object",
                   "properties": {
                     "cpu": {
                       "description": "CPU request",
@@ -449,14 +448,16 @@
                       "type": "string"
                     }
                   },
-                  "type": "object"
+                  "additionalProperties": false
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "skipAuth": {
               "description": "Paths to skip authentication",
+              "type": "array",
               "items": {
+                "type": "object",
                 "properties": {
                   "method": {
                     "type": "string"
@@ -465,20 +466,18 @@
                     "type": "string"
                   }
                 },
-                "type": "object"
-              },
-              "type": [
-                "array"
-              ]
+                "additionalProperties": false
+              }
             },
             "volumeMounts": {
               "description": "Volume mounts for the OIDC proxy",
               "type": "array"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "persistence": {
+          "type": "object",
           "properties": {
             "enabled": {
               "description": "Enable persistence",
@@ -493,69 +492,66 @@
               "type": "string"
             },
             "pvc": {
+              "type": "object",
               "properties": {
                 "accessModes": {
                   "description": "Access modes",
+                  "type": "array",
                   "items": {
                     "type": "string"
+                  }
+                },
+                "dataSource": {
+                  "type": "object",
+                  "properties": {
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the data source",
+                      "type": "string",
+                      "enum": [
+                        "VolumeSnapshot",
+                        "PersistentVolumeClaim"
+                      ]
+                    },
+                    "name": {
+                      "description": "Name of the data source",
+                      "type": "string"
+                    }
                   },
-                  "type": [
-                    "array"
-                  ]
+                  "additionalProperties": false
                 },
                 "resources": {
+                  "type": "object",
                   "properties": {
                     "requests": {
                       "description": "PVC resource requests",
+                      "type": "object",
                       "properties": {
                         "storage": {
                           "description": "Storage resource request",
                           "type": "string"
                         }
                       },
-                      "type": "object"
+                      "additionalProperties": false
                     }
                   },
-                  "type": "object"
+                  "additionalProperties": false
                 },
                 "storageClassName": {
                   "description": "Storage class name",
                   "type": "string"
-                },
-                "dataSource": {
-                  "description": "Data source for the PVC (e.g., from snapshot or existing PVC)",
-                  "properties": {
-                    "name": {
-                      "description": "Name of the data source",
-                      "type": "string"
-                    },
-                    "kind": {
-                      "description": "Kind of the data source",
-                      "enum": [
-                        "VolumeSnapshot",
-                        "PersistentVolumeClaim"
-                      ],
-                      "type": "string"
-                    },
-                    "apiVersion": {
-                      "description": "API version of the data source",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "kind"
-                  ],
-                  "type": "object"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "podAnnotations": {
           "description": "Annotations to add to pods",
+          "type": "object",
           "properties": {
             "config.linkerd.io/skip-outbound-ports": {
               "description": "Linkerd skip outbound ports annotation",
@@ -566,19 +562,17 @@
               "type": "string"
             }
           },
-          "type": [
-            "object"
-          ]
+          "additionalProperties": false
         },
         "podLabels": {
           "description": "Global labels to add to all pods",
-          "properties": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "podSecurityContext": {
           "description": "Pod security context",
-          "properties": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "progressDeadlineSeconds": {
           "description": "the number of seconds the Deployment controller waits before indicating (in the Deployment status) that the Deployment progress has stalled",
@@ -586,15 +580,15 @@
         },
         "readinessProbe": {
           "description": "Readiness probe configuration",
+          "type": "object",
           "properties": {
             "failureThreshold": {
               "description": "Number of failures before the probe is considered failed",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "httpGet": {
               "description": "HTTP probe configuration (exec \u0026 tcpSocket are also available)",
+              "type": "object",
               "properties": {
                 "path": {
                   "description": "Path to probe",
@@ -616,34 +610,26 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "initialDelaySeconds": {
               "description": "Number of seconds after the container has started before the probe is first initiated",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "periodSeconds": {
               "description": "How often to perform the probe",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "successThreshold": {
               "description": "Number of successes before the probe is considered successful",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "timeoutSeconds": {
               "description": "Timeout for the probe",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "replicaCount": {
           "description": "Number of replicas",
@@ -651,9 +637,11 @@
         },
         "resources": {
           "description": "Resource requests and limits for the primary container",
+          "type": "object",
           "properties": {
             "limits": {
               "description": "Resource limits",
+              "type": "object",
               "properties": {
                 "cpu": {
                   "description": "CPU limit",
@@ -671,10 +659,11 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "requests": {
               "description": "Resource requests",
+              "type": "object",
               "properties": {
                 "cpu": {
                   "description": "CPU request",
@@ -692,48 +681,48 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "restartPolicy": {
           "description": "Restart policy for the pod",
+          "type": "string",
           "enum": [
             "Always",
             "OnFailure",
             "Never"
-          ],
-          "type": "string"
+          ]
         },
         "securityContext": {
           "description": "Security context",
-          "properties": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "service": {
           "description": "Service configuration",
+          "type": "object",
           "properties": {
             "port": {
               "description": "Service port",
-              "type": [
-                "number"
-              ]
+              "type": "number"
             },
             "type": {
               "description": "Service type",
               "type": "string"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "serviceAccount": {
           "description": "Service account configuration",
+          "type": "object",
           "properties": {
             "annotations": {
               "description": "Annotations to add to the service account",
-              "properties": {},
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "automount": {
               "description": "Specifies whether to automatically mount a ServiceAccount's API credentials",
@@ -748,7 +737,7 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "shareProcessNamespace": {
           "description": "Share process namespace",
@@ -756,12 +745,11 @@
         },
         "sidecars": {
           "description": "List of sidecars",
-          "type": [
-            "array"
-          ]
+          "type": "array"
         },
         "startupProbe": {
           "description": "Startup probe configuration",
+          "type": "object",
           "properties": {
             "enabled": {
               "description": "Enable the startup probe",
@@ -769,15 +757,16 @@
             },
             "exec": {
               "description": "Exec probe configuration",
+              "type": "object",
               "properties": {
                 "command": {
+                  "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "type": "array"
+                  }
                 }
               },
-              "type": "object"
+              "additionalProperties": false
             },
             "failureThreshold": {
               "description": "Number of failures before the probe is considered failed",
@@ -800,7 +789,7 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "additionalProperties": false
         },
         "tolerations": {
           "description": "Tolerations for the pod",
@@ -819,32 +808,33 @@
           "type": "array"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "jobs": {
       "description": "Jobs to deploy",
-      "patternProperties": {
-        "^.*$": {
-          "$ref": "#/properties/global",
-          "type": "object"
-        }
-      },
-      "properties": {},
-      "type": "object"
-    },
-    "services": {
-      "description": "Services to deploy",
+      "type": "object",
       "patternProperties": {
         "^.*$": {
           "$ref": "#/properties/global",
           "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "services": {
+      "description": "Services to deploy",
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "$ref": "#/properties/global",
+          "type": "object",
+          "additionalProperties": false,
           "unevaluatedProperties": false
         }
       },
-      "properties": {},
-      "type": "object"
+      "additionalProperties": false
     }
   },
-  "title": "stack",
-  "type": "object"
+  "additionalProperties": false
 }

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -191,7 +191,7 @@ global: # @schema description: Global configuration for the stack - this serves 
       dataSource:
         name: "" # @schema description: Name of the data source
         kind: "" # @schema enum: [VolumeSnapshot, PersistentVolumeClaim]; description: Kind of the data source
-        apiVersion: "snapshot.storage.k8s.io/v1" # @schema description: API version of the data source
+        apiGroup: "snapshot.storage.k8s.io/v1" # @schema description: API version of the data source
     existingClaim: "" # @schema description: Existing PVC name
     mountPath: "" # @schema description: Mount path for the PVC
 

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -190,7 +190,7 @@ global: # @schema description: Global configuration for the stack - this serves 
       storageClassName: "default" # @schema description: Storage class name
       dataSource:
         name: "" # @schema description: Name of the data source
-        kind: null # @schema enum: [VolumeSnapshot, PersistentVolumeClaim]; description: Kind of the data source
+        kind: "" # @schema description: Kind of the data source [VolumeSnapshot, PersistentVolumeClaim]
         apiGroup: "snapshot.storage.k8s.io/v1" # @schema description: API version of the data source
     existingClaim: "" # @schema description: Existing PVC name
     mountPath: "" # @schema description: Mount path for the PVC

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -190,7 +190,7 @@ global: # @schema description: Global configuration for the stack - this serves 
       storageClassName: "default" # @schema description: Storage class name
       dataSource:
         name: "" # @schema description: Name of the data source
-        kind: "" # @schema enum: [VolumeSnapshot, PersistentVolumeClaim]; description: Kind of the data source
+        kind: null # @schema enum: [VolumeSnapshot, PersistentVolumeClaim]; description: Kind of the data source
         apiGroup: "snapshot.storage.k8s.io/v1" # @schema description: API version of the data source
     existingClaim: "" # @schema description: Existing PVC name
     mountPath: "" # @schema description: Mount path for the PVC

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -191,7 +191,7 @@ global: # @schema description: Global configuration for the stack - this serves 
       dataSource:
         name: "" # @schema description: Name of the data source
         kind: "" # @schema enum: [VolumeSnapshot, PersistentVolumeClaim]; description: Kind of the data source
-        apiVersion: "snapshot.storage.k8s.io/v1"
+        apiVersion: "snapshot.storage.k8s.io/v1" # @schema description: API version of the data source
     existingClaim: "" # @schema description: Existing PVC name
     mountPath: "" # @schema description: Mount path for the PVC
 

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -188,6 +188,10 @@ global: # @schema description: Global configuration for the stack - this serves 
         requests: # @schema description: PVC resource requests
           storage: 8Gi # @schema description: Storage resource request
       storageClassName: "default" # @schema description: Storage class name
+      dataSource:
+        name: "" # @schema description: Name of the data source
+        kind: "" # @schema enum: [VolumeSnapshot, PersistentVolumeClaim]; description: Kind of the data source
+        apiVersion: "snapshot.storage.k8s.io/v1"
     existingClaim: "" # @schema description: Existing PVC name
     mountPath: "" # @schema description: Mount path for the PVC
 


### PR DESCRIPTION
Biohub needs to be able to mount a volume snapshot but we still need to create the pvc for it. 
Docs:
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#create-persistent-volume-claim-from-volume-snapshot