### PR TITLE
feat(stack): expose Job spec.completionMode

### DIFF
--- a/stack/templates/job.yaml
+++ b/stack/templates/job.yaml
@@ -34,6 +34,9 @@ spec:
   {{- if .Values.parallelism }}
   parallelism: {{ .Values.parallelism }}
   {{- end }}
+  {{- if .Values.completionMode }}
+  completionMode: {{ .Values.completionMode }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/stack/tests/job_test.yaml
+++ b/stack/tests/job_test.yaml
@@ -11,6 +11,7 @@ tests:
           backoffLimit: 2
           completions: 5
           parallelism: 3
+          completionMode: Indexed
           serviceAccount:
             create: true
             annotations:
@@ -61,6 +62,10 @@ tests:
         equal:
           path: spec.parallelism
           value: 3
+      - documentIndex: 0
+        equal:
+          path: spec.completionMode
+          value: Indexed
       - documentIndex: 1
         containsDocument:
           apiVersion: v1

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -451,6 +451,7 @@ jobs: # @schema patternProperties: { "^.*$": {"$ref": "#/properties/global", "ty
   #   backoffLimit: 2
   #   completions: 5
   #   parallelism: 3
+  #   completionMode: Indexed  # set to "Indexed" to make Kubernetes inject JOB_COMPLETION_INDEX into each pod
   #   serviceAccount:
   #     create: true
   #     annotations:


### PR DESCRIPTION
## Summary

Adds a `completionMode` field to the `jobs.<name>.*` config so chart users can render Jobs with `completionMode: Indexed`.

Indexed completion mode makes Kubernetes inject `JOB_COMPLETION_INDEX` into each pod, which is the standard way to shard a parallel workload (each pod handles 1/N of the work deterministically). Today the chart exposes `completions` and `parallelism` but not `completionMode`, which means anyone wanting an Indexed Job has to write a custom template bypassing the chart's `job.yaml` entirely, as done in https://github.com/evolutionaryscale/evolutionaryscale/pull/11125

## Why

We're using this in `biohub-platform` for cellxstate-ingest's image render phase. Each of N pods reads `JOB_COMPLETION_INDEX` and processes a hash-shard of the leaf zarr set. Without `completionMode: Indexed`, pods are non-indexed and the env var isn't injected, so we wrote a custom template — works but duplicates ~80 lines of the chart's job.yaml. This change lets us drop the custom template and just say `completionMode: Indexed` in our values.

## What changed

- `stack/templates/job.yaml`: conditionally render `completionMode: {{ .Values.completionMode }}` after `parallelism`. No-op when unset (backwards-compatible).
- `stack/values.yaml`: document the field in the `jobs.<name>.*` example.
- `stack/tests/job_test.yaml`: extend the existing job test to set `completionMode: Indexed` and assert it lands on the rendered Job.

## Test plan

- [x] `helm template` on the chart with `jobs.j1.completionMode: Indexed` produces `spec.completionMode: Indexed` on the rendered Job manifest.
- [ ] CI helm-unittest passes the extended `job_test.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)