### PR TITLE
fix: prevent grafana folder deletion

### DIFF
--- a/stack/templates/dashboard.yaml
+++ b/stack/templates/dashboard.yaml
@@ -13,22 +13,22 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
   name: {{ $rootFolderName }}
-  # annotations:
-    # grafana.integreatly.org/preserve-resources-on-deletion: "true"
+  annotations:
+    grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
   instanceSelector:
     {{- toYaml .Values.grafanaDashboard.instanceSelector | nindent 4 }}
   title: {{ $rootFolderTitle }}
-  uid: {{ printf "%s-%s" ($rootFolderTitle | lower) .Values.argusMetadata.stackName }}
+  uid: {{ $rootFolderTitle | lower }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
   name: {{ $appFolderName }}
-  # annotations:
-    # grafana.integreatly.org/preserve-resources-on-deletion: "true"
+  annotations:
+    grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
@@ -36,14 +36,14 @@ spec:
     {{- toYaml .Values.grafanaDashboard.instanceSelector | nindent 4 }}
   parentFolderRef: {{ $rootFolderName }}
   title: {{ $appFolderTitle }}
-  uid: {{ printf "%s-%s" ($appFolderTitle | lower) .Values.argusMetadata.stackName }}
+  uid: {{ $appFolderTitle | lower }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
   name: {{ $envFolderName }}
-  # annotations:
-    # grafana.integreatly.org/preserve-resources-on-deletion: "true"
+  annotations:
+    grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
@@ -51,7 +51,7 @@ spec:
     {{- toYaml .Values.grafanaDashboard.instanceSelector | nindent 4 }}
   parentFolderRef: {{ $appFolderName }}
   title: {{ $envFolderTitle }}
-  uid: {{ printf "%s-%s-%s" ($appFolderTitle | lower) ($envFolderTitle | lower) .Values.argusMetadata.stackName }}
+  uid: {{ printf "%s-%s" $appFolderTitle $envFolderTitle | lower }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard

--- a/stack/templates/dashboard.yaml
+++ b/stack/templates/dashboard.yaml
@@ -15,6 +15,7 @@ metadata:
   name: {{ $rootFolderName }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
@@ -29,6 +30,7 @@ metadata:
   name: {{ $appFolderName }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
@@ -44,6 +46,7 @@ metadata:
   name: {{ $envFolderName }}
   annotations:
     argocd.argoproj.io/sync-wave: "3"
+    grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s

--- a/stack/templates/dashboard.yaml
+++ b/stack/templates/dashboard.yaml
@@ -13,7 +13,6 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
   name: {{ $rootFolderName }}
-  annotations:
   # annotations:
     # grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:

--- a/stack/templates/dashboard.yaml
+++ b/stack/templates/dashboard.yaml
@@ -14,23 +14,22 @@ kind: GrafanaFolder
 metadata:
   name: {{ $rootFolderName }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
-    grafana.integreatly.org/preserve-resources-on-deletion: "true"
+  # annotations:
+    # grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
   instanceSelector:
     {{- toYaml .Values.grafanaDashboard.instanceSelector | nindent 4 }}
   title: {{ $rootFolderTitle }}
-  uid: {{ $rootFolderTitle | lower }}
+  uid: {{ printf "%s-%s" ($rootFolderTitle | lower) .Values.argusMetadata.stackName }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
   name: {{ $appFolderName }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-    grafana.integreatly.org/preserve-resources-on-deletion: "true"
+  # annotations:
+    # grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
@@ -38,15 +37,14 @@ spec:
     {{- toYaml .Values.grafanaDashboard.instanceSelector | nindent 4 }}
   parentFolderRef: {{ $rootFolderName }}
   title: {{ $appFolderTitle }}
-  uid: {{ $appFolderTitle | lower }}
+  uid: {{ printf "%s-%s" ($appFolderTitle | lower) .Values.argusMetadata.stackName }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
   name: {{ $envFolderName }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
-    grafana.integreatly.org/preserve-resources-on-deletion: "true"
+  # annotations:
+    # grafana.integreatly.org/preserve-resources-on-deletion: "true"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s
@@ -54,14 +52,12 @@ spec:
     {{- toYaml .Values.grafanaDashboard.instanceSelector | nindent 4 }}
   parentFolderRef: {{ $appFolderName }}
   title: {{ $envFolderTitle }}
-  uid: {{ printf "%s-%s" $appFolderTitle $envFolderTitle | lower }}
+  uid: {{ printf "%s-%s-%s" ($appFolderTitle | lower) ($envFolderTitle | lower) .Values.argusMetadata.stackName }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: {{ include "stack.fullname" . | lower }}-dashboard
-  annotations:
-    argocd.argoproj.io/sync-wave: "4"
 spec:
   allowCrossNamespaceImport: true
   resyncPeriod: 30s


### PR DESCRIPTION
## Summary

- Added `grafana.integreatly.org/preserve-resources-on-deletion: "true"` to all three `GrafanaFolder` resources

## Background

Each invocation of the `stack` Helm chart creates the full folder hierarchy in Grafana (root → app → env) and a dashboard inside the env folder. Since multiple stacks share the same app and env folders (same title and UID), these folders are co-owned by multiple `GrafanaFolder` CRDs across stacks.

The bug: when one stack is deleted, its `GrafanaFolder` CRDs are deleted, causing the grafana-operator to delete the actual Grafana folders — including any dashboards placed there by other stacks. This left surviving stacks with dashboards pointing to deleted folders, causing the grafana-operator to fail with:

```
[GET /dashboards/uid/{uid}][500] getDashboardByUidInternalServerError {"message":"Dashboard folder could not be read"}
```

This error is terminal — the operator does not retry once it marks the resource `ApplyFailed`, so the dashboard stays broken until manually remediated.

## Fix

- **`preserve-resources-on-deletion`** on the three folder CRDs tells the grafana-operator to skip deleting the Grafana folder when the CRD is removed. Since app and env folders are long-lived and shared across stacks, this prevents one stack's deletion from cascading into data loss for sibling stacks. The annotation is intentionally omitted from the dashboard, which should be cleaned up when its stack is deleted.

## Tradeoff

Grafana folders will not be automatically deleted when all stacks are removed. Manual cleanup via the Grafana UI is required when an entire app or env is decommissioned. This is acceptable given that apps and envs are long-lived; only stacks are high-churn.