### PR TITLE
fix: derive envoy-gateway-nlb hostnames from baseDomain alone

### DIFF
--- a/envoy-gateway-nlb/README.md
+++ b/envoy-gateway-nlb/README.md
@@ -12,7 +12,6 @@
 | ---------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
 | - [additionalInternalNLBs](#additionalInternalNLBs ) | No      | array   | No         | -          | -                 |
 | - [baseDomain](#baseDomain )                         | No      | string  | No         | -          | -                 |
-| - [clusterName](#clusterName )                       | No      | string  | No         | -          | -                 |
 | - [externalHostnamePrefix](#externalHostnamePrefix ) | No      | string  | No         | -          | -                 |
 | - [gatewayName](#gatewayName )                       | No      | string  | No         | -          | -                 |
 | - [gatewayNamespace](#gatewayNamespace )             | No      | string  | No         | -          | -                 |
@@ -44,35 +43,28 @@
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="clusterName"></a>3. Property `envoy-gateway-nlb > clusterName`
+## <a name="externalHostnamePrefix"></a>3. Property `envoy-gateway-nlb > externalHostnamePrefix`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="externalHostnamePrefix"></a>4. Property `envoy-gateway-nlb > externalHostnamePrefix`
+## <a name="gatewayName"></a>4. Property `envoy-gateway-nlb > gatewayName`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayName"></a>5. Property `envoy-gateway-nlb > gatewayName`
+## <a name="gatewayNamespace"></a>5. Property `envoy-gateway-nlb > gatewayNamespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayNamespace"></a>6. Property `envoy-gateway-nlb > gatewayNamespace`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-## <a name="internal"></a>7. Property `envoy-gateway-nlb > internal`
+## <a name="internal"></a>6. Property `envoy-gateway-nlb > internal`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -84,35 +76,35 @@
 | ------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
 | - [enabled](#internal_enabled ) | No      | boolean | No         | -          | -                 |
 
-### <a name="internal_enabled"></a>7.1. Property `envoy-gateway-nlb > internal > enabled`
+### <a name="internal_enabled"></a>6.1. Property `envoy-gateway-nlb > internal > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="internalHostnamePrefix"></a>8. Property `envoy-gateway-nlb > internalHostnamePrefix`
+## <a name="internalHostnamePrefix"></a>7. Property `envoy-gateway-nlb > internalHostnamePrefix`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="proxyNamespace"></a>9. Property `envoy-gateway-nlb > proxyNamespace`
+## <a name="proxyNamespace"></a>8. Property `envoy-gateway-nlb > proxyNamespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="proxyProtocolV2"></a>10. Property `envoy-gateway-nlb > proxyProtocolV2`
+## <a name="proxyProtocolV2"></a>9. Property `envoy-gateway-nlb > proxyProtocolV2`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="tags"></a>11. Property `envoy-gateway-nlb > tags`
+## <a name="tags"></a>10. Property `envoy-gateway-nlb > tags`
 
 |                           |                  |
 | ------------------------- | ---------------- |

--- a/envoy-gateway-nlb/templates/nlb-service.yaml
+++ b/envoy-gateway-nlb/templates/nlb-service.yaml
@@ -7,7 +7,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: external
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.externalHostnamePrefix }}.{{ .Values.clusterName }}.{{ .Values.baseDomain }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.externalHostnamePrefix }}.{{ .Values.baseDomain }}
     {{- if .Values.proxyProtocolV2 }}
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
     {{- end }}
@@ -35,7 +35,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.internalHostnamePrefix }}.{{ .Values.clusterName }}.{{ .Values.baseDomain }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.internalHostnamePrefix }}.{{ .Values.baseDomain }}
     {{- if .Values.tags }}
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" . | quote }}
     {{- end }}

--- a/envoy-gateway-nlb/tests/nlb-service_test.yaml
+++ b/envoy-gateway-nlb/tests/nlb-service_test.yaml
@@ -4,8 +4,6 @@ templates:
 
 tests:
   - it: should render only the external Service by default
-    set:
-      clusterName: test-cluster
     asserts:
       - hasDocuments:
           count: 1
@@ -18,18 +16,15 @@ tests:
           path: metadata.namespace
           value: envoy-gateway-controller
 
-  - it: should compose the external hostname from prefix, cluster, and base domain
+  - it: should compose the external hostname from prefix and base domain
     set:
-      clusterName: test-cluster
-      baseDomain: dev.czi.team
+      baseDomain: test-cluster.dev.czi.team
     asserts:
       - equal:
           path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
           value: access-gw.test-cluster.dev.czi.team
 
   - it: should render external NLB annotations
-    set:
-      clusterName: test-cluster
     asserts:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"]
@@ -42,8 +37,6 @@ tests:
           value: external
 
   - it: should enable proxy protocol v2 by default
-    set:
-      clusterName: test-cluster
     asserts:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
@@ -51,15 +44,12 @@ tests:
 
   - it: should omit target group attributes when proxy protocol is disabled
     set:
-      clusterName: test-cluster
       proxyProtocolV2: false
     asserts:
       - notExists:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
 
   - it: should select the envoy proxy pods for the cluster-wide Gateway
-    set:
-      clusterName: test-cluster
     asserts:
       - equal:
           path: spec.selector["app.kubernetes.io/managed-by"]
@@ -73,7 +63,6 @@ tests:
 
   - it: should respect a custom gateway name and namespace in the selector
     set:
-      clusterName: test-cluster
       gatewayName: my-gateway
       gatewayNamespace: my-namespace
     asserts:
@@ -85,8 +74,6 @@ tests:
           value: my-namespace
 
   - it: should forward 80/443 to the envoy listener ports
-    set:
-      clusterName: test-cluster
     asserts:
       - equal:
           path: spec.ports
@@ -110,15 +97,12 @@ tests:
           value: Cluster
 
   - it: should omit the tags annotation when no tags are set
-    set:
-      clusterName: test-cluster
     asserts:
       - notExists:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"]
 
   - it: should render tags as a sorted comma-separated list
     set:
-      clusterName: test-cluster
       tags:
         owner: infra-eng
         env: dev
@@ -130,8 +114,7 @@ tests:
 
   - it: should render the internal Service when enabled
     set:
-      clusterName: test-cluster
-      baseDomain: dev.czi.team
+      baseDomain: test-cluster.dev.czi.team
       internal:
         enabled: true
     asserts:
@@ -163,7 +146,6 @@ tests:
 
   - it: should render additional internal NLBs with their own hostnames
     set:
-      clusterName: test-cluster
       additionalInternalNLBs:
         - name: loki
           hostname: loki.test-cluster.dev.czi.team

--- a/envoy-gateway-nlb/values.schema.json
+++ b/envoy-gateway-nlb/values.schema.json
@@ -10,9 +10,6 @@
     "baseDomain": {
       "type": "string"
     },
-    "clusterName": {
-      "type": "string"
-    },
     "externalHostnamePrefix": {
       "type": "string"
     },

--- a/envoy-gateway-nlb/values.yaml
+++ b/envoy-gateway-nlb/values.yaml
@@ -1,5 +1,4 @@
-clusterName: ""
-baseDomain: "dev.czi.team"
+baseDomain: "example.dev.czi.team"
 
 gatewayName: "envoy-gateway"
 gatewayNamespace: "envoy-gateway"


### PR DESCRIPTION
## What

Reworks envoy-gateway-nlb hostname composition: `baseDomain` is now the cluster's **full DNS zone** (matching the `base-domain` cluster-secret label convention already used by cluster-healthcheck), hostnames are `<prefix>.<baseDomain>`, and `clusterName` is removed.

This fixes the `in-cluster` Application on nonprod ArgoCD rendering the nonsensical `access-gw.in-cluster.dev.czi.team` — with the label-driven values it renders the real FQDN `access-gw.core-platform.dev.czi.team`.

Companion ApplicationSet change (passes `baseDomain` from the `base-domain` label): chanzuckerberg/argus-infra-stacks#2557. Merge both promptly — between the two merges the rendered hostname is transiently wrong (no traffic impact; nothing serves through these NLBs yet).

## Test plan
- `helm unittest` 12/12, `helm lint` clean.
- `helm template --set baseDomain=core-platform.dev.czi.team` renders `external-dns.alpha.kubernetes.io/hostname: access-gw.core-platform.dev.czi.team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)