### PR TITLE
fix: Distribute cluster-wide scrapes via Alloy clustering

### DIFF
--- a/grafana-alloy/README.md
+++ b/grafana-alloy/README.md
@@ -63,15 +63,15 @@
 
 **Description:** Alloy deployment configuration
 
-| Property                                         | Pattern | Type             | Deprecated | Definition | Title/Description                   |
-| ------------------------------------------------ | ------- | ---------------- | ---------- | ---------- | ----------------------------------- |
-| - [clustering](#alloy_alloy_clustering )         | No      | object           | No         | -          | Clustering configuration            |
-| - [configMap](#alloy_alloy_configMap )           | No      | object           | No         | -          | ConfigMap configuration for Alloy   |
-| - [extraArgs](#alloy_alloy_extraArgs )           | No      | array            | No         | -          | Extra arguments to pass to Alloy    |
-| - [extraEnv](#alloy_alloy_extraEnv )             | No      | array            | No         | -          | Extra environment variables         |
-| - [extraPorts](#alloy_alloy_extraPorts )         | No      | array            | No         | -          | Extra ports to expose               |
-| - [image](#alloy_alloy_image )                   | No      | object           | No         | -          | Alloy container image configuration |
-| - [stabilityLevel](#alloy_alloy_stabilityLevel ) | No      | enum (of string) | No         | -          | Stability level for Alloy features  |
+| Property                                         | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                         |
+| ------------------------------------------------ | ------- | ---------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [clustering](#alloy_alloy_clustering )         | No      | object           | No         | -          | Clustering configuration                                                                                                                                                                                                                                                                                                  |
+| - [configMap](#alloy_alloy_configMap )           | No      | object           | No         | -          | ConfigMap configuration for Alloy                                                                                                                                                                                                                                                                                         |
+| - [extraArgs](#alloy_alloy_extraArgs )           | No      | array of string  | No         | -          | Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled. |
+| - [extraEnv](#alloy_alloy_extraEnv )             | No      | array of object  | No         | -          | Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.                                                                                                                                           |
+| - [extraPorts](#alloy_alloy_extraPorts )         | No      | array            | No         | -          | Extra ports to expose                                                                                                                                                                                                                                                                                                     |
+| - [image](#alloy_alloy_image )                   | No      | object           | No         | -          | Alloy container image configuration                                                                                                                                                                                                                                                                                       |
+| - [stabilityLevel](#alloy_alloy_stabilityLevel ) | No      | enum (of string) | No         | -          | Stability level for Alloy features                                                                                                                                                                                                                                                                                        |
 
 #### <a name="alloy_alloy_clustering"></a>1.2.1. Property `grafana-alloy > alloy > alloy > clustering`
 
@@ -141,12 +141,12 @@
 
 #### <a name="alloy_alloy_extraArgs"></a>1.2.3. Property `grafana-alloy > alloy > alloy > extraArgs`
 
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of string` |
+| **Required** | No                |
 
-**Description:** Extra arguments to pass to Alloy
+**Description:** Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -154,16 +154,27 @@
 | **Max items**        | N/A                |
 | **Items unicity**    | False              |
 | **Additional items** | False              |
-| **Tuple validation** | N/A                |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                 | Description |
+| ----------------------------------------------- | ----------- |
+| [extraArgs items](#alloy_alloy_extraArgs_items) | -           |
+
+##### <a name="alloy_alloy_extraArgs_items"></a>1.2.3.1. grafana-alloy > alloy > alloy > extraArgs > extraArgs items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
 #### <a name="alloy_alloy_extraEnv"></a>1.2.4. Property `grafana-alloy > alloy > alloy > extraEnv`
 
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
 
-**Description:** Extra environment variables
+**Description:** Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -171,7 +182,62 @@
 | **Max items**        | N/A                |
 | **Items unicity**    | False              |
 | **Additional items** | False              |
-| **Tuple validation** | N/A                |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be               | Description |
+| --------------------------------------------- | ----------- |
+| [extraEnv items](#alloy_alloy_extraEnv_items) | -           |
+
+##### <a name="alloy_alloy_extraEnv_items"></a>1.2.4.1. grafana-alloy > alloy > alloy > extraEnv > extraEnv items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [name](#alloy_alloy_extraEnv_items_name )           | No      | string | No         | -          | -                 |
+| - [valueFrom](#alloy_alloy_extraEnv_items_valueFrom ) | No      | object | No         | -          | -                 |
+
+###### <a name="alloy_alloy_extraEnv_items_name"></a>1.2.4.1.1. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="alloy_alloy_extraEnv_items_valueFrom"></a>1.2.4.1.2. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > valueFrom`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [fieldRef](#alloy_alloy_extraEnv_items_valueFrom_fieldRef ) | No      | object | No         | -          | -                 |
+
+###### <a name="alloy_alloy_extraEnv_items_valueFrom_fieldRef"></a>1.2.4.1.2.1. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > valueFrom > fieldRef`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                                 | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [fieldPath](#alloy_alloy_extraEnv_items_valueFrom_fieldRef_fieldPath ) | No      | string | No         | -          | -                 |
+
+###### <a name="alloy_alloy_extraEnv_items_valueFrom_fieldRef_fieldPath"></a>1.2.4.1.2.1.1. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > valueFrom > fieldRef > fieldPath`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
 #### <a name="alloy_alloy_extraPorts"></a>1.2.5. Property `grafana-alloy > alloy > alloy > extraPorts`
 

--- a/grafana-alloy/README.md
+++ b/grafana-alloy/README.md
@@ -63,15 +63,15 @@
 
 **Description:** Alloy deployment configuration
 
-| Property                                         | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                         |
-| ------------------------------------------------ | ------- | ---------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [clustering](#alloy_alloy_clustering )         | No      | object           | No         | -          | Clustering configuration                                                                                                                                                                                                                                                                                                  |
-| - [configMap](#alloy_alloy_configMap )           | No      | object           | No         | -          | ConfigMap configuration for Alloy                                                                                                                                                                                                                                                                                         |
-| - [extraArgs](#alloy_alloy_extraArgs )           | No      | array of string  | No         | -          | Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled. |
-| - [extraEnv](#alloy_alloy_extraEnv )             | No      | array of object  | No         | -          | Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.                                                                                                                                           |
-| - [extraPorts](#alloy_alloy_extraPorts )         | No      | array            | No         | -          | Extra ports to expose                                                                                                                                                                                                                                                                                                     |
-| - [image](#alloy_alloy_image )                   | No      | object           | No         | -          | Alloy container image configuration                                                                                                                                                                                                                                                                                       |
-| - [stabilityLevel](#alloy_alloy_stabilityLevel ) | No      | enum (of string) | No         | -          | Stability level for Alloy features                                                                                                                                                                                                                                                                                        |
+| Property                                         | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------ | ------- | ---------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [clustering](#alloy_alloy_clustering )         | No      | object           | No         | -          | Clustering configuration                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [configMap](#alloy_alloy_configMap )           | No      | object           | No         | -          | ConfigMap configuration for Alloy                                                                                                                                                                                                                                                                                                                                                                                                        |
+| - [extraArgs](#alloy_alloy_extraArgs )           | No      | array of string  | No         | -          | Extra arguments to pass to Alloy. The default advertises the node hostname (HOSTNAME, injected by the alloy subchart from spec.nodeName and resolvable via VPC DNS) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Inert when clustering is disabled. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled. |
+| - [extraEnv](#alloy_alloy_extraEnv )             | No      | array            | No         | -          | Extra environment variables                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [extraPorts](#alloy_alloy_extraPorts )         | No      | array            | No         | -          | Extra ports to expose                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| - [image](#alloy_alloy_image )                   | No      | object           | No         | -          | Alloy container image configuration                                                                                                                                                                                                                                                                                                                                                                                                      |
+| - [stabilityLevel](#alloy_alloy_stabilityLevel ) | No      | enum (of string) | No         | -          | Stability level for Alloy features                                                                                                                                                                                                                                                                                                                                                                                                       |
 
 #### <a name="alloy_alloy_clustering"></a>1.2.1. Property `grafana-alloy > alloy > alloy > clustering`
 
@@ -146,7 +146,7 @@
 | **Type**     | `array of string` |
 | **Required** | No                |
 
-**Description:** Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.
+**Description:** Extra arguments to pass to Alloy. The default advertises the node hostname (HOSTNAME, injected by the alloy subchart from spec.nodeName and resolvable via VPC DNS) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Inert when clustering is disabled. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -169,12 +169,12 @@
 
 #### <a name="alloy_alloy_extraEnv"></a>1.2.4. Property `grafana-alloy > alloy > alloy > extraEnv`
 
-|              |                   |
-| ------------ | ----------------- |
-| **Type**     | `array of object` |
-| **Required** | No                |
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
 
-**Description:** Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.
+**Description:** Extra environment variables
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -182,62 +182,7 @@
 | **Max items**        | N/A                |
 | **Items unicity**    | False              |
 | **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be               | Description |
-| --------------------------------------------- | ----------- |
-| [extraEnv items](#alloy_alloy_extraEnv_items) | -           |
-
-##### <a name="alloy_alloy_extraEnv_items"></a>1.2.4.1. grafana-alloy > alloy > alloy > extraEnv > extraEnv items
-
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
-
-| Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [name](#alloy_alloy_extraEnv_items_name )           | No      | string | No         | -          | -                 |
-| - [valueFrom](#alloy_alloy_extraEnv_items_valueFrom ) | No      | object | No         | -          | -                 |
-
-###### <a name="alloy_alloy_extraEnv_items_name"></a>1.2.4.1.1. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > name`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-###### <a name="alloy_alloy_extraEnv_items_valueFrom"></a>1.2.4.1.2. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > valueFrom`
-
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
-
-| Property                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [fieldRef](#alloy_alloy_extraEnv_items_valueFrom_fieldRef ) | No      | object | No         | -          | -                 |
-
-###### <a name="alloy_alloy_extraEnv_items_valueFrom_fieldRef"></a>1.2.4.1.2.1. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > valueFrom > fieldRef`
-
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
-
-| Property                                                                 | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ------------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [fieldPath](#alloy_alloy_extraEnv_items_valueFrom_fieldRef_fieldPath ) | No      | string | No         | -          | -                 |
-
-###### <a name="alloy_alloy_extraEnv_items_valueFrom_fieldRef_fieldPath"></a>1.2.4.1.2.1.1. Property `grafana-alloy > alloy > alloy > extraEnv > extraEnv items > valueFrom > fieldRef > fieldPath`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
+| **Tuple validation** | N/A                |
 
 #### <a name="alloy_alloy_extraPorts"></a>1.2.5. Property `grafana-alloy > alloy > alloy > extraPorts`
 

--- a/grafana-alloy/templates/_helpers.tpl
+++ b/grafana-alloy/templates/_helpers.tpl
@@ -71,3 +71,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+{{/*
+Emit a prometheus.scrape clustering block when Alloy clustering is enabled.
+
+Pairs with alloy.clustering.enabled (which makes the alloy subchart add
+--cluster.enabled and the headless peer-discovery service). Apply ONLY to
+scrapes whose discovery is cluster-wide (service/endpoints), so the target is
+owned by a single peer and scraped once instead of by every DaemonSet pod.
+Do NOT apply to node-local scrapes (pods/kubelet/cadvisor/unix_exporter) — those
+already restrict discovery to the local node and must run on every node.
+
+Pass the root context ($).
+*/}}
+{{- define "grafana-alloy.scrapeClustering" -}}
+{{- if dig "clustering" "enabled" false (.Values.alloy | default dict) }}
+      clustering {
+        enabled = true
+      }
+{{- end }}
+{{- end -}}
+

--- a/grafana-alloy/templates/_helpers.tpl
+++ b/grafana-alloy/templates/_helpers.tpl
@@ -73,7 +73,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Clustering block for cluster-wide scrapes (service/endpoints). Pass root ($). */}}
 {{- define "grafana-alloy.scrapeClustering" -}}
-{{- if dig "clustering" "enabled" false (.Values.alloy | default dict) }}
+{{- if dig "alloy" "clustering" "enabled" false (.Values.alloy | default dict) }}
       clustering {
         enabled = true
       }

--- a/grafana-alloy/templates/_helpers.tpl
+++ b/grafana-alloy/templates/_helpers.tpl
@@ -71,18 +71,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
-{{/*
-Emit a prometheus.scrape clustering block when Alloy clustering is enabled.
-
-Pairs with alloy.clustering.enabled (which makes the alloy subchart add
---cluster.enabled and the headless peer-discovery service). Apply ONLY to
-scrapes whose discovery is cluster-wide (service/endpoints), so the target is
-owned by a single peer and scraped once instead of by every DaemonSet pod.
-Do NOT apply to node-local scrapes (pods/kubelet/cadvisor/unix_exporter) — those
-already restrict discovery to the local node and must run on every node.
-
-Pass the root context ($).
-*/}}
+{{/* Clustering block for cluster-wide scrapes (service/endpoints). Pass root ($). */}}
 {{- define "grafana-alloy.scrapeClustering" -}}
 {{- if dig "clustering" "enabled" false (.Values.alloy | default dict) }}
       clustering {

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -429,6 +429,7 @@ data:
       scrape_interval = {{ $ksmSi | quote }}
       scrape_timeout  = {{ $ksmSt | quote }}
       honor_labels    = true
+{{- include "grafana-alloy.scrapeClustering" $ }}
     }
 
     {{- if gt (len $ksmMetricRelabel) 0 }}
@@ -501,6 +502,7 @@ data:
       forward_to      = [prometheus.relabel.filter_metrics.receiver]
       scrape_interval = {{ .scrapeInterval | default "1m" | quote }}
       scrape_timeout  = {{ .scrapeTimeout | default "10s" | quote }}
+{{- include "grafana-alloy.scrapeClustering" $ }}
     }
     {{- end }}
     {{- end }}
@@ -683,6 +685,7 @@ data:
       scrape_interval = {{ .scrapeInterval | default "15s" | quote }}
       scrape_timeout  = {{ .scrapeTimeout | default "10s" | quote }}
       honor_labels    = true
+{{- include "grafana-alloy.scrapeClustering" $ }}
     }
     {{- end }}
     {{- end }}

--- a/grafana-alloy/tests/configmap_test.yaml
+++ b/grafana-alloy/tests/configmap_test.yaml
@@ -2022,13 +2022,14 @@ tests:
           path: data["config.alloy"]
           pattern: 'clustering \{'
 
-  - it: should distribute cluster-wide scrapes via clustering when alloy.clustering.enabled is true
+  - it: should distribute cluster-wide scrapes via clustering when alloy.alloy.clustering.enabled is true
     set:
       enabled: true
       clusterName: test-cluster
       alloy:
-        clustering:
-          enabled: true
+        alloy:
+          clustering:
+            enabled: true
       alloyConfig:
         metrics:
           enabled: true

--- a/grafana-alloy/tests/configmap_test.yaml
+++ b/grafana-alloy/tests/configmap_test.yaml
@@ -2001,3 +2001,55 @@ tests:
       - matchRegex:
           path: data["config.alloy"]
           pattern: 'discovery\.kubernetes "pods_metrics" \{\s*role = "pod"\s*selectors \{\s*role  = "pod"\s*field = "spec\.nodeName='
+
+  - it: should not emit clustering blocks when alloy.clustering.enabled is false
+    set:
+      enabled: true
+      clusterName: test-cluster
+      alloyConfig:
+        metrics:
+          enabled: true
+      prometheusRemoteWrite:
+        enabled: true
+        scrapeKubeStateMetrics:
+          enabled: true
+        scrapeEndpoints:
+          enabled: true
+        endpoints:
+          - url: http://prometheus.svc/api/v1/write
+    asserts:
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'clustering \{'
+
+  - it: should distribute cluster-wide scrapes via clustering when alloy.clustering.enabled is true
+    set:
+      enabled: true
+      clusterName: test-cluster
+      alloy:
+        clustering:
+          enabled: true
+      alloyConfig:
+        metrics:
+          enabled: true
+      prometheusRemoteWrite:
+        enabled: true
+        scrapeKubeStateMetrics:
+          enabled: true
+        scrapeEndpoints:
+          enabled: true
+        endpoints:
+          - url: http://prometheus.svc/api/v1/write
+    asserts:
+      # kube_state_metrics (role=service) and endpoints (role=endpoints) are cluster-wide -> clustered
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.scrape "kube_state_metrics" \{[\s\S]*?honor_labels    = true\s*clustering \{\s*enabled = true'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.scrape "endpoints" \{[\s\S]*?scrape_timeout  = "[^"]*"\s*clustering \{\s*enabled = true'
+      # node-local pods scrape must NOT be clustered: its block closes right after
+      # scrape_timeout with no clustering block inserted (each node keeps its own targets)
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.scrape "pods" \{[\s\S]*?scrape_timeout  = "10s"\s*\}'

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -47,12 +47,36 @@
               }
             },
             "extraArgs": {
-              "description": "Extra arguments to pass to Alloy",
-              "type": "array"
+              "description": "Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "extraEnv": {
-              "description": "Extra environment variables",
-              "type": "array"
+              "description": "Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "type": "object",
+                    "properties": {
+                      "fieldRef": {
+                        "type": "object",
+                        "properties": {
+                          "fieldPath": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             },
             "extraPorts": {
               "description": "Extra ports to expose",

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -47,36 +47,15 @@
               }
             },
             "extraArgs": {
-              "description": "Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.",
+              "description": "Extra arguments to pass to Alloy. The default advertises the node hostname (HOSTNAME, injected by the alloy subchart from spec.nodeName and resolvable via VPC DNS) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Inert when clustering is disabled. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.",
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
             "extraEnv": {
-              "description": "Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "valueFrom": {
-                    "type": "object",
-                    "properties": {
-                      "fieldRef": {
-                        "type": "object",
-                        "properties": {
-                          "fieldPath": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+              "description": "Extra environment variables",
+              "type": "array"
             },
             "extraPorts": {
               "description": "Extra ports to expose",

--- a/grafana-alloy/values.yaml
+++ b/grafana-alloy/values.yaml
@@ -226,11 +226,16 @@ alloy:
       name: grafana-alloy-config # @schema description: Name of the ConfigMap to use
       key: config.alloy # @schema description: Key in the ConfigMap containing the configuration
 
-    # @schema description: Extra arguments to pass to Alloy
-    extraArgs: []
+    # @schema description: Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.
+    extraArgs:
+      - "--cluster.advertise-address=$(POD_IP):12345"
 
-    # @schema description: Extra environment variables
-    extraEnv: []
+    # @schema description: Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.
+    extraEnv:
+      - name: POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
 
     # @schema description: Extra ports to expose
     extraPorts: []

--- a/grafana-alloy/values.yaml
+++ b/grafana-alloy/values.yaml
@@ -226,16 +226,12 @@ alloy:
       name: grafana-alloy-config # @schema description: Name of the ConfigMap to use
       key: config.alloy # @schema description: Key in the ConfigMap containing the configuration
 
-    # @schema description: Extra arguments to pass to Alloy. The default advertises the node IP (POD_IP env below) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.
+    # @schema description: Extra arguments to pass to Alloy. The default advertises the node hostname (HOSTNAME, injected by the alloy subchart from spec.nodeName and resolvable via VPC DNS) for clustering, required on hostNetwork/Cilium nodes where Alloy interface auto-detection otherwise falls back to 127.0.0.1. Inert when clustering is disabled. Consumers overriding this list must re-include the advertise-address arg when clustering is enabled.
     extraArgs:
-      - "--cluster.advertise-address=$(POD_IP):12345"
+      - "--cluster.advertise-address=$(HOSTNAME):12345"
 
-    # @schema description: Extra environment variables. POD_IP (status.podIP) backs the --cluster.advertise-address arg. Consumers overriding this list must re-include POD_IP when clustering is enabled.
-    extraEnv:
-      - name: POD_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
+    # @schema description: Extra environment variables
+    extraEnv: []
 
     # @schema description: Extra ports to expose
     extraPorts: []


### PR DESCRIPTION
Without clustering, we experience a massive volume of cluster-level metrics duplicated by every node. This is meant to alleviate the strain on central AMP. By default this behavior is disabled.

Original setup included the in-cluster prometheus that handled de-duplication, but now we migrate bhp and mga clusters to a setup without a local in-cluster prometheus, and duplication is becoming an issue.

Tested in dev-cilium-test.