### PR TITLE
fix: add node selector support for pod_metrics

### DIFF
--- a/grafana-alloy/CHANGELOG.md
+++ b/grafana-alloy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.1](https://github.com/chanzuckerberg/argo-helm-charts/compare/grafana-alloy-v0.8.0...grafana-alloy-v0.8.1) (2026-04-20)
+
+
+### Features
+
+* Add shardByNode option for annotated pod scraping to fix cluster-wide discovery on DaemonSet ([#TODO](https://github.com/chanzuckerberg/argo-helm-charts/issues/TODO))
+
 ## [0.8.0](https://github.com/chanzuckerberg/argo-helm-charts/compare/grafana-alloy-v0.7.0...grafana-alloy-v0.8.0) (2026-04-02)
 
 

--- a/grafana-alloy/Chart.yaml
+++ b/grafana-alloy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-alloy
 description: A Helm chart for deploying Grafana Alloy with custom configuration
 type: application
-version: 0.8.0
+version: 0.8.1
 
 dependencies:
   - name: alloy

--- a/grafana-alloy/README.md
+++ b/grafana-alloy/README.md
@@ -968,6 +968,7 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeInterval )                                             | No      | string  | No         | -          | Scrape interval for pods, kube-state-metrics, kubelet, and cadvisor scrapes                                                                                                                                                   |
 | - [scrapeKubeStateMetrics](#prometheusRemoteWrite_scrapeKubeStateMetrics )                             | No      | object  | No         | -          | Scrape kube-state-metrics service for kube_* metrics                                                                                                                                                                          |
 | - [scrapeKubelet](#prometheusRemoteWrite_scrapeKubelet )                                               | No      | object  | No         | -          | Scrape kubelet metrics from each node (kubelet_*, kubernetes_build_info)                                                                                                                                                      |
+| - [scrapePodsAnnotated](#prometheusRemoteWrite_scrapePodsAnnotated )                                   | No      | object  | No         | -          | Scrape pods annotated with prometheus.io/scrape=true                                                                                                                                                                          |
 | - [scrapeSelfRemoteWriteMetrics](#prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics )                 | No      | object  | No         | -          | Scrape this Alloy process /metrics (prometheus_remote_storage_* queue debug metrics) and send to remote_write for AMP cost/ingestion dashboards                                                                               |
 | - [scrapeTailscaleServices](#prometheusRemoteWrite_scrapeTailscaleServices )                           | No      | object  | No         | -          | Scrape Tailscale client metrics via ExternalName Services (requires tailscalesd syncer)                                                                                                                                       |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeTimeout )                                               | No      | string  | No         | -          | Scrape timeout for pods, kube-state-metrics, kubelet, and cadvisor scrapes                                                                                                                                                    |
@@ -1575,7 +1576,30 @@ Must be one of:
 
 **Description:** When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion
 
-### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics"></a>6.16. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics`
+### <a name="prometheusRemoteWrite_scrapePodsAnnotated"></a>6.16. Property `grafana-alloy > prometheusRemoteWrite > scrapePodsAnnotated`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Scrape pods annotated with prometheus.io/scrape=true
+
+| Property                                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                          |
+| ------------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| - [shardByNode](#prometheusRemoteWrite_scrapePodsAnnotated_shardByNode ) | No      | boolean | No         | -          | When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 321x duplication and high AMP ingestion |
+
+#### <a name="prometheusRemoteWrite_scrapePodsAnnotated_shardByNode"></a>6.16.1. Property `grafana-alloy > prometheusRemoteWrite > scrapePodsAnnotated > shardByNode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 321x duplication and high AMP ingestion
+
+### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics"></a>6.17. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1595,56 +1619,56 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeInterval ) | No      | string  | No         | -          | -                 |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeTimeout )   | No      | string  | No         | -          | -                 |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_address"></a>6.16.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > address`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_address"></a>6.17.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > address`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_enabled"></a>6.16.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > enabled`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_enabled"></a>6.17.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_jobLabel"></a>6.16.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > jobLabel`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_jobLabel"></a>6.17.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > jobLabel`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_metricsPath"></a>6.16.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > metricsPath`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_metricsPath"></a>6.17.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > metricsPath`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_namespace"></a>6.16.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > namespace`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_namespace"></a>6.17.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > namespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeInterval"></a>6.16.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeInterval"></a>6.17.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeTimeout"></a>6.16.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeSelfRemoteWriteMetrics_scrapeTimeout"></a>6.17.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeSelfRemoteWriteMetrics > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="prometheusRemoteWrite_scrapeTailscaleServices"></a>6.17. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices`
+### <a name="prometheusRemoteWrite_scrapeTailscaleServices"></a>6.18. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1666,7 +1690,7 @@ Must be one of:
 | - [scrapeInterval](#prometheusRemoteWrite_scrapeTailscaleServices_scrapeInterval ) | No      | string  | No         | -          | Scrape interval for Tailscale client metrics                                                                      |
 | - [scrapeTimeout](#prometheusRemoteWrite_scrapeTailscaleServices_scrapeTimeout )   | No      | string  | No         | -          | Scrape timeout for Tailscale client metrics                                                                       |
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_enabled"></a>6.17.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > enabled`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_enabled"></a>6.18.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1675,7 +1699,7 @@ Must be one of:
 
 **Description:** Enable scraping Tailscale client metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_jobLabel"></a>6.17.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > jobLabel`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_jobLabel"></a>6.18.2. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > jobLabel`
 
 |              |          |
 | ------------ | -------- |
@@ -1684,7 +1708,7 @@ Must be one of:
 
 **Description:** Job label for scraped metrics
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_labelSelector"></a>6.17.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > labelSelector`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_labelSelector"></a>6.18.3. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > labelSelector`
 
 |              |          |
 | ------------ | -------- |
@@ -1693,7 +1717,7 @@ Must be one of:
 
 **Description:** Label selector to find Tailscale ExternalName Services
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_metricsPath"></a>6.17.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > metricsPath`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_metricsPath"></a>6.18.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > metricsPath`
 
 |              |          |
 | ------------ | -------- |
@@ -1702,7 +1726,7 @@ Must be one of:
 
 **Description:** Path to scrape metrics from on each target
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_namespace"></a>6.17.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > namespace`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_namespace"></a>6.18.5. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > namespace`
 
 |              |          |
 | ------------ | -------- |
@@ -1711,7 +1735,7 @@ Must be one of:
 
 **Description:** Namespace where Tailscale ExternalName Services are created
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_portName"></a>6.17.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > portName`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_portName"></a>6.18.6. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > portName`
 
 |              |          |
 | ------------ | -------- |
@@ -1720,7 +1744,7 @@ Must be one of:
 
 **Description:** Service port name to scrape (filters targets to only this port)
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_relayAddress"></a>6.17.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > relayAddress`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_relayAddress"></a>6.18.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > relayAddress`
 
 |              |          |
 | ------------ | -------- |
@@ -1729,7 +1753,7 @@ Must be one of:
 
 **Description:** Address of the metrics relay that rewrites the Host header for Tailscale web client compatibility
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeInterval"></a>6.17.8. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeInterval`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeInterval"></a>6.18.8. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeInterval`
 
 |              |          |
 | ------------ | -------- |
@@ -1738,7 +1762,7 @@ Must be one of:
 
 **Description:** Scrape interval for Tailscale client metrics
 
-#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeTimeout"></a>6.17.9. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeTimeout`
+#### <a name="prometheusRemoteWrite_scrapeTailscaleServices_scrapeTimeout"></a>6.18.9. Property `grafana-alloy > prometheusRemoteWrite > scrapeTailscaleServices > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |
@@ -1747,7 +1771,7 @@ Must be one of:
 
 **Description:** Scrape timeout for Tailscale client metrics
 
-### <a name="prometheusRemoteWrite_scrapeTimeout"></a>6.18. Property `grafana-alloy > prometheusRemoteWrite > scrapeTimeout`
+### <a name="prometheusRemoteWrite_scrapeTimeout"></a>6.19. Property `grafana-alloy > prometheusRemoteWrite > scrapeTimeout`
 
 |              |          |
 | ------------ | -------- |

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -323,6 +323,12 @@ data:
     {{- $st := .Values.prometheusRemoteWrite.scrapeTimeout | default "10s" }}
     discovery.kubernetes "pods_metrics" {
       role = "pod"
+      {{- if (.Values.prometheusRemoteWrite.scrapePodsAnnotated).shardByNode }}
+      selectors {
+        role  = "pod"
+        field = "spec.nodeName=" + coalesce(sys.env("NODE_NAME"), sys.env("HOSTNAME"), constants.hostname)
+      }
+      {{- end }}
     }
 
     discovery.relabel "pods_metrics" {

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -437,16 +437,6 @@
             }
           }
         },
-        "scrapePodsAnnotated": {
-          "description": "Scrape pods annotated with prometheus.io/scrape=true",
-          "type": "object",
-          "properties": {
-            "shardByNode": {
-              "description": "When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 321x duplication and high AMP ingestion",
-              "type": "boolean"
-            }
-          }
-        },
         "scrapeCadvisor": {
           "description": "Scrape cadvisor metrics from each node (container_*)",
           "type": "object",
@@ -608,6 +598,16 @@
             },
             "shardByNode": {
               "description": "When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 23x duplication and high AMP ingestion",
+              "type": "boolean"
+            }
+          }
+        },
+        "scrapePodsAnnotated": {
+          "description": "Scrape pods annotated with prometheus.io/scrape=true",
+          "type": "object",
+          "properties": {
+            "shardByNode": {
+              "description": "When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 321x duplication and high AMP ingestion",
               "type": "boolean"
             }
           }

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -437,6 +437,16 @@
             }
           }
         },
+        "scrapePodsAnnotated": {
+          "description": "Scrape pods annotated with prometheus.io/scrape=true",
+          "type": "object",
+          "properties": {
+            "shardByNode": {
+              "description": "When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 321x duplication and high AMP ingestion",
+              "type": "boolean"
+            }
+          }
+        },
         "scrapeCadvisor": {
           "description": "Scrape cadvisor metrics from each node (container_*)",
           "type": "object",

--- a/grafana-alloy/values.yaml
+++ b/grafana-alloy/values.yaml
@@ -61,6 +61,10 @@ prometheusRemoteWrite:
     portName: "" # @schema description: Optional Kubernetes Service port name to scrape only (e.g. http for VMServiceScrape parity)
     metricRelabelConfigs: [] # @schema description: Optional metric relabel rules after scraping kube-state-metrics (Prometheus-style maps with source_labels, regex, action, target_label, replacement)
 
+  # Scrape pods with prometheus.io/scrape=true annotation for custom application metrics.
+  scrapePodsAnnotated: # @schema description: Scrape pods annotated with prometheus.io/scrape=true
+    shardByNode: false # @schema description: When true (recommended for DaemonSet), each pod scrapes only its own node to avoid 321x duplication and high AMP ingestion
+
   # Scrape kubelet for kubelet_* and kubernetes_build_info metrics.
   scrapeKubelet: # @schema description: Scrape kubelet metrics from each node (kubelet_*, kubernetes_build_info)
     enabled: true # @schema description: Enable scraping kubelet metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)


### PR DESCRIPTION
Add a shardByNode option to the pods_metrics pod discovery block in the grafana-alloy configmap template. Without this, every alloy daemonset pod performs cluster-wide pod discovery and caches the full list of cluster pods in memory- on a 321-node cluster this means every node independently holds and filters the same ~5000-pod list, multiplying the memory footprint 321x. The fix mirrors the existing shardByNode pattern already used for kubelet and cadvisor scrapers, adding a spec.nodeName field selector so each pod only discovers pods scheduled on its own node. 