### PR TITLE
feat(stack): forward ttlSecondsAfterFinished to CronJob jobTemplate

### DIFF
--- a/stack/templates/cronjob.yaml
+++ b/stack/templates/cronjob.yaml
@@ -26,6 +26,9 @@ spec:
   {{- end }}
   jobTemplate:
     spec:
+      {{- if .Values.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+      {{- end }}
       {{- if hasKey .Values "backoffLimit" }}
       backoffLimit: {{ .Values.backoffLimit }}
       {{- end }}

--- a/stack/tests/cronjob_test.yaml
+++ b/stack/tests/cronjob_test.yaml
@@ -209,7 +209,7 @@ tests:
       - hasDocuments:
           count: 1
 
-  - it: should forward suspend/completions/parallelism/completionMode
+  - it: should forward suspend/completions/parallelism/completionMode/ttlSecondsAfterFinished
     set:
       cronJobs:
         indexed-job:
@@ -218,6 +218,7 @@ tests:
           completions: 4
           parallelism: 4
           completionMode: Indexed
+          ttlSecondsAfterFinished: 3600
           image:
             repository: my-repo
             tag: sha-mytag
@@ -241,8 +242,12 @@ tests:
         equal:
           path: spec.jobTemplate.spec.completionMode
           value: Indexed
+      - documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+          value: 3600
 
-  - it: should omit suspend/completions/parallelism/completionMode when unset
+  - it: should omit suspend/completions/parallelism/completionMode/ttlSecondsAfterFinished when unset
     set:
       cronJobs:
         plain-job:
@@ -264,6 +269,9 @@ tests:
       - documentIndex: 0
         notExists:
           path: spec.jobTemplate.spec.completionMode
+      - documentIndex: 0
+        notExists:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
 
   - it: should forward podAnnotations + podLabels to jobTemplate pod metadata
     set:


### PR DESCRIPTION
## What

Pass `ttlSecondsAfterFinished` through to the CronJob `jobTemplate.spec`, mirroring the existing passthrough in `job.yaml`. Used in https://github.com/evolutionaryscale/evolutionaryscale/pull/11889 (blocked on this releasing)

## Why

The CronJob template never forwarded `ttlSecondsAfterFinished`, so finished Jobs and their pods linger indefinitely. This bites on-demand ingest runs in particular: `kubectl create job --from=cronjob/<name>` copies the CronJob's `jobTemplate.spec` into the new Job, so the TTL set here also governs those manually-triggered Jobs — letting them self-clean instead of accumulating completed pods in the namespace (and cluttering the ArgoCD tree).

## Changes

- `stack/templates/cronjob.yaml`: emit `ttlSecondsAfterFinished` in `jobTemplate.spec` when set (same `{{- if .Values.ttlSecondsAfterFinished }}` guard as `job.yaml`).
- `stack/tests/cronjob_test.yaml`: extend the existing forward/omit tests to cover the new field.

## Testing

`helm unittest stack` — 120/120 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)