### PR TITLE
feat: enable cluster-wide secrets in stack helm chart

### DIFF
--- a/stack/Chart.lock
+++ b/stack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argus-config
   repository: https://chanzuckerberg.github.io/argo-helm-charts
-  version: 1.5.0
-digest: sha256:6b84d577eaa70994c7c29c053af387cb68d3f3a6d0b2e1c083eae30455c5a7ae
-generated: "2025-09-23T14:10:48.389773-07:00"
+  version: 1.5.1
+digest: sha256:6ed5e1c5f2b19b2a2ee997c9e719003e1682f56ed0752ba5e61eef42e36d5042
+generated: "2025-09-23T14:38:14.611734-07:00"

--- a/stack/Chart.yaml
+++ b/stack/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: argus-config
-    version: 1.5.0
+    version: 1.5.1
     repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -49,7 +49,7 @@ tests:
             secretName: blah4
           clusterSecret:
             secretName: blah5
-          clusterSecretCLI:
+          clusterCLISecret:
             secretName: blah6
         oidcProxy:
           enabled: true
@@ -75,7 +75,7 @@ tests:
             secretName: blah4
           clusterSecret:
             secretName: blah5
-          clusterSecretCLI:
+          clusterCLISecret:
             secretName: blah6
         oidcProxy:
           enabled: true


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-5238

## Summary

Bump the version of argus-config in the stack helm chart.