### PR TITLE
feat: node-shard cluster-wide scrapes (avoids grafana-alloy clustering)

### DIFF
--- a/grafana-alloy/README.md
+++ b/grafana-alloy/README.md
@@ -1189,14 +1189,15 @@ Must be one of:
 
 **Description:** Scrape NVIDIA DCGM exporter endpoints (VMAgent VMServiceScrape-style)
 
-| Property                                                                                  | Pattern | Type    | Deprecated | Definition | Title/Description                                                        |
-| ----------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------ |
-| - [enabled](#prometheusRemoteWrite_scrapeDcgmExporter_enabled )                           | No      | boolean | No         | -          | -                                                                        |
-| - [namespaces](#prometheusRemoteWrite_scrapeDcgmExporter_namespaces )                     | No      | array   | No         | -          | Kubernetes namespaces to search (e.g. nvidia-gpu-operator, gpu-operator) |
-| - [portName](#prometheusRemoteWrite_scrapeDcgmExporter_portName )                         | No      | string  | No         | -          | Endpoint port name to keep                                               |
-| - [scrapeInterval](#prometheusRemoteWrite_scrapeDcgmExporter_scrapeInterval )             | No      | string  | No         | -          | -                                                                        |
-| - [scrapeTimeout](#prometheusRemoteWrite_scrapeDcgmExporter_scrapeTimeout )               | No      | string  | No         | -          | -                                                                        |
-| - [serviceAppLabelValue](#prometheusRemoteWrite_scrapeDcgmExporter_serviceAppLabelValue ) | No      | string  | No         | -          | Value of the Service label app=...                                       |
+| Property                                                                                  | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#prometheusRemoteWrite_scrapeDcgmExporter_enabled )                           | No      | boolean | No         | -          | -                                                                                                                                                                                                                         |
+| - [namespaces](#prometheusRemoteWrite_scrapeDcgmExporter_namespaces )                     | No      | array   | No         | -          | Kubernetes namespaces to search (e.g. nvidia-gpu-operator, gpu-operator)                                                                                                                                                  |
+| - [portName](#prometheusRemoteWrite_scrapeDcgmExporter_portName )                         | No      | string  | No         | -          | Endpoint port name to keep                                                                                                                                                                                                |
+| - [scrapeInterval](#prometheusRemoteWrite_scrapeDcgmExporter_scrapeInterval )             | No      | string  | No         | -          | -                                                                                                                                                                                                                         |
+| - [scrapeTimeout](#prometheusRemoteWrite_scrapeDcgmExporter_scrapeTimeout )               | No      | string  | No         | -          | -                                                                                                                                                                                                                         |
+| - [serviceAppLabelValue](#prometheusRemoteWrite_scrapeDcgmExporter_serviceAppLabelValue ) | No      | string  | No         | -          | Value of the Service label app=...                                                                                                                                                                                        |
+| - [shardByNode](#prometheusRemoteWrite_scrapeDcgmExporter_shardByNode )                   | No      | boolean | No         | -          | When true (DaemonSet), each pod scrapes only the dcgm endpoints on its own node. dcgm-exporter is per-GPU-node, so this gives one scraper per exporter with locality and no duplication. Alternative to Alloy clustering. |
 
 #### <a name="prometheusRemoteWrite_scrapeDcgmExporter_enabled"></a>6.9.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > enabled`
 
@@ -1254,6 +1255,15 @@ Must be one of:
 
 **Description:** Value of the Service label app=...
 
+#### <a name="prometheusRemoteWrite_scrapeDcgmExporter_shardByNode"></a>6.9.7. Property `grafana-alloy > prometheusRemoteWrite > scrapeDcgmExporter > shardByNode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** When true (DaemonSet), each pod scrapes only the dcgm endpoints on its own node. dcgm-exporter is per-GPU-node, so this gives one scraper per exporter with locality and no duplication. Alternative to Alloy clustering.
+
 ### <a name="prometheusRemoteWrite_scrapeEndpoints"></a>6.10. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints`
 
 |                           |                  |
@@ -1264,11 +1274,12 @@ Must be one of:
 
 **Description:** Scrape Kubernetes service endpoints with prometheus.io/scrape annotations
 
-| Property                                                                   | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                          |
-| -------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
-| - [enabled](#prometheusRemoteWrite_scrapeEndpoints_enabled )               | No      | boolean | No         | -          | Enable scraping service endpoints (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled) |
-| - [scrapeInterval](#prometheusRemoteWrite_scrapeEndpoints_scrapeInterval ) | No      | string  | No         | -          | Scrape interval for endpoint scraping                                                                      |
-| - [scrapeTimeout](#prometheusRemoteWrite_scrapeEndpoints_scrapeTimeout )   | No      | string  | No         | -          | Scrape timeout for endpoint scraping                                                                       |
+| Property                                                                   | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#prometheusRemoteWrite_scrapeEndpoints_enabled )               | No      | boolean | No         | -          | Enable scraping service endpoints (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)                                                                                                                                                                                                                                          |
+| - [scrapeInterval](#prometheusRemoteWrite_scrapeEndpoints_scrapeInterval ) | No      | string  | No         | -          | Scrape interval for endpoint scraping                                                                                                                                                                                                                                                                                                               |
+| - [scrapeTimeout](#prometheusRemoteWrite_scrapeEndpoints_scrapeTimeout )   | No      | string  | No         | -          | Scrape timeout for endpoint scraping                                                                                                                                                                                                                                                                                                                |
+| - [shardByNode](#prometheusRemoteWrite_scrapeEndpoints_shardByNode )       | No      | boolean | No         | -          | When true (DaemonSet), each pod scrapes only the annotated endpoints whose backing pod runs on its own node, so each target is scraped once instead of once per node. Alternative to Alloy clustering. Note - drops targets with no endpoint node name (external/headless services), so only use where all annotated scrape targets are pod-backed. |
 
 #### <a name="prometheusRemoteWrite_scrapeEndpoints_enabled"></a>6.10.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > enabled`
 
@@ -1296,6 +1307,15 @@ Must be one of:
 | **Required** | No       |
 
 **Description:** Scrape timeout for endpoint scraping
+
+#### <a name="prometheusRemoteWrite_scrapeEndpoints_shardByNode"></a>6.10.4. Property `grafana-alloy > prometheusRemoteWrite > scrapeEndpoints > shardByNode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** When true (DaemonSet), each pod scrapes only the annotated endpoints whose backing pod runs on its own node, so each target is scraped once instead of once per node. Alternative to Alloy clustering. Note - drops targets with no endpoint node name (external/headless services), so only use where all annotated scrape targets are pod-backed.
 
 ### <a name="prometheusRemoteWrite_scrapeHostNodeExporter"></a>6.11. Property `grafana-alloy > prometheusRemoteWrite > scrapeHostNodeExporter`
 
@@ -1462,15 +1482,16 @@ Must be one of:
 
 **Description:** Scrape kube-state-metrics service for kube_* metrics
 
-| Property                                                                                      | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                    |
-| --------------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#prometheusRemoteWrite_scrapeKubeStateMetrics_enabled )                           | No      | boolean | No         | -          | Enable scraping kube-state-metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)                                          |
-| - [metricRelabelConfigs](#prometheusRemoteWrite_scrapeKubeStateMetrics_metricRelabelConfigs ) | No      | array   | No         | -          | Optional metric relabel rules after scraping kube-state-metrics (Prometheus-style maps with source_labels, regex, action, target_label, replacement) |
-| - [namespace](#prometheusRemoteWrite_scrapeKubeStateMetrics_namespace )                       | No      | string  | No         | -          | Namespace where kube-state-metrics service runs                                                                                                      |
-| - [portName](#prometheusRemoteWrite_scrapeKubeStateMetrics_portName )                         | No      | string  | No         | -          | Optional Kubernetes Service port name to scrape only (e.g. http for VMServiceScrape parity)                                                          |
-| - [scrapeInterval](#prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeInterval )             | No      | string  | No         | -          | Optional scrape interval override (defaults to prometheusRemoteWrite.scrapeInterval)                                                                 |
-| - [scrapeTimeout](#prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeTimeout )               | No      | string  | No         | -          | Optional scrape timeout override (defaults to prometheusRemoteWrite.scrapeTimeout)                                                                   |
-| - [serviceSelector](#prometheusRemoteWrite_scrapeKubeStateMetrics_serviceSelector )           | No      | string  | No         | -          | Label selector (key=value) to find the kube-state-metrics service                                                                                    |
+| Property                                                                                      | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| --------------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#prometheusRemoteWrite_scrapeKubeStateMetrics_enabled )                           | No      | boolean | No         | -          | Enable scraping kube-state-metrics (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)                                                                                                                       |
+| - [metricRelabelConfigs](#prometheusRemoteWrite_scrapeKubeStateMetrics_metricRelabelConfigs ) | No      | array   | No         | -          | Optional metric relabel rules after scraping kube-state-metrics (Prometheus-style maps with source_labels, regex, action, target_label, replacement)                                                                              |
+| - [namespace](#prometheusRemoteWrite_scrapeKubeStateMetrics_namespace )                       | No      | string  | No         | -          | Namespace where kube-state-metrics service runs                                                                                                                                                                                   |
+| - [portName](#prometheusRemoteWrite_scrapeKubeStateMetrics_portName )                         | No      | string  | No         | -          | Optional Kubernetes Service port name to scrape only (e.g. http for VMServiceScrape parity)                                                                                                                                       |
+| - [scrapeInterval](#prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeInterval )             | No      | string  | No         | -          | Optional scrape interval override (defaults to prometheusRemoteWrite.scrapeInterval)                                                                                                                                              |
+| - [scrapeTimeout](#prometheusRemoteWrite_scrapeKubeStateMetrics_scrapeTimeout )               | No      | string  | No         | -          | Optional scrape timeout override (defaults to prometheusRemoteWrite.scrapeTimeout)                                                                                                                                                |
+| - [serviceSelector](#prometheusRemoteWrite_scrapeKubeStateMetrics_serviceSelector )           | No      | string  | No         | -          | Label selector (key=value) to find the kube-state-metrics service                                                                                                                                                                 |
+| - [shardByNode](#prometheusRemoteWrite_scrapeKubeStateMetrics_shardByNode )                   | No      | boolean | No         | -          | When true (DaemonSet), discover KSM via role=endpoints and keep only the endpoint on this pod's node, so the single KSM is scraped once instead of once per node. Alternative to Alloy clustering for cluster-singleton scraping. |
 
 #### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_enabled"></a>6.14.1. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > enabled`
 
@@ -1542,6 +1563,15 @@ Must be one of:
 | **Required** | No       |
 
 **Description:** Label selector (key=value) to find the kube-state-metrics service
+
+#### <a name="prometheusRemoteWrite_scrapeKubeStateMetrics_shardByNode"></a>6.14.8. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubeStateMetrics > shardByNode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** When true (DaemonSet), discover KSM via role=endpoints and keep only the endpoint on this pod's node, so the single KSM is scraped once instead of once per node. Alternative to Alloy clustering for cluster-singleton scraping.
 
 ### <a name="prometheusRemoteWrite_scrapeKubelet"></a>6.15. Property `grafana-alloy > prometheusRemoteWrite > scrapeKubelet`
 

--- a/grafana-alloy/templates/_helpers.tpl
+++ b/grafana-alloy/templates/_helpers.tpl
@@ -71,13 +71,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
-{{/*
-Node-shard a role=endpoints scrape: keep only targets whose backing pod runs on THIS
-Alloy's node, so a DaemonSet scrapes each cluster-wide endpoint exactly once instead of
-once per node. Exact node-name match via keepequal (no regex/wildcard ambiguity).
-Targets with no endpoint node name (e.g. external/headless) are dropped — only use where
-all scrape targets are pod-backed.
-*/}}
+{{/* Keep only role=endpoints targets backed by a pod on this node (node-shard). Pass root ($). */}}
 {{- define "grafana-alloy.shardByEndpointNode" -}}
 rule {
   target_label = "__tmp_local_node"

--- a/grafana-alloy/templates/_helpers.tpl
+++ b/grafana-alloy/templates/_helpers.tpl
@@ -71,7 +71,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
-{{/* Keep only role=endpoints targets backed by a pod on this node (node-shard). Pass root ($). */}}
 {{- define "grafana-alloy.shardByEndpointNode" -}}
 rule {
   target_label = "__tmp_local_node"

--- a/grafana-alloy/templates/_helpers.tpl
+++ b/grafana-alloy/templates/_helpers.tpl
@@ -71,3 +71,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+{{/*
+Node-shard a role=endpoints scrape: keep only targets whose backing pod runs on THIS
+Alloy's node, so a DaemonSet scrapes each cluster-wide endpoint exactly once instead of
+once per node. Exact node-name match via keepequal (no regex/wildcard ambiguity).
+Targets with no endpoint node name (e.g. external/headless) are dropped — only use where
+all scrape targets are pod-backed.
+*/}}
+{{- define "grafana-alloy.shardByEndpointNode" -}}
+rule {
+  target_label = "__tmp_local_node"
+  replacement  = coalesce(sys.env("NODE_NAME"), sys.env("HOSTNAME"), constants.hostname)
+}
+rule {
+  source_labels = ["__meta_kubernetes_endpoint_node_name"]
+  target_label  = "__tmp_local_node"
+  action        = "keepequal"
+}
+rule {
+  action = "labeldrop"
+  regex  = "__tmp_local_node"
+}
+{{- end -}}
+

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -389,13 +389,14 @@ data:
     {{- $ksmMetricRelabel := .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.metricRelabelConfigs | default list }}
     {{- $ksmSi := .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.scrapeInterval | default $si }}
     {{- $ksmSt := .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.scrapeTimeout | default $st }}
+    {{- $ksmShard := .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.shardByNode }}
     discovery.kubernetes "kube_state_metrics_svc" {
-      role = "service"
+      role = {{ if $ksmShard }}"endpoints"{{ else }}"service"{{ end }}
       namespaces {
         names = [{{ (.Values.prometheusRemoteWrite.scrapeKubeStateMetrics.namespace | default "kube-system") | quote }}]
       }
       selectors {
-        role  = "service"
+        role  = {{ if $ksmShard }}"endpoints"{{ else }}"service"{{ end }}
         label = {{ (.Values.prometheusRemoteWrite.scrapeKubeStateMetrics.serviceSelector | default "app.kubernetes.io/name=kube-state-metrics") | quote }}
       }
     }
@@ -416,10 +417,13 @@ data:
 
       {{- with .Values.prometheusRemoteWrite.scrapeKubeStateMetrics.portName }}
       rule {
-        source_labels = ["__meta_kubernetes_service_port_name"]
+        source_labels = [{{ if $ksmShard }}"__meta_kubernetes_endpoint_port_name"{{ else }}"__meta_kubernetes_service_port_name"{{ end }}]
         regex         = {{ . | quote }}
         action        = "keep"
       }
+      {{- end }}
+      {{- if $ksmShard }}
+{{- include "grafana-alloy.shardByEndpointNode" . | nindent 6 }}
       {{- end }}
     }
 
@@ -454,6 +458,9 @@ data:
         regex         = "(?i)^\\s*true\\s*$"
         action        = "keep"
       }
+      {{- if $.Values.prometheusRemoteWrite.scrapeEndpoints.shardByNode }}
+{{- include "grafana-alloy.shardByEndpointNode" . | nindent 6 }}
+      {{- end }}
 
       rule {
         source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_path"]
@@ -664,6 +671,9 @@ data:
         regex         = {{ .portName | default "gpu-metrics" | quote }}
         action        = "keep"
       }
+      {{- if .shardByNode }}
+{{- include "grafana-alloy.shardByEndpointNode" . | nindent 6 }}
+      {{- end }}
 
       rule {
         source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_service_name"]

--- a/grafana-alloy/tests/configmap_test.yaml
+++ b/grafana-alloy/tests/configmap_test.yaml
@@ -2001,3 +2001,71 @@ tests:
       - matchRegex:
           path: data["config.alloy"]
           pattern: 'discovery\.kubernetes "pods_metrics" \{\s*role = "pod"\s*selectors \{\s*role  = "pod"\s*field = "spec\.nodeName='
+
+  - it: should not node-shard cluster-wide scrapes when shardByNode is false (default)
+    set:
+      enabled: true
+      clusterName: test-cluster
+      alloyConfig:
+        metrics:
+          enabled: true
+      prometheusRemoteWrite:
+        enabled: true
+        scrapeKubeStateMetrics:
+          enabled: true
+        scrapeEndpoints:
+          enabled: true
+        endpoints:
+          - url: http://prometheus.svc/api/v1/write
+    asserts:
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'keepequal'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '__tmp_local_node'
+      # KSM stays role=service when not sharded
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery\.kubernetes "kube_state_metrics_svc" \{\s*role = "service"'
+
+  - it: should node-shard endpoints, dcgm, and kube-state-metrics when shardByNode is true
+    set:
+      enabled: true
+      clusterName: test-cluster
+      alloyConfig:
+        metrics:
+          enabled: true
+      prometheusRemoteWrite:
+        enabled: true
+        endpoints:
+          - url: http://prometheus.svc/api/v1/write
+        scrapeKubeStateMetrics:
+          enabled: true
+          portName: http
+          shardByNode: true
+        scrapeEndpoints:
+          enabled: true
+          shardByNode: true
+        scrapeDcgmExporter:
+          enabled: true
+          namespaces: ["kube-system"]
+          shardByNode: true
+    asserts:
+      # KSM switches role=service -> role=endpoints and uses the endpoint port-name meta label
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery\.kubernetes "kube_state_metrics_svc" \{\s*role = "endpoints"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'source_labels = \["__meta_kubernetes_endpoint_port_name"\]'
+      # each cluster-wide scrape gets a keepequal node-shard on endpoint node name
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery\.relabel "endpoints" \{[\s\S]*?__meta_kubernetes_endpoint_node_name[\s\S]*?action        = "keepequal"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery\.relabel "kube_state_metrics" \{[\s\S]*?action        = "keepequal"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery\.relabel "dcgm_exporter" \{[\s\S]*?action        = "keepequal"'

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -475,6 +475,10 @@
             "serviceAppLabelValue": {
               "description": "Value of the Service label app=...",
               "type": "string"
+            },
+            "shardByNode": {
+              "description": "When true (DaemonSet), each pod scrapes only the dcgm endpoints on its own node. dcgm-exporter is per-GPU-node, so this gives one scraper per exporter with locality and no duplication. Alternative to Alloy clustering.",
+              "type": "boolean"
             }
           }
         },
@@ -493,6 +497,10 @@
             "scrapeTimeout": {
               "description": "Scrape timeout for endpoint scraping",
               "type": "string"
+            },
+            "shardByNode": {
+              "description": "When true (DaemonSet), each pod scrapes only the annotated endpoints whose backing pod runs on its own node, so each target is scraped once instead of once per node. Alternative to Alloy clustering. Note - drops targets with no endpoint node name (external/headless services), so only use where all annotated scrape targets are pod-backed.",
+              "type": "boolean"
             }
           }
         },
@@ -585,6 +593,10 @@
             "serviceSelector": {
               "description": "Label selector (key=value) to find the kube-state-metrics service",
               "type": "string"
+            },
+            "shardByNode": {
+              "description": "When true (DaemonSet), discover KSM via role=endpoints and keep only the endpoint on this pod's node, so the single KSM is scraped once instead of once per node. Alternative to Alloy clustering for cluster-singleton scraping.",
+              "type": "boolean"
             }
           }
         },

--- a/grafana-alloy/values.yaml
+++ b/grafana-alloy/values.yaml
@@ -60,6 +60,7 @@ prometheusRemoteWrite:
     scrapeTimeout: "" # @schema description: Optional scrape timeout override (defaults to prometheusRemoteWrite.scrapeTimeout)
     portName: "" # @schema description: Optional Kubernetes Service port name to scrape only (e.g. http for VMServiceScrape parity)
     metricRelabelConfigs: [] # @schema description: Optional metric relabel rules after scraping kube-state-metrics (Prometheus-style maps with source_labels, regex, action, target_label, replacement)
+    shardByNode: false # @schema description: When true (DaemonSet), discover KSM via role=endpoints and keep only the endpoint on this pod's node, so the single KSM is scraped once instead of once per node. Alternative to Alloy clustering for cluster-singleton scraping.
 
   # Scrape kubelet for kubelet_* and kubernetes_build_info metrics.
   scrapeKubelet: # @schema description: Scrape kubelet metrics from each node (kubelet_*, kubernetes_build_info)
@@ -78,6 +79,7 @@ prometheusRemoteWrite:
     portName: "gpu-metrics" # @schema description: Endpoint port name to keep
     scrapeInterval: "15s"
     scrapeTimeout: "10s"
+    shardByNode: false # @schema description: When true (DaemonSet), each pod scrapes only the dcgm endpoints on its own node. dcgm-exporter is per-GPU-node, so this gives one scraper per exporter with locality and no duplication. Alternative to Alloy clustering.
 
   scrapeHostNodeExporter: # @schema description: Scrape node exporter on the local node for hostNetwork DaemonSet pods. Typical address 127.0.0.1:9101 (Andromeda-style port).
     enabled: false
@@ -119,6 +121,7 @@ prometheusRemoteWrite:
     enabled: true # @schema description: Enable scraping service endpoints (requires alloyConfig.metrics.enabled and prometheusRemoteWrite.enabled)
     scrapeInterval: "1m" # @schema description: Scrape interval for endpoint scraping
     scrapeTimeout: "10s" # @schema description: Scrape timeout for endpoint scraping
+    shardByNode: false # @schema description: When true (DaemonSet), each pod scrapes only the annotated endpoints whose backing pod runs on its own node, so each target is scraped once instead of once per node. Alternative to Alloy clustering. Note - drops targets with no endpoint node name (external/headless services), so only use where all annotated scrape targets are pod-backed.
 
   additionalStaticScrapes: [] # @schema description: Extra prometheus.scrape blocks with static __address__ targets (forward_to filter_metrics). Each item: jobName, optional metricsPath, scrapeInterval, scrapeTimeout, targets: [{ address, optional job, optional namespace }]
 


### PR DESCRIPTION
This PR allows enablement of sharding for cluster level metrics to avoid duplication (presently every alloy pod collects the same cluster level metrics). Original approach was to enable clustering to achieve the same goal, but sharding seems to be less intrusive and eliminates cross-az traffic. Validated in dev-cilium-test and dev-core-platform.

As the result of this change, the overall traffic flowing to central AMP will be significantly reduced. Hopefully, it will help us address throttling visible by BHP users in grafana.