### PR TITLE
feat(stack): render podAnnotations + podLabels on CronJob jobTemplate

### DIFF
--- a/stack/Chart.yaml
+++ b/stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.37.0
+version: 2.38.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stack/templates/cronjob.yaml
+++ b/stack/templates/cronjob.yaml
@@ -39,6 +39,16 @@ spec:
       parallelism: {{ .Values.parallelism }}
       {{- end }}
       template:
+        metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "service.labels" . | nindent 12 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           serviceAccountName: {{ include "service.serviceAccountName" . }}
           containers:

--- a/stack/tests/cronjob_test.yaml
+++ b/stack/tests/cronjob_test.yaml
@@ -265,6 +265,34 @@ tests:
         notExists:
           path: spec.jobTemplate.spec.completionMode
 
+  - it: should forward podAnnotations + podLabels to jobTemplate pod metadata
+    set:
+      cronJobs:
+        annotated-job:
+          schedule: "*/5 * * * *"
+          podAnnotations:
+            karpenter.sh/do-not-disrupt: "true"
+            custom-annotation: "value"
+          podLabels:
+            custom-label: "value"
+          image:
+            repository: my-repo
+            tag: sha-mytag
+          command: ["hello-world"]
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["karpenter.sh/do-not-disrupt"]
+          value: "true"
+      - documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["custom-annotation"]
+          value: "value"
+      - documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.template.metadata.labels["custom-label"]
+          value: "value"
+
   - it: should include argus/env-name label when argusMetadata.envName is set
     set:
       global:


### PR DESCRIPTION
## Summary

`cronjob.yaml` wasn't passing through `podAnnotations` / `podLabels` to `spec.jobTemplate.spec.template.metadata` at all. Any annotation set in values was silently dropped when rendering the CronJob.

This PR mirrors the rendering already done in `templates/job.yaml`.

Bumps chart 2.37.0 → 2.38.0.

## Why

We hit this in biohub-platform's cellxstate ingestion pipeline: a multi-hour multi-pod CronJob with `karpenter.sh/do-not-disrupt: "true"` set in `podAnnotations`. Karpenter was evicting our pods mid-render during node consolidation because the annotation was never on the actual pods — only the `batch.kubernetes.io/job-completion-index` annotation was making it through.

## Test plan

- [x] Added a helm-unittest case in `stack/tests/cronjob_test.yaml` that sets both `podAnnotations` and `podLabels` and asserts they render at `spec.jobTemplate.spec.template.metadata.{annotations,labels}`.
- [ ] Consumer-side validation in biohub-platform once 2.38.0 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)