### PR TITLE
fix: re-apply gpu-not-ready taint on startup and wait for stable GPU health

### DIFF
--- a/karpenter-gpu-nodepool/templates/node-readiness.yaml
+++ b/karpenter-gpu-nodepool/templates/node-readiness.yaml
@@ -72,6 +72,8 @@ spec:
             - /bin/sh
             - -c
             - |
+              echo "Ensuring startup taint {{ .Values.nodeReadiness.startupTaintKey }}:NoSchedule is present on $NODE_NAME"
+              kubectl taint node "$NODE_NAME" {{ .Values.nodeReadiness.startupTaintKey }}:NoSchedule --overwrite
               until [ -n "$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')" ]; do
                 echo "Waiting for nvidia.com/gpu to appear in node allocatable resources..."
                 sleep 5

--- a/karpenter-gpu-nodepool/templates/node-readiness.yaml
+++ b/karpenter-gpu-nodepool/templates/node-readiness.yaml
@@ -74,11 +74,18 @@ spec:
             - |
               echo "Ensuring startup taint {{ .Values.nodeReadiness.startupTaintKey }}:NoSchedule is present on $NODE_NAME"
               kubectl taint node "$NODE_NAME" {{ .Values.nodeReadiness.startupTaintKey }}:NoSchedule --overwrite
-              until [ -n "$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')" ]; do
-                echo "Waiting for nvidia.com/gpu to appear in node allocatable resources..."
+              STABLE=0
+              while [ "$STABLE" -lt 3 ]; do
+                if [ -n "$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')" ]; then
+                  STABLE=$((STABLE + 1))
+                  echo "GPU healthy check $STABLE/3 on $NODE_NAME..."
+                else
+                  STABLE=0
+                  echo "Waiting for nvidia.com/gpu to appear in node allocatable resources..."
+                fi
                 sleep 5
               done
-              echo "GPUs allocatable on $NODE_NAME, removing startup taint {{ .Values.nodeReadiness.startupTaintKey }}"
+              echo "GPUs stable on $NODE_NAME, removing startup taint {{ .Values.nodeReadiness.startupTaintKey }}"
               kubectl taint node "$NODE_NAME" {{ .Values.nodeReadiness.startupTaintKey }}:NoSchedule- || true
               sleep infinity
           env:


### PR DESCRIPTION
Two related races that cause `UnexpectedAdmissionError` on GPU pods:

1. **Taint cleared before node-readiness starts**: The `nvidia.com/gpu-not-ready:NoSchedule` startup taint can be removed before the node-readiness pod starts (e.g. CNI delay, fast Karpenter initialization). Re-applying it with `--overwrite` at pod startup closes this window.

2. **GPU transiently healthy**: `nvidia.com/gpu` can appear in `status.allocatable` briefly while the device plugin is still initializing, then drop back to unhealthy. Removing the taint on the first positive check lets pods schedule into a device plugin that isn't stable yet. Fixed by requiring 3 consecutive healthy checks (15s) before removing the taint.