### PR TITLE
feat: Pre-commit hooks for secret and credential scanning

### DIFF
--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,28 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
+          GITLEAKS_ENABLE_SUMMARY: "true"

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -11,18 +11,36 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
   security-events: write
 
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: 8.30.1
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
-          GITLEAKS_ENABLE_SUMMARY: "true"
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan git history
+        run: gitleaks detect --redact --verbose --config .gitleaks.toml --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+
+      - name: Upload report artifact
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks.sarif

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+title = "argo-helm-charts gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "argo-helm-charts allowlist"
+regexTarget = "line"
+
+paths = [
+  '''(?i)^test-fixtures/''',
+  '''(?i)^.*/tests/.*''',
+  '''(?i)^.*/values\.schema\.json$''',
+  '''(?i)^.*/CHANGELOG\.md$''',
+  '''(?i)^\.release-please-manifest\.json$''',
+]
+
+regexes = [
+  '''\{\{[^}]*\}\}''',
+  '''\$__file\{[^}]*\}''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,29 +3,53 @@ title = "argo-helm-charts gitleaks config"
 [extend]
 useDefault = true
 
-# Custom rule — fills a gap in gitleaks defaults.
-# Anthropic, OpenAI, AWS, GitHub, Slack, Datadog, Grafana legacy/cloud, etc.
-# are all already covered by gitleaks' built-in rules.
-
 [[rules]]
 id = "grafana-service-account-token"
 description = "Grafana service account token (glsa_<id>_<crc32>)"
 regex = '''\bglsa_[A-Za-z0-9]{22}_[a-fA-F0-9]{8}\b'''
 keywords = ["glsa_"]
 
+[[rules]]
+id = "url-userinfo-password"
+description = "Credential embedded in a URL (scheme://user:password@host)"
+regex = '''\b[a-zA-Z][a-zA-Z0-9+.-]{1,15}:\/\/[^\s:\/@'"]+:([^\s@\/'"]{4,})@'''
+secretGroup = 1
+keywords = ["://"]
+
+[[rules]]
+id = "authorization-bearer-token"
+description = "Opaque bearer token in an Authorization header"
+regex = '''(?i)\bauthorization\s*[:=]\s*["']?bearer\s+([A-Za-z0-9._\-]{20,})'''
+secretGroup = 1
+keywords = ["bearer"]
+
+[[rules]]
+id = "password-assignment-dq"
+description = "Hardcoded password/passwd/pwd assignment (double-quoted)"
+regex = '''(?i)\b(?:password|passwd|pwd)\s*[:=]\s*"([^"]{8,})"'''
+secretGroup = 1
+keywords = ["password", "passwd", "pwd"]
+
+[[rules]]
+id = "password-assignment-sq"
+description = "Hardcoded password/passwd/pwd assignment (single-quoted)"
+regex = '''(?i)\b(?:password|passwd|pwd)\s*[:=]\s*'([^']{8,})\''''
+secretGroup = 1
+keywords = ["password", "passwd", "pwd"]
+
 [allowlist]
 description = "argo-helm-charts allowlist"
-regexTarget = "line"
+regexTarget = "secret"
 
 paths = [
   '''(?i)^test-fixtures/''',
   '''(?i)^.*/tests/.*''',
-  '''(?i)^.*/values\.schema\.json$''',
   '''(?i)^.*/CHANGELOG\.md$''',
-  '''(?i)^\.release-please-manifest\.json$''',
 ]
 
 regexes = [
-  '''\{\{[^}]*\}\}''',
-  '''\$__file\{[^}]*\}''',
+  '''^(?:\{\{[^}]+\}\}\s*)+$''',
+  '''^\$__file\{[^}]+\}$''',
+  '''^\$\{[^}]+\}$''',
+  '''^<path:[^>]+>$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,19 +37,37 @@ regex = '''(?i)\b(?:password|passwd|pwd)\s*[:=]\s*'([^']{8,})\''''
 secretGroup = 1
 keywords = ["password", "passwd", "pwd"]
 
-[allowlist]
-description = "argo-helm-charts allowlist"
-regexTarget = "secret"
-
+[[allowlists]]
+description = "exempt fixture and changelog paths"
 paths = [
   '''(?i)^test-fixtures/''',
   '''(?i)^.*/tests/.*''',
   '''(?i)^.*/CHANGELOG\.md$''',
 ]
 
+[[allowlists]]
+description = "exempt pure interpolation values"
+regexTarget = "secret"
 regexes = [
   '''^(?:\{\{[^}]+\}\}\s*)+$''',
   '''^\$__file\{[^}]+\}$''',
   '''^\$\{[^}]+\}$''',
   '''^<path:[^>]+>$''',
+]
+
+[[allowlists]]
+description = "exempt well-known documentation placeholder values"
+stopwords = [
+  "my-password",
+  "my_password",
+  "your-password",
+  "your_password",
+  "changeme",
+  "change-me",
+  "change_me",
+  "placeholder",
+  "redacted",
+  "<password",
+  "REPLACE_ME",
+  "REPLACE-ME",
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,6 +3,16 @@ title = "argo-helm-charts gitleaks config"
 [extend]
 useDefault = true
 
+# Custom rule — fills a gap in gitleaks defaults.
+# Anthropic, OpenAI, AWS, GitHub, Slack, Datadog, Grafana legacy/cloud, etc.
+# are all already covered by gitleaks' built-in rules.
+
+[[rules]]
+id = "grafana-service-account-token"
+description = "Grafana service account token (glsa_<id>_<crc32>)"
+regex = '''\bglsa_[A-Za-z0-9]{22}_[a-fA-F0-9]{8}\b'''
+keywords = ["glsa_"]
+
 [allowlist]
 description = "argo-helm-charts allowlist"
 regexTarget = "line"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     hooks:
       - id: gitleaks
         name: Detect hardcoded secrets
-        description: Run gitleaks against staged changes (uses the brew-installed binary)
-        entry: gitleaks git --pre-commit --redact --staged --verbose
+        description: Scan the working tree for secrets (catches unstaged edits too, not just staged)
+        entry: gitleaks detect --no-banner --redact --verbose --no-git --source .
         language: system
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: gitleaks
         name: Detect hardcoded secrets
         description: Scan the working tree for secrets (catches unstaged edits too, not just staged)
-        entry: gitleaks detect --no-banner --redact --verbose --no-git --source .
+        entry: gitleaks detect --no-banner --redact --verbose --no-git --source . --config .gitleaks.toml
         language: system
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: local
+    hooks:
+      - id: gitleaks
+        name: Detect hardcoded secrets
+        description: Run gitleaks against staged changes (uses the brew-installed binary)
+        entry: gitleaks git --pre-commit --redact --staged --verbose
+        language: system
+        pass_filenames: false
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+        exclude: '^.*/templates/.*\.ya?ml$'
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=500']

--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ The `stack` chart is the standard chart for used when deploying an Argus applica
     - this can be run from the root directory to run tests for all charts
     - or from any helm chart directory to run tests just for that chart
 
+### Pre-commit hooks (recommended)
+
+This repo uses [pre-commit](https://pre-commit.com/) with [gitleaks](https://github.com/gitleaks/gitleaks) to prevent credential leaks. Set up once per clone:
+
+```shell
+brew install pre-commit gitleaks
+pre-commit install
+```
+
+Hooks then run automatically on `git commit`. To scan the whole repo manually:
+
+```shell
+pre-commit run --all-files
+gitleaks detect --no-banner --redact
+```
+
+The same gitleaks scan runs in CI on every PR and blocks merge on any finding.
+
 ### Testing an un-published chart in Argus
 
 You can create a stack from a chart that has not been published.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ brew install pre-commit gitleaks
 pre-commit install
 ```
 
-Hooks then run automatically on `git commit`. To scan the whole repo manually:
+Hooks then run automatically on `git commit` and scan the working tree (staged, unstaged, and untracked files). On a finding, the hook prints the rule ID, file, and line; the secret itself is redacted to keep it out of terminal scrollback and screenshots.
+
+To run scans manually:
 
 ```shell
-pre-commit run --all-files
-gitleaks detect --no-banner --redact
+pre-commit run --all-files            # working tree — matches what the commit hook does
+gitleaks detect --no-banner --redact  # full git history — catches anything already committed
 ```
 
 The same gitleaks scan runs in CI on every PR and blocks merge on any finding.

--- a/README.md
+++ b/README.md
@@ -13,23 +13,32 @@ The `stack` chart is the standard chart for used when deploying an Argus applica
 
 ### Pre-commit hooks (recommended)
 
-This repo uses [pre-commit](https://pre-commit.com/) with [gitleaks](https://github.com/gitleaks/gitleaks) to prevent credential leaks. Set up once per clone:
+This repo uses [pre-commit](https://pre-commit.com/) with [gitleaks](https://github.com/gitleaks/gitleaks) to prevent credential leaks. Install both tools once per clone, then activate the hooks:
 
 ```shell
+# macOS
 brew install pre-commit gitleaks
+
+# Linux / Windows — see upstream install docs:
+#   https://pre-commit.com/#installation
+#   https://github.com/gitleaks/gitleaks#installing
+
 pre-commit install
 ```
 
-Hooks then run automatically on `git commit` and scan the working tree (staged, unstaged, and untracked files). On a finding, the hook prints the rule ID, file, and line; the secret itself is redacted to keep it out of terminal scrollback and screenshots.
+Hooks then run automatically on `git commit` and scan the working tree (staged, unstaged, and untracked files) against the rules in [`.gitleaks.toml`](./.gitleaks.toml). On a finding, the hook prints the rule ID, file, and line; the secret itself is redacted to keep it out of terminal scrollback and screenshots.
 
 To run scans manually:
 
 ```shell
-pre-commit run --all-files            # working tree — matches what the commit hook does
-gitleaks detect --no-banner --redact  # full git history — catches anything already committed
+# Working tree scan — same as the commit hook (uses .gitleaks.toml)
+pre-commit run --all-files
+
+# Full git history scan — catches anything already committed
+gitleaks detect --no-banner --redact --config .gitleaks.toml
 ```
 
-The same gitleaks scan runs in CI on every PR and blocks merge on any finding.
+CI runs the same `gitleaks detect` against the full git history on every PR and on pushes to `main`, using the same [`.gitleaks.toml`](./.gitleaks.toml). The check fails on any finding; whether that blocks merge depends on branch protection rules. Note that the CI scan covers git history while the local pre-commit hook covers the working tree — so each catches things the other can't, and you should run both.
 
 ### Testing an un-published chart in Argus
 


### PR DESCRIPTION
This PR adds a pre-commit hook that validates no credentials escape using gitleaks in the current work tree; it also adds a github workflow to validate the same after the commit. Known patterns for password placeholders are whitelisted.

Both github workflow and a pre-commit hook both indicate which file violates the constraints without displaying the actual leaked secret.

This is meant to complement the existing credential leakage scan in github on the prevention side.

<img width="1119" height="531" alt="image" src="https://github.com/user-attachments/assets/71188c58-ca59-49d3-b893-0a0a8e1e6f77" />
