### PR TITLE
fix: shard pods_metrics discovery by node to stop duplicate scrapes

### DIFF
--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -323,6 +323,10 @@ data:
     {{- $st := .Values.prometheusRemoteWrite.scrapeTimeout | default "10s" }}
     discovery.kubernetes "pods_metrics" {
       role = "pod"
+      selectors {
+        role  = "pod"
+        field = "spec.nodeName=" + coalesce(sys.env("NODE_NAME"), sys.env("HOSTNAME"), constants.hostname)
+      }
     }
 
     discovery.relabel "pods_metrics" {

--- a/grafana-alloy/tests/configmap_test.yaml
+++ b/grafana-alloy/tests/configmap_test.yaml
@@ -1985,3 +1985,19 @@ tests:
       - notMatchRegex:
           path: data["config.alloy"]
           pattern: 'prometheus\.scrape "self_remote_write"'
+
+  - it: should shard pods_metrics discovery by node so each DaemonSet pod scrapes only its own node
+    set:
+      enabled: true
+      clusterName: test-cluster
+      alloyConfig:
+        metrics:
+          enabled: true
+      prometheusRemoteWrite:
+        enabled: true
+        endpoints:
+          - url: http://prometheus.svc/api/v1/write
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery\.kubernetes "pods_metrics" \{\s*role = "pod"\s*selectors \{\s*role  = "pod"\s*field = "spec\.nodeName='


### PR DESCRIPTION
## Problem

`prometheus.scrape "pods"` discovers its targets via:

```alloy
discovery.kubernetes "pods_metrics" {
  role = "pod"
}
```

This has **no node selector**, so on a DaemonSet deployment *every* Alloy pod discovers and scrapes *every* `prometheus.io/scrape: "true"` pod in the cluster. With N nodes, each application target is scraped N times, producing N identical copies of every series (same labels — there is no per-scraper identifier).