### PR TITLE
feat(stack): forward suspend/completions/parallelism/completionMode to CronJob

### DIFF
--- a/stack/Chart.yaml
+++ b/stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.36.0
+version: 2.37.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stack/templates/cronjob.yaml
+++ b/stack/templates/cronjob.yaml
@@ -21,10 +21,22 @@ spec:
   {{- if .Values.concurrencyPolicy }}
   concurrencyPolicy: {{ .Values.concurrencyPolicy }}
   {{- end }}
+  {{- if hasKey .Values "suspend" }}
+  suspend: {{ .Values.suspend }}
+  {{- end }}
   jobTemplate:
     spec:
       {{- if hasKey .Values "backoffLimit" }}
       backoffLimit: {{ .Values.backoffLimit }}
+      {{- end }}
+      {{- if .Values.completionMode }}
+      completionMode: {{ .Values.completionMode }}
+      {{- end }}
+      {{- if hasKey .Values "completions" }}
+      completions: {{ .Values.completions }}
+      {{- end }}
+      {{- if hasKey .Values "parallelism" }}
+      parallelism: {{ .Values.parallelism }}
       {{- end }}
       template:
         spec:

--- a/stack/tests/cronjob_test.yaml
+++ b/stack/tests/cronjob_test.yaml
@@ -209,6 +209,62 @@ tests:
       - hasDocuments:
           count: 1
 
+  - it: should forward suspend/completions/parallelism/completionMode
+    set:
+      cronJobs:
+        indexed-job:
+          schedule: "0 0 1 1 *"
+          suspend: true
+          completions: 4
+          parallelism: 4
+          completionMode: Indexed
+          image:
+            repository: my-repo
+            tag: sha-mytag
+          command: ["hello-world"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        equal:
+          path: spec.suspend
+          value: true
+      - documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.completions
+          value: 4
+      - documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.parallelism
+          value: 4
+      - documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.completionMode
+          value: Indexed
+
+  - it: should omit suspend/completions/parallelism/completionMode when unset
+    set:
+      cronJobs:
+        plain-job:
+          schedule: "*/5 * * * *"
+          image:
+            repository: my-repo
+            tag: sha-mytag
+          command: ["hello-world"]
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: spec.suspend
+      - documentIndex: 0
+        notExists:
+          path: spec.jobTemplate.spec.completions
+      - documentIndex: 0
+        notExists:
+          path: spec.jobTemplate.spec.parallelism
+      - documentIndex: 0
+        notExists:
+          path: spec.jobTemplate.spec.completionMode
+
   - it: should include argus/env-name label when argusMetadata.envName is set
     set:
       global:

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -435,6 +435,10 @@ cronJobs: # @schema patternProperties: { "^.*$": {"$ref": "#/properties/global",
   # cronJob1:
   #   concurrencyPolicy: Forbid
   #   schedule: "* * * * *"
+  #   suspend: false          # set to true to pause scheduled runs (on-demand-only CronJobs paired with `kubectl create job --from=cronjob/...`)
+  #   completions: 4          # forwarded to spec.jobTemplate.spec.completions
+  #   parallelism: 4          # forwarded to spec.jobTemplate.spec.parallelism
+  #   completionMode: Indexed # forwarded to spec.jobTemplate.spec.completionMode (Kubernetes injects JOB_COMPLETION_INDEX into each pod)
   #   serviceAccount:
   #     create: true
   #   image:


### PR DESCRIPTION
## Summary

Mirrors the support `templates/job.yaml` already has for these fields, now on the CronJob template.

- `suspend` — CronJob-level (`spec.suspend`)
- `completions` / `parallelism` / `completionMode` — jobTemplate-level (`spec.jobTemplate.spec.*`)

Bumps chart 2.36.0 → 2.37.0.

## Why

Lets a CronJob act as a **suspended template for on-demand multi-pod Jobs**. The pattern:

```yaml
cronJobs:
  long-running-thing:
    schedule: "0 0 1 1 *"   # never auto-fires
    suspend: true            # belt + suspenders
    completionMode: Indexed  # multi-pod sharded
    parallelism: 4
    completions: 4
    image: { ... }
    env: [ ... ]
```

Operators trigger on-demand via:

```bash
kubectl create job --from=cronjob/<release>-stack-long-running-thing run-$(date +%s)
```

The Job inherits the CronJob's `spec.jobTemplate.spec` — including the indexed/parallel knobs — and uses the CronJob's current image tag (Helm-managed).

We hit this need for the cellxstate ingestion pipeline in biohub-platform: a multi-hour, multi-pod, retry-prone Job that's currently a Helm `post-install` hook. The hook approach has been blocking ArgoCD sync when a Job ends up stuck `Terminating` (e.g. `ImagePullBackOff` pods after an image-tag bump that never built the ingest container). Moving it to this on-demand CronJob pattern decouples ingest runs from sync events.

This is the same approach as #458 (which added `completionMode` to regular Jobs and was released as 2.36.0).

## Test plan

- [x] Added two helm-unittest cases in `stack/tests/cronjob_test.yaml` — one with all four fields set (assert each is rendered to the right spec path), one with them unset (assert each is absent from the rendered output).
- [ ] Consumer-side validation in biohub-platform once 2.37.0 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)