### PR TITLE
feat: Allow static pod scrapes in grafana alloy

### DIFF
--- a/grafana-alloy/README.md
+++ b/grafana-alloy/README.md
@@ -953,6 +953,7 @@ Must be one of:
 
 | Property                                                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                             |
 | ------------------------------------------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [additionalPodDiscoveryScrapes](#prometheusRemoteWrite_additionalPodDiscoveryScrapes )               | No      | array   | No         | -          | -                                                                                                                                                                                                                             |
 | - [additionalStaticScrapes](#prometheusRemoteWrite_additionalStaticScrapes )                           | No      | array   | No         | -          | Extra prometheus.scrape blocks with static __address__ targets (forward_to filter_metrics). Each item: jobName, optional metricsPath, scrapeInterval, scrapeTimeout, targets: [{ address, optional job, optional namespace }] |
 | - [enabled](#prometheusRemoteWrite_enabled )                                                           | No      | boolean | No         | -          | Enable Prometheus remote write                                                                                                                                                                                                |
 | - [endpoints](#prometheusRemoteWrite_endpoints )                                                       | No      | array   | No         | -          | Array of remote write endpoints                                                                                                                                                                                               |
@@ -972,7 +973,22 @@ Must be one of:
 | - [scrapeTailscaleServices](#prometheusRemoteWrite_scrapeTailscaleServices )                           | No      | object  | No         | -          | Scrape Tailscale client metrics via ExternalName Services (requires tailscalesd syncer)                                                                                                                                       |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeTimeout )                                               | No      | string  | No         | -          | Scrape timeout for pods, kube-state-metrics, kubelet, and cadvisor scrapes                                                                                                                                                    |
 
-### <a name="prometheusRemoteWrite_additionalStaticScrapes"></a>6.1. Property `grafana-alloy > prometheusRemoteWrite > additionalStaticScrapes`
+### <a name="prometheusRemoteWrite_additionalPodDiscoveryScrapes"></a>6.1. Property `grafana-alloy > prometheusRemoteWrite > additionalPodDiscoveryScrapes`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+### <a name="prometheusRemoteWrite_additionalStaticScrapes"></a>6.2. Property `grafana-alloy > prometheusRemoteWrite > additionalStaticScrapes`
 
 |              |         |
 | ------------ | ------- |
@@ -989,7 +1005,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-### <a name="prometheusRemoteWrite_enabled"></a>6.2. Property `grafana-alloy > prometheusRemoteWrite > enabled`
+### <a name="prometheusRemoteWrite_enabled"></a>6.3. Property `grafana-alloy > prometheusRemoteWrite > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -998,7 +1014,7 @@ Must be one of:
 
 **Description:** Enable Prometheus remote write
 
-### <a name="prometheusRemoteWrite_endpoints"></a>6.3. Property `grafana-alloy > prometheusRemoteWrite > endpoints`
+### <a name="prometheusRemoteWrite_endpoints"></a>6.4. Property `grafana-alloy > prometheusRemoteWrite > endpoints`
 
 |              |         |
 | ------------ | ------- |
@@ -1015,7 +1031,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-### <a name="prometheusRemoteWrite_extraFilterRelabelRules"></a>6.4. Property `grafana-alloy > prometheusRemoteWrite > extraFilterRelabelRules`
+### <a name="prometheusRemoteWrite_extraFilterRelabelRules"></a>6.5. Property `grafana-alloy > prometheusRemoteWrite > extraFilterRelabelRules`
 
 |              |         |
 | ------------ | ------- |
@@ -1032,7 +1048,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-### <a name="prometheusRemoteWrite_metricsFilter"></a>6.5. Property `grafana-alloy > prometheusRemoteWrite > metricsFilter`
+### <a name="prometheusRemoteWrite_metricsFilter"></a>6.6. Property `grafana-alloy > prometheusRemoteWrite > metricsFilter`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1047,7 +1063,7 @@ Must be one of:
 | - [enabled](#prometheusRemoteWrite_metricsFilter_enabled ) | No      | boolean | No         | -          | Enable metrics filtering                    |
 | - [regex](#prometheusRemoteWrite_metricsFilter_regex )     | No      | string  | No         | -          | Regex pattern to match metric names to keep |
 
-#### <a name="prometheusRemoteWrite_metricsFilter_enabled"></a>6.5.1. Property `grafana-alloy > prometheusRemoteWrite > metricsFilter > enabled`
+#### <a name="prometheusRemoteWrite_metricsFilter_enabled"></a>6.6.1. Property `grafana-alloy > prometheusRemoteWrite > metricsFilter > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1056,7 +1072,7 @@ Must be one of:
 
 **Description:** Enable metrics filtering
 
-#### <a name="prometheusRemoteWrite_metricsFilter_regex"></a>6.5.2. Property `grafana-alloy > prometheusRemoteWrite > metricsFilter > regex`
+#### <a name="prometheusRemoteWrite_metricsFilter_regex"></a>6.6.2. Property `grafana-alloy > prometheusRemoteWrite > metricsFilter > regex`
 
 |              |          |
 | ------------ | -------- |
@@ -1065,7 +1081,7 @@ Must be one of:
 
 **Description:** Regex pattern to match metric names to keep
 
-### <a name="prometheusRemoteWrite_relabelNamespace"></a>6.6. Property `grafana-alloy > prometheusRemoteWrite > relabelNamespace`
+### <a name="prometheusRemoteWrite_relabelNamespace"></a>6.7. Property `grafana-alloy > prometheusRemoteWrite > relabelNamespace`
 
 |              |           |
 | ------------ | --------- |
@@ -1074,7 +1090,7 @@ Must be one of:
 
 **Description:** When true, copy exported_namespace to namespace for metrics that have it (fixes kube-state-metrics, nginx, etc. showing namespace="loki")
 
-### <a name="prometheusRemoteWrite_scrapeBlackboxStatic"></a>6.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic`
+### <a name="prometheusRemoteWrite_scrapeBlackboxStatic"></a>6.8. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1092,7 +1108,7 @@ Must be one of:
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeBlackboxStatic_scrapeTimeout )   | No      | string  | No         | -          | Scrape timeout for static blackbox scraping                                                              |
 | - [targets](#prometheusRemoteWrite_scrapeBlackboxStatic_targets )               | No      | array   | No         | -          | List of static blackbox targets to probe                                                                 |
 
-#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_config"></a>6.7.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > config`
+#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_config"></a>6.8.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > config`
 
 |              |          |
 | ------------ | -------- |
@@ -1101,7 +1117,7 @@ Must be one of:
 
 **Description:** Blackbox exporter configuration in YAML format (defaults to standard modules if not provided)
 
-#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_enabled"></a>6.7.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > enabled`
+#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_enabled"></a>6.8.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1110,7 +1126,7 @@ Must be one of:
 
 **Description:** Enable static blackbox scraping (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
 
-#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_scrapeInterval"></a>6.7.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_scrapeInterval"></a>6.8.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
@@ -1119,7 +1135,7 @@ Must be one of:
 
 **Description:** Scrape interval for static blackbox scraping
 
-#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_scrapeTimeout"></a>6.7.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_scrapeTimeout"></a>6.8.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
@@ -1128,7 +1144,7 @@ Must be one of:
 
 **Description:** Scrape timeout for static blackbox scraping
 
-#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_targets"></a>6.7.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > targets`
+#### <a name="prometheusRemoteWrite_scrapeBlackboxStatic_targets"></a>6.8.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeBlackboxStatic > targets`
 
 |              |         |
 | ------------ | ------- |
@@ -1145,7 +1161,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-### <a name="prometheusRemoteWrite_scrapeCadvisor"></a>6.8. Property `grafana-alloy > prometheusRemoteWrite > scrapeCadvisor`
+### <a name="prometheusRemoteWrite_scrapeCadvisor"></a>6.9. Property `grafana-alloy > prometheusRemoteWrite > scrapeCadvisor`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1160,7 +1176,7 @@ Must be one of:
 | - [enabled](#prometheusRemoteWrite_scrapeCadvisor_enabled )         | No      | boolean | No         | -          | Enable scraping cadvisor metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)                 |
 | - [shardByNode](#prometheusRemoteWrite_scrapeCadvisor_shardByNode ) | No      | boolean | No         | -          | When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion |
 
-#### <a name="prometheusRemoteWrite_scrapeCadvisor_enabled"></a>6.8.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeCadvisor > enabled`
+#### <a name="prometheusRemoteWrite_scrapeCadvisor_enabled"></a>6.9.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeCadvisor > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1169,7 +1185,7 @@ Must be one of:
 
 **Description:** Enable scraping cadvisor metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
 
-#### <a name="prometheusRemoteWrite_scrapeCadvisor_shardByNode"></a>6.8.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeCadvisor > shardByNode`
+#### <a name="prometheusRemoteWrite_scrapeCadvisor_shardByNode"></a>6.9.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeCadvisor > shardByNode`
 
 |              |           |
 | ------------ | --------- |
@@ -1178,7 +1194,7 @@ Must be one of:
 
 **Description:** When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion
 
-### <a name="prometheusRemoteWrite_scrapeDcgmExporter"></a>6.9. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter`
+### <a name="prometheusRemoteWrite_scrapeDcgmExporter"></a>6.10. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1197,14 +1213,14 @@ Must be one of:
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeDcgmExporter_scrapeTimeout )               | No      | string  | No         | -          | -                                                                        |
 | - [serviceAppLabelValue](#prometheusRemoteWrite_scrapeDcgmExporter_serviceAppLabelValue ) | No      | string  | No         | -          | Value of the Service label app=...                                       |
 
-#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_enabled"></a>6.9.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > enabled`
+#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_enabled"></a>6.10.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_namespaces"></a>6.9.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > namespaces`
+#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_namespaces"></a>6.10.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > namespaces`
 
 |              |         |
 | ------------ | ------- |
@@ -1221,7 +1237,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_portName"></a>6.9.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > portName`
+#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_portName"></a>6.10.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > portName`
 
 |              |          |
 | ------------ | -------- |
@@ -1230,21 +1246,21 @@ Must be one of:
 
 **Description:** Endpoint port name to keep
 
-#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_scrapeInterval"></a>6.9.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_scrapeInterval"></a>6.10.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_scrapeTimeout"></a>6.9.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_scrapeTimeout"></a>6.10.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_serviceAppLabelValue"></a>6.9.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > serviceAppLabelValue`
+#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_serviceAppLabelValue"></a>6.10.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > serviceAppLabelValue`
 
 |              |          |
 | ------------ | -------- |
@@ -1253,7 +1269,7 @@ Must be one of:
 
 **Description:** Value of the Service label app=...
 
-### <a name="prometheusRemoteWrite_scrapeEndpoints"></a>6.10. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints`
+### <a name="prometheusRemoteWrite_scrapeEndpoints"></a>6.11. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1269,7 +1285,7 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeEndpoints_scrapeInterval ) | No      | string  | No         | -          | Scrape interval for endpoint scraping                                                                      |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeEndpoints_scrapeTimeout )   | No      | string  | No         | -          | Scrape timeout for endpoint scraping                                                                       |
 
-#### <a name="prometheusRemoteWrite_scrapeEndpoints_enabled"></a>6.10.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > enabled`
+#### <a name="prometheusRemoteWrite_scrapeEndpoints_enabled"></a>6.11.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1278,7 +1294,7 @@ Must be one of:
 
 **Description:** Enable scraping service endpoints (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
 
-#### <a name="prometheusRemoteWrite_scrapeEndpoints_scrapeInterval"></a>6.10.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeEndpoints_scrapeInterval"></a>6.11.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
@@ -1287,7 +1303,7 @@ Must be one of:
 
 **Description:** Scrape interval for endpoint scraping
 
-#### <a name="prometheusRemoteWrite_scrapeEndpoints_scrapeTimeout"></a>6.10.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeEndpoints_scrapeTimeout"></a>6.11.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
@@ -1296,7 +1312,7 @@ Must be one of:
 
 **Description:** Scrape timeout for endpoint scraping
 
-### <a name="prometheusRemoteWrite_scrapeHostNodeExporter"></a>6.11. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter`
+### <a name="prometheusRemoteWrite_scrapeHostNodeExporter"></a>6.12. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1316,28 +1332,28 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeHostNodeExporter_scrapeInterval )             | No      | string  | No         | -          | -                 |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeHostNodeExporter_scrapeTimeout )               | No      | string  | No         | -          | -                 |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_address"></a>6.11.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > address`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_address"></a>6.12.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > address`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_enabled"></a>6.11.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > enabled`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_enabled"></a>6.12.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_jobLabel"></a>6.11.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > jobLabel`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_jobLabel"></a>6.12.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > jobLabel`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_metricRelabelConfigs"></a>6.11.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > metricRelabelConfigs`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_metricRelabelConfigs"></a>6.12.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > metricRelabelConfigs`
 
 |              |         |
 | ------------ | ------- |
@@ -1352,28 +1368,28 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_metricsPath"></a>6.11.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > metricsPath`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_metricsPath"></a>6.12.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > metricsPath`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_scrapeInterval"></a>6.11.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_scrapeInterval"></a>6.12.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_scrapeTimeout"></a>6.11.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporter_scrapeTimeout"></a>6.12.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast"></a>6.12. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast`
+### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast"></a>6.13. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1393,56 +1409,56 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_scrapeInterval )   | No      | string  | No         | -          | -                 |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_scrapeTimeout )     | No      | string  | No         | -          | -                 |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_address"></a>6.12.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > address`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_address"></a>6.13.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > address`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_enabled"></a>6.12.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > enabled`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_enabled"></a>6.13.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_jobLabel"></a>6.12.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > jobLabel`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_jobLabel"></a>6.13.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > jobLabel`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_metricKeepRegex"></a>6.12.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > metricKeepRegex`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_metricKeepRegex"></a>6.13.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > metricKeepRegex`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_metricsPath"></a>6.12.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > metricsPath`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_metricsPath"></a>6.13.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > metricsPath`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_scrapeInterval"></a>6.12.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_scrapeInterval"></a>6.13.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_scrapeTimeout"></a>6.12.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeHostNodeExporterInfinibandFast_scrapeTimeout"></a>6.13.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporterInfinibandFast > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="prometheusRemoteWrite_scrapeInterval"></a>6.13. Property `grafana-alloy > prometheusRemoteWrite > scrapeInterval`
+### <a name="prometheusRemoteWrite_scrapeInterval"></a>6.14. Property `grafana-alloy > prometheusRemoteWrite > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
@@ -1451,7 +1467,7 @@ Must be one of:
 
 **Description:** Scrape interval for pods, kube-state-metrics, kubelet, and cadvisor scrapes
 
-### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics"></a>6.14. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics`
+### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics"></a>6.15. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1471,7 +1487,7 @@ Must be one of:
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeTimeout )               | No      | string  | No         | -          | Optional scrape timeout override (defaults to prometheusRemoteWrite.scrapeTimeout)                                                                   |
 | - [serviceSelector](#prometheusRemoteWrite_scrapeKubeStateMetrics_serviceSelector )           | No      | string  | No         | -          | Label selector (key=value) to find the kube-state-metrics service                                                                                    |
 
-#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_enabled"></a>6.14.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > enabled`
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_enabled"></a>6.15.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1480,7 +1496,7 @@ Must be one of:
 
 **Description:** Enable scraping kube-state-metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
 
-#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_metricRelabelConfigs"></a>6.14.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > metricRelabelConfigs`
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_metricRelabelConfigs"></a>6.15.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > metricRelabelConfigs`
 
 |              |         |
 | ------------ | ------- |
@@ -1497,7 +1513,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_namespace"></a>6.14.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > namespace`
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_namespace"></a>6.15.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > namespace`
 
 |              |          |
 | ------------ | -------- |
@@ -1506,7 +1522,7 @@ Must be one of:
 
 **Description:** Namespace where kube-state-metrics service runs
 
-#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_portName"></a>6.14.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > portName`
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_portName"></a>6.15.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > portName`
 
 |              |          |
 | ------------ | -------- |
@@ -1515,7 +1531,7 @@ Must be one of:
 
 **Description:** Optional Kubernetes Service port name to scrape only (e.g. http for VMServiceScrape parity)
 
-#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeInterval"></a>6.14.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeInterval"></a>6.15.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
@@ -1524,7 +1540,7 @@ Must be one of:
 
 **Description:** Optional scrape interval override (defaults to prometheusRemoteWrite.scrapeInterval)
 
-#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeTimeout"></a>6.14.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeTimeout"></a>6.15.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
@@ -1533,7 +1549,7 @@ Must be one of:
 
 **Description:** Optional scrape timeout override (defaults to prometheusRemoteWrite.scrapeTimeout)
 
-#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_serviceSelector"></a>6.14.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > serviceSelector`
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_serviceSelector"></a>6.15.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > serviceSelector`
 
 |              |          |
 | ------------ | -------- |
@@ -1542,7 +1558,7 @@ Must be one of:
 
 **Description:** Label selector (key=value) to find the kube-state-metrics service
 
-### <a name="prometheusRemoteWrite_scrapeKubelet"></a>6.15. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubelet`
+### <a name="prometheusRemoteWrite_scrapeKubelet"></a>6.16. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubelet`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1557,7 +1573,7 @@ Must be one of:
 | - [enabled](#prometheusRemoteWrite_scrapeKubelet_enabled )         | No      | boolean | No         | -          | Enable scraping kubelet metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)                  |
 | - [shardByNode](#prometheusRemoteWrite_scrapeKubelet_shardByNode ) | No      | boolean | No         | -          | When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion |
 
-#### <a name="prometheusRemoteWrite_scrapeKubelet_enabled"></a>6.15.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubelet > enabled`
+#### <a name="prometheusRemoteWrite_scrapeKubelet_enabled"></a>6.16.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubelet > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1566,7 +1582,7 @@ Must be one of:
 
 **Description:** Enable scraping kubelet metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
 
-#### <a name="prometheusRemoteWrite_scrapeKubelet_shardByNode"></a>6.15.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubelet > shardByNode`
+#### <a name="prometheusRemoteWrite_scrapeKubelet_shardByNode"></a>6.16.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubelet > shardByNode`
 
 |              |           |
 | ------------ | --------- |
@@ -1575,7 +1591,7 @@ Must be one of:
 
 **Description:** When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion
 
-### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics"></a>6.16. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics`
+### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics"></a>6.17. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1595,56 +1611,56 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeInterval ) | No      | string  | No         | -          | -                 |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeTimeout )   | No      | string  | No         | -          | -                 |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_address"></a>6.16.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > address`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_address"></a>6.17.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > address`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_enabled"></a>6.16.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > enabled`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_enabled"></a>6.17.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_jobLabel"></a>6.16.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > jobLabel`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_jobLabel"></a>6.17.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > jobLabel`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_metricsPath"></a>6.16.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > metricsPath`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_metricsPath"></a>6.17.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > metricsPath`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_namespace"></a>6.16.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > namespace`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_namespace"></a>6.17.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > namespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeInterval"></a>6.16.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeInterval"></a>6.17.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeTimeout"></a>6.16.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeTimeout"></a>6.17.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="prometheusRemoteWrite_scrapeTailscaleServices"></a>6.17. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices`
+### <a name="prometheusRemoteWrite_scrapeTailscaleServices"></a>6.18. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1666,7 +1682,7 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeTailscaleServices_scrapeInterval ) | No      | string  | No         | -          | Scrape interval for Tailscale client metrics                                                                      |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeTailscaleServices_scrapeTimeout )   | No      | string  | No         | -          | Scrape timeout for Tailscale client metrics                                                                       |
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_enabled"></a>6.17.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > enabled`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_enabled"></a>6.18.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1675,7 +1691,7 @@ Must be one of:
 
 **Description:** Enable scraping Tailscale client metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_jobLabel"></a>6.17.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > jobLabel`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_jobLabel"></a>6.18.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > jobLabel`
 
 |              |          |
 | ------------ | -------- |
@@ -1684,7 +1700,7 @@ Must be one of:
 
 **Description:** Job label for scraped metrics
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_labelSelector"></a>6.17.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > labelSelector`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_labelSelector"></a>6.18.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > labelSelector`
 
 |              |          |
 | ------------ | -------- |
@@ -1693,7 +1709,7 @@ Must be one of:
 
 **Description:** Label selector to find Tailscale ExternalName Services
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_metricsPath"></a>6.17.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > metricsPath`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_metricsPath"></a>6.18.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > metricsPath`
 
 |              |          |
 | ------------ | -------- |
@@ -1702,7 +1718,7 @@ Must be one of:
 
 **Description:** Path to scrape metrics from on each target
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_namespace"></a>6.17.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > namespace`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_namespace"></a>6.18.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > namespace`
 
 |              |          |
 | ------------ | -------- |
@@ -1711,7 +1727,7 @@ Must be one of:
 
 **Description:** Namespace where Tailscale ExternalName Services are created
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_portName"></a>6.17.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > portName`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_portName"></a>6.18.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > portName`
 
 |              |          |
 | ------------ | -------- |
@@ -1720,7 +1736,7 @@ Must be one of:
 
 **Description:** Service port name to scrape (filters targets to only this port)
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_relayAddress"></a>6.17.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > relayAddress`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_relayAddress"></a>6.18.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > relayAddress`
 
 |              |          |
 | ------------ | -------- |
@@ -1729,7 +1745,7 @@ Must be one of:
 
 **Description:** Address of the metrics relay that rewrites the Host header for Tailscale web client compatibility
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeInterval"></a>6.17.8. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeInterval"></a>6.18.8. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
@@ -1738,7 +1754,7 @@ Must be one of:
 
 **Description:** Scrape interval for Tailscale client metrics
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeTimeout"></a>6.17.9. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeTimeout"></a>6.18.9. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
@@ -1747,7 +1763,7 @@ Must be one of:
 
 **Description:** Scrape timeout for Tailscale client metrics
 
-### <a name="prometheusRemoteWrite_scrapeTimeout"></a>6.18. Property `grafana-alloy > prometheusRemoteWrite > scrapeTimeout`
+### <a name="prometheusRemoteWrite_scrapeTimeout"></a>6.19. Property `grafana-alloy > prometheusRemoteWrite > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |

--- a/grafana-alloy/alloy/templates/controllers/_pod.yaml
+++ b/grafana-alloy/alloy/templates/controllers/_pod.yaml
@@ -1,0 +1,93 @@
+{{- define "alloy.pod-template" -}}
+{{- $values := (mustMergeOverwrite .Values.alloy (or .Values.agent dict)) -}}
+metadata:
+  annotations:
+    kubectl.kubernetes.io/default-container: alloy
+    {{- if and (not .Values.configReloader.enabled) $values.configMap.create $values.configMap.content }}
+    checksum/config: {{ (tpl  $values.configMap.content .) | sha256sum | trunc 63 }}
+    {{- end }}
+    {{- with .Values.controller.podAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "alloy.selectorLabels" . | nindent 4 }}
+    {{- with .Values.controller.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.global.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  serviceAccountName: {{ include "alloy.serviceAccountName" . }}
+  {{- if or .Values.global.image.pullSecrets .Values.image.pullSecrets }}
+  imagePullSecrets:
+    {{- if .Values.global.image.pullSecrets }}
+    {{- toYaml .Values.global.image.pullSecrets | nindent 4 }}
+    {{- else }}
+    {{- toYaml .Values.image.pullSecrets | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.controller.initContainers }}
+  initContainers:
+    {{- with .Values.controller.initContainers }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  containers:
+    {{- include "alloy.container" . | nindent 4 }}
+    {{- include "alloy.watch-container" . | nindent 4 }}
+    {{- with .Values.controller.extraContainers }}
+    {{- toYaml . | nindent 4 }}
+    {{- end}}
+  {{- if .Values.controller.priorityClassName }}
+  priorityClassName: {{ .Values.controller.priorityClassName }}
+  {{- end }}
+  {{- if .Values.controller.hostNetwork }}
+  hostNetwork: {{ .Values.controller.hostNetwork }}
+  {{- end }}
+  {{- if .Values.controller.hostPID }}
+  hostPID: {{ .Values.controller.hostPID }}
+  {{- end }}
+  dnsPolicy: {{ .Values.controller.dnsPolicy }}
+  {{- with .Values.controller.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.controller.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds | int }}
+  {{- end }}
+  {{- with .Values.controller.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.controller.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.controller.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  volumes:
+    - name: config
+      configMap:
+        name: {{ include "alloy.config-map.name" . }}
+    {{- if $values.mounts.varlog }}
+    - name: varlog
+      hostPath:
+        path: /var/log
+    {{- end }}
+    {{- if $values.mounts.dockercontainers }}
+    - name: dockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+    {{- end }}
+    {{- if .Values.controller.volumes.extra }}
+    {{- toYaml .Values.controller.volumes.extra | nindent 4 }}
+    {{- end }}
+  {{- if $values.hostAliases }}
+  hostAliases:
+    {{- toYaml $values.hostAliases | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/grafana-alloy/templates/_helpers.tpl
+++ b/grafana-alloy/templates/_helpers.tpl
@@ -49,6 +49,16 @@ app.kubernetes.io/name: {{ include "grafana-alloy.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{- define "grafana-alloy.stripDiscoveryJobLastSegmentRule" }}
+rule {
+  source_labels = ["job"]
+  regex         = ".+/(.+)"
+  target_label  = "job"
+  replacement   = "$1"
+  action        = "replace"
+}
+{{- end }}
+
 {{- define "grafana-alloy.promRelabelRules" -}}
 {{- range . }}
       rule {
@@ -70,4 +80,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       }
 {{- end }}
 {{- end }}
+
+{{- define "grafana-alloy.normalizeLabel" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9_]" . "_" -}}
+{{- end -}}
 

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -321,6 +321,7 @@ data:
     {{- if and .Values.alloyConfig.metrics.enabled .Values.prometheusRemoteWrite.enabled }}
     {{- $si := .Values.prometheusRemoteWrite.scrapeInterval | default "1m" }}
     {{- $st := .Values.prometheusRemoteWrite.scrapeTimeout | default "10s" }}
+    {{- $stripJob := .Values.prometheusRemoteWrite.stripDiscoveryJobLastSegment | default true }}
     discovery.kubernetes "pods_metrics" {
       role = "pod"
     }
@@ -372,6 +373,10 @@ data:
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "job"
       }
+
+      {{- if $stripJob }}
+{{- include "grafana-alloy.stripDiscoveryJobLastSegmentRule" . | nindent 6 }}
+      {{- end }}
     }
 
     prometheus.scrape "pods" {
@@ -409,6 +414,10 @@ data:
         separator     = "/"
         target_label  = "job"
       }
+
+      {{- if $stripJob }}
+{{- include "grafana-alloy.stripDiscoveryJobLastSegmentRule" . | nindent 6 }}
+      {{- end }}
 
       {{- with .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.portName }}
       rule {
@@ -486,6 +495,10 @@ data:
         target_label  = "job"
       }
 
+      {{- if $stripJob }}
+{{- include "grafana-alloy.stripDiscoveryJobLastSegmentRule" . | nindent 6 }}
+      {{- end }}
+
       rule {
         source_labels = ["__meta_kubernetes_endpoint_node_name"]
         target_label  = "node"
@@ -527,6 +540,75 @@ data:
     {{- end }}
     {{- end }}
 
+    {{- if and .Values.alloyConfig.metrics.enabled .Values.prometheusRemoteWrite.enabled }}
+    {{- $prw := .Values.prometheusRemoteWrite }}
+    {{- $defaultSi := $prw.scrapeInterval | default "1m" }}
+    {{- $defaultSt := $prw.scrapeTimeout | default "10s" }}
+    {{- $podScrapes := $prw.additionalPodDiscoveryScrapes | default list }}
+    {{- if $podScrapes }}
+    discovery.kubernetes "additional_pods" {
+      role = "pod"
+      selectors {
+        role  = "pod"
+        field = join("", ["spec.nodeName=", coalesce(sys.env("NODE_NAME"), sys.env("HOSTNAME"), constants.hostname)])
+      }
+    }
+    {{- range $idx, $scrape := $podScrapes }}
+    discovery.relabel "pod_scrape_{{ $idx }}" {
+      targets = discovery.kubernetes.additional_pods.targets
+      {{- if $scrape.namespaces }}
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        regex         = {{ join "|" $scrape.namespaces | quote }}
+        action        = "keep"
+      }
+      {{- end }}
+      {{- range $key, $val := $scrape.matchLabels }}
+      rule {
+        source_labels = [{{ printf "__meta_kubernetes_pod_label_%s" (include "grafana-alloy.normalizeLabel" $key) | quote }}]
+        regex         = {{ $val | quote }}
+        action        = "keep"
+      }
+      {{- end }}
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_port_number"]
+        regex         = {{ $scrape.port | quote }}
+        action        = "keep"
+      }
+      rule {
+        source_labels = ["__address__"]
+        regex         = "([^:]+)(?::\\d+)?"
+        replacement   = join("", ["$1", ":", {{ $scrape.port | quote }}])
+        target_label  = "__address__"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label  = "node"
+      }
+      rule {
+        target_label  = "job"
+        replacement   = {{ $scrape.jobName | quote }}
+      }
+    }
+    prometheus.scrape "pod_scrape_{{ $idx }}" {
+      targets         = discovery.relabel.pod_scrape_{{ $idx }}.output
+      forward_to      = [prometheus.relabel.filter_metrics.receiver]
+      scrape_interval = {{ $scrape.scrapeInterval | default $defaultSi | quote }}
+      scrape_timeout  = {{ $scrape.scrapeTimeout | default $defaultSt | quote }}
+      metrics_path    = {{ $scrape.path | default "/metrics" | quote }}
+    }
+    {{- end }}
+    {{- end }}
+    {{- end }}
+
     {{- if and .Values.alloyConfig.metrics.enabled .Values.prometheusRemoteWrite.enabled .Values.prometheusRemoteWrite.scrapeKubelet .Values.prometheusRemoteWrite.scrapeKubelet.enabled }}
     discovery.kubernetes "kubelet" {
       role = "node"
@@ -559,6 +641,10 @@ data:
         target_label = "job"
         replacement  = "integrations/kubernetes/kubelet"
       }
+
+      {{- if $stripJob }}
+{{- include "grafana-alloy.stripDiscoveryJobLastSegmentRule" . | nindent 6 }}
+      {{- end }}
     }
 
     prometheus.scrape "kubelet" {
@@ -614,6 +700,10 @@ data:
         target_label = "job"
         replacement  = "integrations/kubernetes/cadvisor"
       }
+
+      {{- if $stripJob }}
+{{- include "grafana-alloy.stripDiscoveryJobLastSegmentRule" . | nindent 6 }}
+      {{- end }}
     }
 
     prometheus.scrape "cadvisor" {
@@ -666,6 +756,10 @@ data:
         separator     = "/"
         target_label  = "job"
       }
+
+      {{- if $stripJob }}
+{{- include "grafana-alloy.stripDiscoveryJobLastSegmentRule" . | nindent 6 }}
+      {{- end }}
 
       rule {
         source_labels = ["__meta_kubernetes_endpoint_node_name"]

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -322,6 +322,11 @@ data:
     {{- $si := .Values.prometheusRemoteWrite.scrapeInterval | default "1m" }}
     {{- $st := .Values.prometheusRemoteWrite.scrapeTimeout | default "10s" }}
     {{- $stripJob := .Values.prometheusRemoteWrite.stripDiscoveryJobLastSegment | default true }}
+    {{- $scrapeAnnotatedPodsEnabled := true }}
+    {{- if and .Values.prometheusRemoteWrite.scrapeAnnotatedPods (hasKey .Values.prometheusRemoteWrite.scrapeAnnotatedPods "enabled") }}
+    {{- $scrapeAnnotatedPodsEnabled = .Values.prometheusRemoteWrite.scrapeAnnotatedPods.enabled }}
+    {{- end }}
+    {{- if $scrapeAnnotatedPodsEnabled }}
     discovery.kubernetes "pods_metrics" {
       role = "pod"
     }
@@ -385,6 +390,7 @@ data:
       scrape_interval = {{ $si | quote }}
       scrape_timeout  = {{ $st | quote }}
     }
+    {{- end }}
 
     {{- if and .Values.alloyConfig.metrics.enabled .Values.prometheusRemoteWrite.enabled .Values.prometheusRemoteWrite.scrapeKubeStateMetrics .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.enabled }}
     {{- $ksmMetricRelabel := .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.metricRelabelConfigs | default list }}

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -377,6 +377,13 @@
     "prometheusRemoteWrite": {
       "type": "object",
       "properties": {
+        "additionalPodDiscoveryScrapes": {
+          "type": "array"
+        },
+        "additionalStaticScrapes": {
+          "description": "Extra prometheus.scrape blocks with static __address__ targets (forward_to filter_metrics). Each item: jobName, optional metricsPath, scrapeInterval, scrapeTimeout, targets: [{ address, optional job, optional namespace }]",
+          "type": "array"
+        },
         "enabled": {
           "description": "Enable Prometheus remote write",
           "type": "boolean"
@@ -388,10 +395,6 @@
         "extraFilterRelabelRules": {
           "description": "Extra prometheus.relabel rules applied in filter_metrics before the cluster label (e.g. Andromeda-style job/service drops)",
           "type": "array"
-        },
-        "stripDiscoveryJobLastSegment": {
-          "description": "When true, strip job to last / segment for built-in discovery scrapes before filter_metrics",
-          "type": "boolean"
         },
         "metricsFilter": {
           "description": "Metrics filtering configuration",
@@ -492,108 +495,6 @@
             },
             "scrapeTimeout": {
               "description": "Scrape timeout for endpoint scraping",
-              "type": "string"
-            }
-          }
-        },
-        "additionalStaticScrapes": {
-          "description": "Extra prometheus.scrape blocks with static targets forwarded to filter_metrics",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "jobName": {
-                "type": "string"
-              },
-              "metricsPath": {
-                "type": "string"
-              },
-              "scrapeInterval": {
-                "type": "string"
-              },
-              "scrapeTimeout": {
-                "type": "string"
-              },
-              "targets": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "address": {
-                      "type": "string"
-                    },
-                    "job": {
-                      "type": "string"
-                    },
-                    "namespace": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "additionalPodDiscoveryScrapes": {
-          "description": "Dynamic pod discovery scrapes using node-sharded Kubernetes discovery",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["jobName", "matchLabels", "port"],
-            "properties": {
-              "jobName": {
-                "type": "string"
-              },
-              "namespaces": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "matchLabels": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
-              "port": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string"
-              },
-              "scrapeInterval": {
-                "type": "string"
-              },
-              "scrapeTimeout": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "scrapeSelfRemoteWriteMetrics": {
-          "description": "Scrape Alloy /metrics for prometheus_remote_storage_* debug metrics",
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "jobLabel": {
-              "type": "string"
-            },
-            "metricsPath": {
-              "type": "string"
-            },
-            "namespace": {
-              "type": "string"
-            },
-            "scrapeInterval": {
-              "type": "string"
-            },
-            "scrapeTimeout": {
               "type": "string"
             }
           }
@@ -701,6 +602,33 @@
             "shardByNode": {
               "description": "When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion",
               "type": "boolean"
+            }
+          }
+        },
+        "scrapeSelfRemoteWriteMetrics": {
+          "description": "Scrape this Alloy process /metrics (prometheus_remote_storage_* queue debug metrics) and send to remote_write for AMP cost/ingestion dashboards",
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "jobLabel": {
+              "type": "string"
+            },
+            "metricsPath": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "scrapeInterval": {
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "type": "string"
             }
           }
         },

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -377,10 +377,6 @@
     "prometheusRemoteWrite": {
       "type": "object",
       "properties": {
-        "additionalStaticScrapes": {
-          "description": "Extra prometheus.scrape blocks with static __address__ targets (forward_to filter_metrics). Each item: jobName, optional metricsPath, scrapeInterval, scrapeTimeout, targets: [{ address, optional job, optional namespace }]",
-          "type": "array"
-        },
         "enabled": {
           "description": "Enable Prometheus remote write",
           "type": "boolean"
@@ -392,6 +388,10 @@
         "extraFilterRelabelRules": {
           "description": "Extra prometheus.relabel rules applied in filter_metrics before the cluster label (e.g. Andromeda-style job/service drops)",
           "type": "array"
+        },
+        "stripDiscoveryJobLastSegment": {
+          "description": "When true, strip job to last / segment for built-in discovery scrapes before filter_metrics",
+          "type": "boolean"
         },
         "metricsFilter": {
           "description": "Metrics filtering configuration",
@@ -492,6 +492,108 @@
             },
             "scrapeTimeout": {
               "description": "Scrape timeout for endpoint scraping",
+              "type": "string"
+            }
+          }
+        },
+        "additionalStaticScrapes": {
+          "description": "Extra prometheus.scrape blocks with static targets forwarded to filter_metrics",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "jobName": {
+                "type": "string"
+              },
+              "metricsPath": {
+                "type": "string"
+              },
+              "scrapeInterval": {
+                "type": "string"
+              },
+              "scrapeTimeout": {
+                "type": "string"
+              },
+              "targets": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "job": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalPodDiscoveryScrapes": {
+          "description": "Dynamic pod discovery scrapes using node-sharded Kubernetes discovery",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["jobName", "matchLabels", "port"],
+            "properties": {
+              "jobName": {
+                "type": "string"
+              },
+              "namespaces": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "matchLabels": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "port": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "scrapeInterval": {
+                "type": "string"
+              },
+              "scrapeTimeout": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "scrapeSelfRemoteWriteMetrics": {
+          "description": "Scrape Alloy /metrics for prometheus_remote_storage_* debug metrics",
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "jobLabel": {
+              "type": "string"
+            },
+            "metricsPath": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "scrapeInterval": {
+              "type": "string"
+            },
+            "scrapeTimeout": {
               "type": "string"
             }
           }
@@ -599,33 +701,6 @@
             "shardByNode": {
               "description": "When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion",
               "type": "boolean"
-            }
-          }
-        },
-        "scrapeSelfRemoteWriteMetrics": {
-          "description": "Scrape this Alloy process /metrics (prometheus_remote_storage_* queue debug metrics) and send to remote_write for AMP cost/ingestion dashboards",
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "jobLabel": {
-              "type": "string"
-            },
-            "metricsPath": {
-              "type": "string"
-            },
-            "namespace": {
-              "type": "string"
-            },
-            "scrapeInterval": {
-              "type": "string"
-            },
-            "scrapeTimeout": {
-              "type": "string"
             }
           }
         },

--- a/grafana-alloy/values.yaml
+++ b/grafana-alloy/values.yaml
@@ -107,6 +107,8 @@ prometheusRemoteWrite:
 
   additionalStaticScrapes: [] # @schema description: Extra prometheus.scrape blocks with static __address__ targets (forward_to filter_metrics). Each item: jobName, optional metricsPath, scrapeInterval, scrapeTimeout, targets: [{ address, optional job, optional namespace }]
 
+  additionalPodDiscoveryScrapes: []
+
   scrapeSelfRemoteWriteMetrics: # @schema description: Scrape this Alloy process /metrics (prometheus_remote_storage_* queue debug metrics) and send to remote_write for AMP cost/ingestion dashboards
     enabled: false
     address: "127.0.0.1:12345"

--- a/karpenter-gpu-nodepool/tests/nodepool_test.yaml
+++ b/karpenter-gpu-nodepool/tests/nodepool_test.yaml
@@ -117,6 +117,26 @@ tests:
           path: spec.template.spec.nodeClassRef.name
           value: custom-nodeclass
 
+  - it: should allow custom nodeClassRef group and kind
+    set:
+      nodepool:
+        template:
+          spec:
+            nodeClassRef:
+              group: karpenter.test.io
+              kind: CustomNodeClass
+              name: custom-ref
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeClassRef.group
+          value: karpenter.test.io
+      - equal:
+          path: spec.template.spec.nodeClassRef.kind
+          value: CustomNodeClass
+      - equal:
+          path: spec.template.spec.nodeClassRef.name
+          value: custom-ref
+
   - it: should have startup taints
     asserts:
       - isNotEmpty:
@@ -157,6 +177,24 @@ tests:
             operator: NotIn
             values:
               - "0"
+
+  - it: should have arch and os requirements
+    asserts:
+      - contains:
+          path: spec.template.spec.requirements
+          content:
+            key: kubernetes.io/arch
+            operator: In
+            values:
+              - amd64
+              - arm64
+      - contains:
+          path: spec.template.spec.requirements
+          content:
+            key: kubernetes.io/os
+            operator: In
+            values:
+              - linux
 
   - it: should have capacity type requirement
     asserts:

--- a/karpenter-gpu-nodepool/tests/nvidia-daemonset_test.yaml
+++ b/karpenter-gpu-nodepool/tests/nvidia-daemonset_test.yaml
@@ -155,6 +155,16 @@ tests:
           path: spec.updateStrategy.type
           value: RollingUpdate
 
+  - it: should allow custom update strategy
+    set:
+      nvidiaDriver:
+        updateStrategy:
+          type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
   - it: should have correct pod labels
     asserts:
       - equal:
@@ -245,6 +255,17 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.priorityClassName
+
+  - it: should use explicit priorityClassName when chart PriorityClass is disabled
+    set:
+      priorityClass:
+        enabled: false
+      nvidiaDriver:
+        priorityClassName: system-node-critical
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-node-critical
 
   - it: should allow custom priorityClassName
     set:

--- a/karpenter-gpu-nodepool/tests/priorityclass_test.yaml
+++ b/karpenter-gpu-nodepool/tests/priorityclass_test.yaml
@@ -47,20 +47,18 @@ tests:
 
   - it: should use default priority value
     asserts:
-      - isNotNull:
+      - equal:
           path: value
-      - isKind:
-          of: PriorityClass
+          value: 9.00002e+08
 
   - it: should allow custom priority value
     set:
       priorityClass:
         value: 500000000
     asserts:
-      - isNotNull:
+      - equal:
           path: value
-      - isKind:
-          of: PriorityClass
+          value: 5e+08
 
   - it: should not be global default by default
     asserts:


### PR DESCRIPTION
This PR combines **Grafana Alloy** Prometheus remote_write enhancements (optional `job` normalization, configurable per-node pod scrapes, vendored upstream pod template) with expanded **helm unittest** coverage for **karpenter-gpu-nodepool**.