### PR TITLE
feat: Switch Envoy to ClusterIP (to drop Classic Load Balancer)

### DIFF
--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -13,6 +13,7 @@
 | - [alternateNames](#alternateNames ) | No      | array  | No         | -          | -                 |
 | - [baseDomain](#baseDomain )         | No      | string | No         | -          | -                 |
 | - [clusterName](#clusterName )       | No      | string | No         | -          | -                 |
+| - [envoyService](#envoyService )     | No      | object | No         | -          | -                 |
 | - [gatewayName](#gatewayName )       | No      | string | No         | -          | -                 |
 | - [geoip](#geoip )                   | No      | object | No         | -          | -                 |
 | - [serviceAccount](#serviceAccount ) | No      | object | No         | -          | -                 |
@@ -46,14 +47,33 @@
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayName"></a>4. Property `envoy-gateway-resources > gatewayName`
+## <a name="envoyService"></a>4. Property `envoy-gateway-resources > envoyService`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                      | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [type](#envoyService_type ) | No      | string | No         | -          | -                 |
+
+### <a name="envoyService_type"></a>4.1. Property `envoy-gateway-resources > envoyService > type`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="geoip"></a>5. Property `envoy-gateway-resources > geoip`
+## <a name="gatewayName"></a>5. Property `envoy-gateway-resources > gatewayName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="geoip"></a>6. Property `envoy-gateway-resources > geoip`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -66,7 +86,7 @@
 | - [blockedCountries](#geoip_blockedCountries ) | No      | array of string | No         | -          | -                 |
 | - [enabled](#geoip_enabled )                   | No      | boolean         | No         | -          | -                 |
 
-### <a name="geoip_blockedCountries"></a>5.1. Property `envoy-gateway-resources > geoip > blockedCountries`
+### <a name="geoip_blockedCountries"></a>6.1. Property `envoy-gateway-resources > geoip > blockedCountries`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -85,21 +105,21 @@
 | ------------------------------------------------------- | ----------- |
 | [blockedCountries items](#geoip_blockedCountries_items) | -           |
 
-#### <a name="geoip_blockedCountries_items"></a>5.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
+#### <a name="geoip_blockedCountries_items"></a>6.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="geoip_enabled"></a>5.2. Property `envoy-gateway-resources > geoip > enabled`
+### <a name="geoip_enabled"></a>6.2. Property `envoy-gateway-resources > geoip > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="serviceAccount"></a>6. Property `envoy-gateway-resources > serviceAccount`
+## <a name="serviceAccount"></a>7. Property `envoy-gateway-resources > serviceAccount`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -112,7 +132,7 @@
 | - [annotations](#serviceAccount_annotations ) | No      | object | No         | -          | -                 |
 | - [name](#serviceAccount_name )               | No      | string | No         | -          | -                 |
 
-### <a name="serviceAccount_annotations"></a>6.1. Property `envoy-gateway-resources > serviceAccount > annotations`
+### <a name="serviceAccount_annotations"></a>7.1. Property `envoy-gateway-resources > serviceAccount > annotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -120,7 +140,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-### <a name="serviceAccount_name"></a>6.2. Property `envoy-gateway-resources > serviceAccount > name`
+### <a name="serviceAccount_name"></a>7.2. Property `envoy-gateway-resources > serviceAccount > name`
 
 |              |          |
 | ------------ | -------- |

--- a/envoy-gateway-resources/templates/envoyproxy.yaml
+++ b/envoy-gateway-resources/templates/envoyproxy.yaml
@@ -10,7 +10,7 @@ spec:
       envoyServiceAccount:
         name: {{ .Values.serviceAccount.name }}
       envoyService:
-        type: ClusterIP
+        type: {{ .Values.envoyService.type }}
       {{- if .Values.geoip.enabled }}
       envoyDeployment:
         patch:

--- a/envoy-gateway-resources/templates/envoyproxy.yaml
+++ b/envoy-gateway-resources/templates/envoyproxy.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.geoip.enabled }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -10,6 +9,9 @@ spec:
     kubernetes:
       envoyServiceAccount:
         name: {{ .Values.serviceAccount.name }}
+      envoyService:
+        type: ClusterIP
+      {{- if .Values.geoip.enabled }}
       envoyDeployment:
         patch:
           type: StrategicMerge
@@ -44,4 +46,4 @@ spec:
                   volumes:
                   - name: geoip-db
                     emptyDir: {}
-{{- end }}
+      {{- end }}

--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -12,13 +12,11 @@ metadata:
   namespace: envoy-gateway
 spec:
   gatewayClassName: eg
-{{- if .Values.geoip.enabled }}
   infrastructure:
     parametersRef:
       group: gateway.envoyproxy.io
       kind: EnvoyProxy
       name: {{ .Values.gatewayName }}-proxy
-{{- end }}
   listeners:
     - name: http
       protocol: HTTP

--- a/envoy-gateway-resources/tests/envoyproxy_test.yaml
+++ b/envoy-gateway-resources/tests/envoyproxy_test.yaml
@@ -22,7 +22,7 @@ tests:
           path: metadata.namespace
           value: envoy-gateway
 
-  - it: should set envoyService.type to ClusterIP
+  - it: should default envoyService.type to ClusterIP
     set:
       geoip.enabled: false
     asserts:
@@ -30,13 +30,22 @@ tests:
           path: spec.provider.kubernetes.envoyService.type
           value: ClusterIP
 
-  - it: should set envoyService.type to ClusterIP when geoip is enabled too
+  - it: should default envoyService.type to ClusterIP when geoip is enabled too
     set:
       geoip.enabled: true
     asserts:
       - equal:
           path: spec.provider.kubernetes.envoyService.type
           value: ClusterIP
+
+  - it: should honor envoyService.type override
+    set:
+      geoip.enabled: false
+      envoyService.type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.type
+          value: LoadBalancer
 
   - it: should omit envoyDeployment patch when geoip is disabled
     set:

--- a/envoy-gateway-resources/tests/envoyproxy_test.yaml
+++ b/envoy-gateway-resources/tests/envoyproxy_test.yaml
@@ -3,15 +3,49 @@ templates:
   - envoyproxy.yaml
 
 tests:
-  # Test when geoip is disabled
-  - it: should not render when geoip.enabled is false
+  - it: should render EnvoyProxy regardless of geoip.enabled
+    set:
+      geoip.enabled: false
+      gatewayName: test-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: EnvoyProxy
+      - equal:
+          path: apiVersion
+          value: gateway.envoyproxy.io/v1alpha1
+      - equal:
+          path: metadata.name
+          value: test-gateway-proxy
+      - equal:
+          path: metadata.namespace
+          value: envoy-gateway
+
+  - it: should set envoyService.type to ClusterIP
     set:
       geoip.enabled: false
     asserts:
-      - hasDocuments:
-          count: 0
+      - equal:
+          path: spec.provider.kubernetes.envoyService.type
+          value: ClusterIP
 
-  # Basic EnvoyProxy resource tests
+  - it: should set envoyService.type to ClusterIP when geoip is enabled too
+    set:
+      geoip.enabled: true
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.type
+          value: ClusterIP
+
+  - it: should omit envoyDeployment patch when geoip is disabled
+    set:
+      geoip.enabled: false
+    asserts:
+      - notExists:
+          path: spec.provider.kubernetes.envoyDeployment
+
+  # Basic EnvoyProxy resource tests when geoip enabled
   - it: should render EnvoyProxy when geoip.enabled is true
     set:
       geoip.enabled: true
@@ -39,7 +73,7 @@ tests:
           path: spec.provider.type
           value: Kubernetes
 
-  - it: should use StrategicMerge patch type
+  - it: should use StrategicMerge patch type when geoip enabled
     set:
       geoip.enabled: true
     asserts:

--- a/envoy-gateway-resources/tests/gateway_test.yaml
+++ b/envoy-gateway-resources/tests/gateway_test.yaml
@@ -64,28 +64,17 @@ tests:
           path: spec.gatewayClassName
           value: eg
 
-  # GeoIP infrastructure parametersRef tests
-  - it: should not include infrastructure parametersRef when geoip.enabled is false
+  - it: should always include infrastructure parametersRef (regardless of geoip)
     set:
       gatewayName: test-gateway
       clusterName: test-cluster
       geoip.enabled: false
     documentIndex: 1
     asserts:
-      - notExists:
-          path: spec.infrastructure
-
-  - it: should include infrastructure parametersRef when geoip.enabled is true
-    set:
-      gatewayName: test-gateway
-      clusterName: test-cluster
-      geoip.enabled: true
-    documentIndex: 1
-    asserts:
       - isNotEmpty:
           path: spec.infrastructure.parametersRef
 
-  - it: should reference EnvoyProxy resource when geoip.enabled is true
+  - it: should reference EnvoyProxy resource
     set:
       gatewayName: test-gateway
       clusterName: test-cluster

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -13,6 +13,14 @@
     "clusterName": {
       "type": "string"
     },
+    "envoyService": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      }
+    },
     "gatewayName": {
       "type": "string"
     },

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -7,6 +7,9 @@ serviceAccount:
   name: envoy-gateway-proxy
   annotations: {}
 
+envoyService:
+  type: ClusterIP
+
 geoip:
   enabled: true
   blockedCountries:


### PR DESCRIPTION
By default, Envoy data plane service is created as LoadBalancer which uses in-tree legacy AWS provisioner and creates a Classic ELB. This PR allows us to switch to ClusterIP by default and use ALB controller annotations to create NLBs.

[CCIE-6666]

[CCIE-6666]: https://czi.atlassian.net/browse/CCIE-6666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ