### PR TITLE
feat: add envoy-gateway-nlb chart (CCIE-6701)

### DIFF
--- a/envoy-gateway-nlb/Chart.yaml
+++ b/envoy-gateway-nlb/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: envoy-gateway-nlb
+description: NLB LoadBalancer Services fronting the Envoy Gateway proxy (external + optional internal)
+type: application
+version: 0.1.0
+appVersion: "1"

--- a/envoy-gateway-nlb/Makefile
+++ b/envoy-gateway-nlb/Makefile
@@ -1,0 +1,2 @@
+include ../common.mk
+include ../schema.mk

--- a/envoy-gateway-nlb/README.md
+++ b/envoy-gateway-nlb/README.md
@@ -1,0 +1,123 @@
+# envoy-gateway-nlb
+
+**Title:** envoy-gateway-nlb
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                             | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ---------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [additionalInternalNLBs](#additionalInternalNLBs ) | No      | array   | No         | -          | -                 |
+| - [baseDomain](#baseDomain )                         | No      | string  | No         | -          | -                 |
+| - [clusterName](#clusterName )                       | No      | string  | No         | -          | -                 |
+| - [externalHostnamePrefix](#externalHostnamePrefix ) | No      | string  | No         | -          | -                 |
+| - [gatewayName](#gatewayName )                       | No      | string  | No         | -          | -                 |
+| - [gatewayNamespace](#gatewayNamespace )             | No      | string  | No         | -          | -                 |
+| - [internal](#internal )                             | No      | object  | No         | -          | -                 |
+| - [internalHostnamePrefix](#internalHostnamePrefix ) | No      | string  | No         | -          | -                 |
+| - [proxyNamespace](#proxyNamespace )                 | No      | string  | No         | -          | -                 |
+| - [proxyProtocolV2](#proxyProtocolV2 )               | No      | boolean | No         | -          | -                 |
+| - [tags](#tags )                                     | No      | object  | No         | -          | -                 |
+
+## <a name="additionalInternalNLBs"></a>1. Property `envoy-gateway-nlb > additionalInternalNLBs`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+## <a name="baseDomain"></a>2. Property `envoy-gateway-nlb > baseDomain`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="clusterName"></a>3. Property `envoy-gateway-nlb > clusterName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="externalHostnamePrefix"></a>4. Property `envoy-gateway-nlb > externalHostnamePrefix`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="gatewayName"></a>5. Property `envoy-gateway-nlb > gatewayName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="gatewayNamespace"></a>6. Property `envoy-gateway-nlb > gatewayNamespace`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="internal"></a>7. Property `envoy-gateway-nlb > internal`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                        | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [enabled](#internal_enabled ) | No      | boolean | No         | -          | -                 |
+
+### <a name="internal_enabled"></a>7.1. Property `envoy-gateway-nlb > internal > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+## <a name="internalHostnamePrefix"></a>8. Property `envoy-gateway-nlb > internalHostnamePrefix`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="proxyNamespace"></a>9. Property `envoy-gateway-nlb > proxyNamespace`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="proxyProtocolV2"></a>10. Property `envoy-gateway-nlb > proxyProtocolV2`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+## <a name="tags"></a>11. Property `envoy-gateway-nlb > tags`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+----------------------------------------------------------------------------------------------------------------------------

--- a/envoy-gateway-nlb/templates/_helpers.tpl
+++ b/envoy-gateway-nlb/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{- define "envoy-gateway-nlb.selector" -}}
+app.kubernetes.io/managed-by: envoy-gateway
+gateway.envoyproxy.io/owning-gateway-name: {{ .Values.gatewayName }}
+gateway.envoyproxy.io/owning-gateway-namespace: {{ .Values.gatewayNamespace }}
+{{- end }}
+
+{{- define "envoy-gateway-nlb.ports" -}}
+- name: http
+  port: 80
+  targetPort: 10080
+  protocol: TCP
+- name: https
+  port: 443
+  targetPort: 10443
+  protocol: TCP
+{{- end }}
+
+{{- define "envoy-gateway-nlb.tags" -}}
+{{- $pairs := list -}}
+{{- range $k, $v := .Values.tags -}}
+{{- $pairs = append $pairs (printf "%s=%s" $k $v) -}}
+{{- end -}}
+{{- join "," $pairs -}}
+{{- end }}

--- a/envoy-gateway-nlb/templates/nlb-service.yaml
+++ b/envoy-gateway-nlb/templates/nlb-service.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nlb-envoy
+  namespace: {{ .Values.proxyNamespace }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.externalHostnamePrefix }}.{{ .Values.clusterName }}.{{ .Values.baseDomain }}
+    {{- if .Values.proxyProtocolV2 }}
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
+    {{- end }}
+    {{- if .Values.tags }}
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" . | quote }}
+    {{- end }}
+spec:
+  type: LoadBalancer
+  loadBalancerClass: service.k8s.aws/nlb
+  externalTrafficPolicy: Cluster
+  selector:
+    {{- include "envoy-gateway-nlb.selector" . | nindent 4 }}
+  ports:
+    {{- include "envoy-gateway-nlb.ports" . | nindent 4 }}
+{{- if .Values.internal.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nlb-envoy-internal
+  namespace: {{ .Values.proxyNamespace }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.internalHostnamePrefix }}.{{ .Values.clusterName }}.{{ .Values.baseDomain }}
+    {{- if .Values.tags }}
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" . | quote }}
+    {{- end }}
+spec:
+  type: LoadBalancer
+  loadBalancerClass: service.k8s.aws/nlb
+  externalTrafficPolicy: Cluster
+  selector:
+    {{- include "envoy-gateway-nlb.selector" . | nindent 4 }}
+  ports:
+    {{- include "envoy-gateway-nlb.ports" . | nindent 4 }}
+{{- end }}
+{{- range .Values.additionalInternalNLBs }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nlb-envoy-{{ .name }}-internal
+  namespace: {{ $.Values.proxyNamespace }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
+    external-dns.alpha.kubernetes.io/hostname: {{ .hostname }}
+    {{- if $.Values.tags }}
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" $ | quote }}
+    {{- end }}
+spec:
+  type: LoadBalancer
+  loadBalancerClass: service.k8s.aws/nlb
+  externalTrafficPolicy: Cluster
+  selector:
+    {{- include "envoy-gateway-nlb.selector" $ | nindent 4 }}
+  ports:
+    {{- include "envoy-gateway-nlb.ports" $ | nindent 4 }}
+{{- end }}

--- a/envoy-gateway-nlb/tests/nlb-service_test.yaml
+++ b/envoy-gateway-nlb/tests/nlb-service_test.yaml
@@ -1,0 +1,184 @@
+suite: test nlb-service.yaml
+templates:
+  - nlb-service.yaml
+
+tests:
+  - it: should render only the external Service by default
+    set:
+      clusterName: test-cluster
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: nlb-envoy
+      - equal:
+          path: metadata.namespace
+          value: envoy-gateway-controller
+
+  - it: should compose the external hostname from prefix, cluster, and base domain
+    set:
+      clusterName: test-cluster
+      baseDomain: dev.czi.team
+    asserts:
+      - equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+          value: access-gw.test-cluster.dev.czi.team
+
+  - it: should render external NLB annotations
+    set:
+      clusterName: test-cluster
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"]
+          value: instance
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]
+          value: internet-facing
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: external
+
+  - it: should enable proxy protocol v2 by default
+    set:
+      clusterName: test-cluster
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
+          value: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
+
+  - it: should omit target group attributes when proxy protocol is disabled
+    set:
+      clusterName: test-cluster
+      proxyProtocolV2: false
+    asserts:
+      - notExists:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
+
+  - it: should select the envoy proxy pods for the cluster-wide Gateway
+    set:
+      clusterName: test-cluster
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/managed-by"]
+          value: envoy-gateway
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-name"]
+          value: envoy-gateway
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-namespace"]
+          value: envoy-gateway
+
+  - it: should respect a custom gateway name and namespace in the selector
+    set:
+      clusterName: test-cluster
+      gatewayName: my-gateway
+      gatewayNamespace: my-namespace
+    asserts:
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-name"]
+          value: my-gateway
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-namespace"]
+          value: my-namespace
+
+  - it: should forward 80/443 to the envoy listener ports
+    set:
+      clusterName: test-cluster
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - name: http
+              port: 80
+              targetPort: 10080
+              protocol: TCP
+            - name: https
+              port: 443
+              targetPort: 10443
+              protocol: TCP
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.loadBalancerClass
+          value: service.k8s.aws/nlb
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Cluster
+
+  - it: should omit the tags annotation when no tags are set
+    set:
+      clusterName: test-cluster
+    asserts:
+      - notExists:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"]
+
+  - it: should render tags as a sorted comma-separated list
+    set:
+      clusterName: test-cluster
+      tags:
+        owner: infra-eng
+        env: dev
+        managedBy: argocd
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"]
+          value: env=dev,managedBy=argocd,owner=infra-eng
+
+  - it: should render the internal Service when enabled
+    set:
+      clusterName: test-cluster
+      baseDomain: dev.czi.team
+      internal:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: nlb-envoy-internal
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]
+          value: internal
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"]
+          value: ip
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: nlb-ip
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+          value: access-gw-internal.test-cluster.dev.czi.team
+        documentIndex: 1
+
+  - it: should render additional internal NLBs with their own hostnames
+    set:
+      clusterName: test-cluster
+      additionalInternalNLBs:
+        - name: loki
+          hostname: loki.test-cluster.dev.czi.team
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: nlb-envoy-loki-internal
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+          value: loki.test-cluster.dev.czi.team
+        documentIndex: 1
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-name"]
+          value: envoy-gateway
+        documentIndex: 1

--- a/envoy-gateway-nlb/values.schema.json
+++ b/envoy-gateway-nlb/values.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "argo.helm.charts/envoy-gateway-nlb",
+  "title": "envoy-gateway-nlb",
+  "type": "object",
+  "properties": {
+    "additionalInternalNLBs": {
+      "type": "array"
+    },
+    "baseDomain": {
+      "type": "string"
+    },
+    "clusterName": {
+      "type": "string"
+    },
+    "externalHostnamePrefix": {
+      "type": "string"
+    },
+    "gatewayName": {
+      "type": "string"
+    },
+    "gatewayNamespace": {
+      "type": "string"
+    },
+    "internal": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "internalHostnamePrefix": {
+      "type": "string"
+    },
+    "proxyNamespace": {
+      "type": "string"
+    },
+    "proxyProtocolV2": {
+      "type": "boolean"
+    },
+    "tags": {
+      "type": "object"
+    }
+  }
+}

--- a/envoy-gateway-nlb/values.yaml
+++ b/envoy-gateway-nlb/values.yaml
@@ -1,0 +1,19 @@
+clusterName: ""
+baseDomain: "dev.czi.team"
+
+gatewayName: "envoy-gateway"
+gatewayNamespace: "envoy-gateway"
+
+proxyNamespace: "envoy-gateway-controller"
+
+externalHostnamePrefix: "access-gw"
+internalHostnamePrefix: "access-gw-internal"
+
+proxyProtocolV2: true
+
+internal:
+  enabled: false
+
+additionalInternalNLBs: []
+
+tags: {}


### PR DESCRIPTION
## What

Adds the **envoy-gateway-nlb** chart: NLB `LoadBalancer` Services fronting the Envoy Gateway proxy, for the nginx → Envoy Gateway migration ([CCIE-6701](https://czi.atlassian.net/browse/CCIE-6701)).

This is the ApplicationSet-pattern rework of the Terraform `eks-nlb-to-envoy-service` module from chanzuckerberg/argus-infra-stacks#2546 — that module managed only Kubernetes objects, so per review feedback it belongs here instead.

### What it deploys
- `nlb-envoy` Service in `envoy-gateway-controller` (where envoy-gateway creates the proxy pods): internet-facing NLB at `access-gw.<clusterName>.<baseDomain>` via external-dns, ports `80→10080` / `443→10443`, proxy protocol v2 + client-IP preservation on by default.
- Selects the proxy pods via the stable owning-Gateway labels (`gateway.envoyproxy.io/owning-gateway-name: envoy-gateway`), matching the `envoy-gateway-resources` chart — no lookup of the envoy-gateway-managed proxy Service needed.
- Optional `internal.enabled` / `additionalInternalNLBs` Services preserve the shape needed for VPC endpoint services later (AWS-side resources stay in Terraform and locate these NLBs by controller tags).
- `tags` value renders the `aws-load-balancer-additional-resource-tags` annotation.

### Design notes
- Hostnames are concrete per-cluster records (not wildcards) so they can be used as CNAME targets — wildcard records [can't be](https://serverfault.com/questions/1135066/point-cname-record-to-multiple-wildcard-a-records).
- `externalTrafficPolicy: Cluster` is required with instance target type; with `Local`, the healthCheckNodePort is set to the wrong port number under proxy protocol v2.

### Companion PR
ApplicationSets consuming this chart: linked in comments. This chart PR should merge first — the ApplicationSets reference the chart path at HEAD.

## Test plan
- `helm unittest`: 12/12 passing (hostname composition, selector, ports, proxy-protocol toggle, tags rendering, internal + additional internal NLBs).
- `helm lint` clean.
- `helm template` with `clusterName=dev-ml-platform` renders annotations/spec equivalent to the Terraform module output that was plan-verified in #2546's test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIE-6701]: https://czi.atlassian.net/browse/CCIE-6701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ