### PR TITLE
feat: update helm chart to include a new envFrom section tf cluster-wide secrets

### DIFF
--- a/argus-config/README.md
+++ b/argus-config/README.md
@@ -2,11 +2,11 @@
 
 **Title:** argus-config
 
-|                           |             |
-| ------------------------- | ----------- |
-| **Type**                  | `object`    |
-| **Required**              | No          |
-| **Additional properties** | Not allowed |
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
 
 | Property             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | -------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
@@ -73,11 +73,12 @@
 
 **Description:** App secrets (provided by Argus API)
 
-| Property                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ---------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [clusterSecret](#global_appSecrets_clusterSecret ) | No      | object | No         | -          | -                 |
-| - [envSecret](#global_appSecrets_envSecret )         | No      | object | No         | -          | -                 |
-| - [stackSecret](#global_appSecrets_stackSecret )     | No      | object | No         | -          | -                 |
+| Property                                                 | Pattern | Type   | Deprecated | Definition | Title/Description |
+| -------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [clusterSecret](#global_appSecrets_clusterSecret )     | No      | object | No         | -          | -                 |
+| - [clusterSecretTF](#global_appSecrets_clusterSecretTF ) | No      | object | No         | -          | -                 |
+| - [envSecret](#global_appSecrets_envSecret )             | No      | object | No         | -          | -                 |
+| - [stackSecret](#global_appSecrets_stackSecret )         | No      | object | No         | -          | -                 |
 
 #### <a name="global_appSecrets_clusterSecret"></a>1.2.1. Property `argus-config > global > appSecrets > clusterSecret`
 
@@ -110,7 +111,38 @@
 
 **Description:** Cluster-level Kube secret name to write External Secrets to
 
-#### <a name="global_appSecrets_envSecret"></a>1.2.2. Property `argus-config > global > appSecrets > envSecret`
+#### <a name="global_appSecrets_clusterSecretTF"></a>1.2.2. Property `argus-config > global > appSecrets > clusterSecretTF`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                       | Pattern | Type   | Deprecated | Definition | Title/Description                                                            |
+| -------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ---------------------------------------------------------------------------- |
+| - [secretKey](#global_appSecrets_clusterSecretTF_secretKey )   | No      | string | No         | -          | Cluster-level secret key to map External Secrets from                        |
+| - [secretName](#global_appSecrets_clusterSecretTF_secretName ) | No      | string | No         | -          | Cluster-level Kube secret name set by terraform to write External Secrets to |
+
+##### <a name="global_appSecrets_clusterSecretTF_secretKey"></a>1.2.2.1. Property `argus-config > global > appSecrets > clusterSecretTF > secretKey`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Cluster-level secret key to map External Secrets from
+
+##### <a name="global_appSecrets_clusterSecretTF_secretName"></a>1.2.2.2. Property `argus-config > global > appSecrets > clusterSecretTF > secretName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Cluster-level Kube secret name set by terraform to write External Secrets to
+
+#### <a name="global_appSecrets_envSecret"></a>1.2.3. Property `argus-config > global > appSecrets > envSecret`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -123,7 +155,7 @@
 | - [secretKey](#global_appSecrets_envSecret_secretKey )   | No      | string | No         | -          | Environment-level secret key to map External Secrets from       |
 | - [secretName](#global_appSecrets_envSecret_secretName ) | No      | string | No         | -          | Environment-level Kube secret name to write External Secrets to |
 
-##### <a name="global_appSecrets_envSecret_secretKey"></a>1.2.2.1. Property `argus-config > global > appSecrets > envSecret > secretKey`
+##### <a name="global_appSecrets_envSecret_secretKey"></a>1.2.3.1. Property `argus-config > global > appSecrets > envSecret > secretKey`
 
 |              |          |
 | ------------ | -------- |
@@ -132,7 +164,7 @@
 
 **Description:** Environment-level secret key to map External Secrets from
 
-##### <a name="global_appSecrets_envSecret_secretName"></a>1.2.2.2. Property `argus-config > global > appSecrets > envSecret > secretName`
+##### <a name="global_appSecrets_envSecret_secretName"></a>1.2.3.2. Property `argus-config > global > appSecrets > envSecret > secretName`
 
 |              |          |
 | ------------ | -------- |
@@ -141,7 +173,7 @@
 
 **Description:** Environment-level Kube secret name to write External Secrets to
 
-#### <a name="global_appSecrets_stackSecret"></a>1.2.3. Property `argus-config > global > appSecrets > stackSecret`
+#### <a name="global_appSecrets_stackSecret"></a>1.2.4. Property `argus-config > global > appSecrets > stackSecret`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -154,7 +186,7 @@
 | - [secretKey](#global_appSecrets_stackSecret_secretKey )   | No      | string | No         | -          | Stack-level secret key to map External Secrets from       |
 | - [secretName](#global_appSecrets_stackSecret_secretName ) | No      | string | No         | -          | Stack-level Kube secret name to write External Secrets to |
 
-##### <a name="global_appSecrets_stackSecret_secretKey"></a>1.2.3.1. Property `argus-config > global > appSecrets > stackSecret > secretKey`
+##### <a name="global_appSecrets_stackSecret_secretKey"></a>1.2.4.1. Property `argus-config > global > appSecrets > stackSecret > secretKey`
 
 |              |          |
 | ------------ | -------- |
@@ -163,7 +195,7 @@
 
 **Description:** Stack-level secret key to map External Secrets from
 
-##### <a name="global_appSecrets_stackSecret_secretName"></a>1.2.3.2. Property `argus-config > global > appSecrets > stackSecret > secretName`
+##### <a name="global_appSecrets_stackSecret_secretName"></a>1.2.4.2. Property `argus-config > global > appSecrets > stackSecret > secretName`
 
 |              |          |
 | ------------ | -------- |

--- a/argus-config/templates/_helpers.tpl
+++ b/argus-config/templates/_helpers.tpl
@@ -10,6 +10,11 @@ envFrom:
     name: {{ .Values.appSecrets.clusterSecret.secretName }}
     optional: true
 {{- end }}
+{{- if ne (trim .Values.appSecrets.clusterSecretTF.secretName) "" }}
+- secretRef:
+    name: {{ .Values.appSecrets.clusterSecret.secretName }}
+    optional: true
+{{- end }}
 {{- if ne (trim .Values.appSecrets.envSecret.secretName) "" }}
 - secretRef:
     name: {{ .Values.appSecrets.envSecret.secretName }}

--- a/argus-config/values.schema.json
+++ b/argus-config/values.schema.json
@@ -1,13 +1,16 @@
 {
-  "$id": "argo.helm.charts/argus-config",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "additionalProperties": false,
+  "$id": "argo.helm.charts/argus-config",
+  "title": "argus-config",
+  "type": "object",
   "properties": {
     "global": {
       "description": "Global parameters",
+      "type": "object",
       "properties": {
         "appContext": {
           "description": "App context (provided by Argus API)",
+          "type": "object",
           "properties": {
             "envContextConfigMapName": {
               "description": "Environment level configuration configmap name",
@@ -17,13 +20,14 @@
               "description": "Stack level configuration configmap name",
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         },
         "appSecrets": {
           "description": "App secrets (provided by Argus API)",
+          "type": "object",
           "properties": {
             "clusterSecret": {
+              "type": "object",
               "properties": {
                 "secretKey": {
                   "description": "Cluster-level secret key to map External Secrets from",
@@ -33,10 +37,23 @@
                   "description": "Cluster-level Kube secret name to write External Secrets to",
                   "type": "string"
                 }
-              },
-              "type": "object"
+              }
+            },
+            "clusterSecretTF": {
+              "type": "object",
+              "properties": {
+                "secretKey": {
+                  "description": "Cluster-level secret key to map External Secrets from",
+                  "type": "string"
+                },
+                "secretName": {
+                  "description": "Cluster-level Kube secret name set by terraform to write External Secrets to",
+                  "type": "string"
+                }
+              }
             },
             "envSecret": {
+              "type": "object",
               "properties": {
                 "secretKey": {
                   "description": "Environment-level secret key to map External Secrets from",
@@ -46,10 +63,10 @@
                   "description": "Environment-level Kube secret name to write External Secrets to",
                   "type": "string"
                 }
-              },
-              "type": "object"
+              }
             },
             "stackSecret": {
+              "type": "object",
               "properties": {
                 "secretKey": {
                   "description": "Stack-level secret key to map External Secrets from",
@@ -59,14 +76,13 @@
                   "description": "Stack-level Kube secret name to write External Secrets to",
                   "type": "string"
                 }
-              },
-              "type": "object"
+              }
             }
-          },
-          "type": "object"
+          }
         },
         "argoBuildEnv": {
           "description": "Argo built-in environment parameters",
+          "type": "object",
           "properties": {
             "appName": {
               "description": "equivalant to ARGOCD_APP_NAME",
@@ -100,8 +116,7 @@
               "description": "equivalant to ARGOCD_APP_SOURCE_REPO_URL",
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         },
         "deploymentStage": {
           "description": "Deployment stage",
@@ -109,18 +124,15 @@
         },
         "ingress": {
           "description": "Ingress configuration",
+          "type": "object",
           "properties": {
             "host": {
               "description": "Ingress host",
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         }
-      },
-      "type": "object"
+      }
     }
-  },
-  "title": "argus-config",
-  "type": "object"
+  }
 }

--- a/argus-config/values.yaml
+++ b/argus-config/values.yaml
@@ -4,7 +4,7 @@ global: # @schema description: Global parameters
     stackContextConfigMapName: "" # @schema description: Stack level configuration configmap name
 
   appSecrets: # @schema description: App secrets (provided by Argus API)
-    envSecret: 
+    envSecret:
       secretName: "" # @schema description: Environment-level Kube secret name to write External Secrets to
       secretKey: "" # @schema description: Environment-level secret key to map External Secrets from
     stackSecret:
@@ -12,6 +12,9 @@ global: # @schema description: Global parameters
       secretKey: "" # @schema description: Stack-level secret key to map External Secrets from
     clusterSecret:
       secretName: "" # @schema description: Cluster-level Kube secret name to write External Secrets to
+      secretKey: "" # @schema description: Cluster-level secret key to map External Secrets from
+    clusterSecretTF:
+      secretName: "" # @schema description: Cluster-level Kube secret name set by terraform to write External Secrets to
       secretKey: "" # @schema description: Cluster-level secret key to map External Secrets from
 
   deploymentStage: "staging" # @schema description: Deployment stage
@@ -28,7 +31,4 @@ global: # @schema description: Global parameters
     appSourcePath: "" # @schema description: equivalant to ARGOCD_APP_SOURCE_PATH
     appSourceRepoUrl: "" # @schema description: equivalant to ARGOCD_APP_SOURCE_REPO_URL
     appSourceTargetRevision: "" # @schema description: equivalant to ARGOCD_APP_SOURCE_REPO_URL
-
-
-
 


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-5238

## Summary

Create a section that can be used to store the secret name and key for the cluster-wide secrets set by terraform as well as set by `argus set secret`. This will be filled in by argus API.

## References

* https://github.com/chanzuckerberg/argus-infra-stacks/pull/1857