### PR TITLE
feat(grafana): add configurable HTTP client timeout for central Grafana CR

### DIFF
--- a/grafana/Chart.yaml
+++ b/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: grafana
-version: 0.10.0
+version: 0.11.0

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -65,13 +65,14 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                              | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                |
-| ----------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------- |
-| - [apiKeySecret](#centralGrafana_apiKeySecret )       | No      | object  | No         | -          | -                                                                                                                |
-| - [enabled](#centralGrafana_enabled )                 | No      | boolean | No         | -          | Enable the resource provisioning into the Central Grafana workspace.                                             |
-| - [grafanaName](#centralGrafana_grafanaName )         | No      | string  | No         | -          | Name of the Grafana instance to create.                                                                          |
-| - [tenantNamespace](#centralGrafana_tenantNamespace ) | No      | string  | No         | -          | Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance. |
-| - [url](#centralGrafana_url )                         | No      | string  | No         | -          | URL of the Central Grafana instance (Argus Metrics Gateway). Must be a valid AWS Managed Grafana workspace URL.  |
+| Property                                              | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                            |
+| ----------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| - [apiKeySecret](#centralGrafana_apiKeySecret )       | No      | object          | No         | -          | -                                                                                                                                                                                                                                                            |
+| - [clientTimeout](#centralGrafana_clientTimeout )     | No      | integer or null | No         | -          | HTTP client timeout in seconds for the grafana-operator when talking to the Central Grafana workspace. When null (default), the operator uses its built-in default of 10s. Increase (e.g. 120) if folder finalization times out against AWS Managed Grafana. |
+| - [enabled](#centralGrafana_enabled )                 | No      | boolean         | No         | -          | Enable the resource provisioning into the Central Grafana workspace.                                                                                                                                                                                         |
+| - [grafanaName](#centralGrafana_grafanaName )         | No      | string          | No         | -          | Name of the Grafana instance to create.                                                                                                                                                                                                                      |
+| - [tenantNamespace](#centralGrafana_tenantNamespace ) | No      | string          | No         | -          | Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance.                                                                                                                                             |
+| - [url](#centralGrafana_url )                         | No      | string          | No         | -          | URL of the Central Grafana instance (Argus Metrics Gateway). Must be a valid AWS Managed Grafana workspace URL.                                                                                                                                              |
 
 ### <a name="centralGrafana_apiKeySecret"></a>4.1. Property `grafana > centralGrafana > apiKeySecret`
 
@@ -104,7 +105,20 @@ Must be one of:
 
 **Description:** Name of the secret containing the Admin API key for the Central Grafana instance.
 
-### <a name="centralGrafana_enabled"></a>4.2. Property `grafana > centralGrafana > enabled`
+### <a name="centralGrafana_clientTimeout"></a>4.2. Property `grafana > centralGrafana > clientTimeout`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `integer or null` |
+| **Required** | No                |
+
+**Description:** HTTP client timeout in seconds for the grafana-operator when talking to the Central Grafana workspace. When null (default), the operator uses its built-in default of 10s. Increase (e.g. 120) if folder finalization times out against AWS Managed Grafana.
+
+| Restrictions |        |
+| ------------ | ------ |
+| **Minimum**  | &ge; 1 |
+
+### <a name="centralGrafana_enabled"></a>4.3. Property `grafana > centralGrafana > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -113,7 +127,7 @@ Must be one of:
 
 **Description:** Enable the resource provisioning into the Central Grafana workspace.
 
-### <a name="centralGrafana_grafanaName"></a>4.3. Property `grafana > centralGrafana > grafanaName`
+### <a name="centralGrafana_grafanaName"></a>4.4. Property `grafana > centralGrafana > grafanaName`
 
 |              |          |
 | ------------ | -------- |
@@ -122,7 +136,7 @@ Must be one of:
 
 **Description:** Name of the Grafana instance to create.
 
-### <a name="centralGrafana_tenantNamespace"></a>4.4. Property `grafana > centralGrafana > tenantNamespace`
+### <a name="centralGrafana_tenantNamespace"></a>4.5. Property `grafana > centralGrafana > tenantNamespace`
 
 |              |          |
 | ------------ | -------- |
@@ -131,7 +145,7 @@ Must be one of:
 
 **Description:** Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance.
 
-### <a name="centralGrafana_url"></a>4.5. Property `grafana > centralGrafana > url`
+### <a name="centralGrafana_url"></a>4.6. Property `grafana > centralGrafana > url`
 
 |              |          |
 | ------------ | -------- |

--- a/grafana/templates/central-grafana.yaml
+++ b/grafana/templates/central-grafana.yaml
@@ -9,6 +9,10 @@ metadata:
     name: {{ $centralGrafana.grafanaName | default "central-grafana" | quote }}
   name: {{ $centralGrafana.grafanaName | default "central-grafana" | quote }}
 spec:
+  {{- if $centralGrafana.clientTimeout }}
+  client:
+    timeout: {{ $centralGrafana.clientTimeout }}
+  {{- end }}
   external:
     apiKey:
       key: {{ $apiKeySecret.key | default "GF_SECURITY_ADMIN_APIKEY" | quote }}

--- a/grafana/values.schema.json
+++ b/grafana/values.schema.json
@@ -38,14 +38,6 @@
             }
           }
         },
-        "enabled": {
-          "description": "Enable the resource provisioning into the Central Grafana workspace.",
-          "type": "boolean"
-        },
-        "grafanaName": {
-          "description": "Name of the Grafana instance to create.",
-          "type": "string"
-        },
         "clientTimeout": {
           "description": "HTTP client timeout in seconds for the grafana-operator when talking to the Central Grafana workspace. When null (default), the operator uses its built-in default of 10s. Increase (e.g. 120) if folder finalization times out against AWS Managed Grafana.",
           "type": [
@@ -53,6 +45,14 @@
             "null"
           ],
           "minimum": 1
+        },
+        "enabled": {
+          "description": "Enable the resource provisioning into the Central Grafana workspace.",
+          "type": "boolean"
+        },
+        "grafanaName": {
+          "description": "Name of the Grafana instance to create.",
+          "type": "string"
         },
         "tenantNamespace": {
           "description": "Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance.",

--- a/grafana/values.schema.json
+++ b/grafana/values.schema.json
@@ -46,6 +46,14 @@
           "description": "Name of the Grafana instance to create.",
           "type": "string"
         },
+        "clientTimeout": {
+          "description": "HTTP client timeout in seconds for the grafana-operator when talking to the Central Grafana workspace. When null (default), the operator uses its built-in default of 10s. Increase (e.g. 120) if folder finalization times out against AWS Managed Grafana.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
         "tenantNamespace": {
           "description": "Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance.",
           "type": "string"

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -62,3 +62,4 @@ centralGrafana:
     key: GF_SECURITY_ADMIN_APIKEY # @schema description: Key of the secret containing the Admin API key for the Central Grafana instance.
   url: https://g-0000000000.grafana-workspace.us-west-2.amazonaws.com # @schema description: URL of the Central Grafana instance (Argus Metrics Gateway). Must be a valid AWS Managed Grafana workspace URL.; pattern: ^https://g-[a-f0-9]+\.grafana-workspace\.[a-z0-9]+(-[a-z0-9]+)*\.amazonaws\.com$
   tenantNamespace: default # @schema description: Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance.
+  clientTimeout: null # @schema description: HTTP client timeout in seconds for the grafana-operator when talking to the Central Grafana workspace. When null (default), the operator uses its built-in default of 10s. Increase (e.g. 120) if folder finalization times out against AWS Managed Grafana.; type: ["integer", "null"]; minimum: 1


### PR DESCRIPTION
Jira: https://czi.atlassian.net/browse/CCIE-6556

## Summary

- Adds `centralGrafana.clientTimeout` (optional integer, seconds) to the grafana chart's `values.yaml` and JSON schema.
- When set, `central-grafana.yaml` emits `spec.client.timeout` on the external `Grafana` CR so the grafana-operator uses a longer HTTP deadline when communicating with AWS Managed Grafana.
- When null/unset (the default), `spec.client` is omitted entirely—existing behavior is completely unchanged.

## Motivation

The grafana-operator defaults to a 10s HTTP client timeout. `DELETE /api/folders/...?forceDeleteRules=true` calls against AMG can occasionally exceed that, causing `Client.Timeout exceeded while awaiting headers` errors on `GrafanaFolder` finalization and leaving finalizers permanently stuck. Raising `centralGrafana.clientTimeout` (e.g. to 120) in argus-infra-stacks values gives the operator enough headroom for tail-latency AMG responses.

## Test plan

- [ ] `helm lint grafana/` passes (verified locally).
- [ ] `helm template` with `centralGrafana.clientTimeout=120` shows `spec.client.timeout: 120` on the central Grafana CR.
- [ ] `helm template` without the key shows no `spec.client` block (no behavioral change for existing clusters).