### PR TITLE
feat: add ClientTrafficPolicy enabling proxy protocol on envoy (default on)

### DIFF
--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -16,6 +16,7 @@
 | - [envoyService](#envoyService )     | No      | object | No         | -          | -                 |
 | - [gatewayName](#gatewayName )       | No      | string | No         | -          | -                 |
 | - [geoip](#geoip )                   | No      | object | No         | -          | -                 |
+| - [proxyProtocol](#proxyProtocol )   | No      | object | No         | -          | -                 |
 | - [serviceAccount](#serviceAccount ) | No      | object | No         | -          | -                 |
 
 ## <a name="alternateNames"></a>1. Property `envoy-gateway-resources > alternateNames`
@@ -119,7 +120,34 @@
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="serviceAccount"></a>7. Property `envoy-gateway-resources > serviceAccount`
+## <a name="proxyProtocol"></a>7. Property `envoy-gateway-resources > proxyProtocol`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                               | Pattern | Type    | Deprecated | Definition | Title/Description |
+| -------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [enabled](#proxyProtocol_enabled )   | No      | boolean | No         | -          | -                 |
+| - [optional](#proxyProtocol_optional ) | No      | boolean | No         | -          | -                 |
+
+### <a name="proxyProtocol_enabled"></a>7.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+### <a name="proxyProtocol_optional"></a>7.2. Property `envoy-gateway-resources > proxyProtocol > optional`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+## <a name="serviceAccount"></a>8. Property `envoy-gateway-resources > serviceAccount`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -132,7 +160,7 @@
 | - [annotations](#serviceAccount_annotations ) | No      | object | No         | -          | -                 |
 | - [name](#serviceAccount_name )               | No      | string | No         | -          | -                 |
 
-### <a name="serviceAccount_annotations"></a>7.1. Property `envoy-gateway-resources > serviceAccount > annotations`
+### <a name="serviceAccount_annotations"></a>8.1. Property `envoy-gateway-resources > serviceAccount > annotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -140,7 +168,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-### <a name="serviceAccount_name"></a>7.2. Property `envoy-gateway-resources > serviceAccount > name`
+### <a name="serviceAccount_name"></a>8.2. Property `envoy-gateway-resources > serviceAccount > name`
 
 |              |          |
 | ------------ | -------- |

--- a/envoy-gateway-resources/templates/client-traffic-policy.yaml
+++ b/envoy-gateway-resources/templates/client-traffic-policy.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.proxyProtocol.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: {{ .Values.gatewayName }}-client-traffic
+  namespace: envoy-gateway
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.gatewayName }}
+  proxyProtocol:
+    optional: {{ .Values.proxyProtocol.optional }}
+{{- end }}

--- a/envoy-gateway-resources/tests/client-traffic-policy_test.yaml
+++ b/envoy-gateway-resources/tests/client-traffic-policy_test.yaml
@@ -1,0 +1,57 @@
+suite: test client-traffic-policy.yaml
+templates:
+  - client-traffic-policy.yaml
+
+tests:
+  - it: should render nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ClientTrafficPolicy targeting the Gateway when enabled
+    set:
+      proxyProtocol:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClientTrafficPolicy
+      - equal:
+          path: metadata.name
+          value: envoy-gateway-client-traffic
+      - equal:
+          path: metadata.namespace
+          value: envoy-gateway
+      - equal:
+          path: spec.targetRefs[0].kind
+          value: Gateway
+      - equal:
+          path: spec.targetRefs[0].name
+          value: envoy-gateway
+      - equal:
+          path: spec.proxyProtocol.optional
+          value: false
+
+  - it: should follow a custom gateway name
+    set:
+      gatewayName: my-gateway
+      proxyProtocol:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-gateway-client-traffic
+      - equal:
+          path: spec.targetRefs[0].name
+          value: my-gateway
+
+  - it: should pass through optional proxy protocol
+    set:
+      proxyProtocol:
+        enabled: true
+        optional: true
+    asserts:
+      - equal:
+          path: spec.proxyProtocol.optional
+          value: true

--- a/envoy-gateway-resources/tests/client-traffic-policy_test.yaml
+++ b/envoy-gateway-resources/tests/client-traffic-policy_test.yaml
@@ -3,15 +3,7 @@ templates:
   - client-traffic-policy.yaml
 
 tests:
-  - it: should render nothing by default
-    asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: should render a ClientTrafficPolicy targeting the Gateway when enabled
-    set:
-      proxyProtocol:
-        enabled: true
+  - it: should render a ClientTrafficPolicy by default
     asserts:
       - hasDocuments:
           count: 1
@@ -33,11 +25,17 @@ tests:
           path: spec.proxyProtocol.optional
           value: false
 
+  - it: should render nothing when disabled
+    set:
+      proxyProtocol:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should follow a custom gateway name
     set:
       gatewayName: my-gateway
-      proxyProtocol:
-        enabled: true
     asserts:
       - equal:
           path: metadata.name
@@ -49,7 +47,6 @@ tests:
   - it: should pass through optional proxy protocol
     set:
       proxyProtocol:
-        enabled: true
         optional: true
     asserts:
       - equal:

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -38,6 +38,17 @@
         }
       }
     },
+    "proxyProtocol": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "optional": {
+          "type": "boolean"
+        }
+      }
+    },
     "serviceAccount": {
       "type": "object",
       "properties": {

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -39,3 +39,7 @@ geoip:
     - "UA"
     - "VE"
     - "YE"
+
+proxyProtocol:
+  enabled: false
+  optional: false

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -41,5 +41,5 @@ geoip:
     - "YE"
 
 proxyProtocol:
-  enabled: false
+  enabled: true
   optional: false


### PR DESCRIPTION
## What

Adds a `ClientTrafficPolicy` to the envoy-gateway-resources chart targeting the cluster-wide Gateway, enabling the proxy protocol listener filter — **on by default** (`proxyProtocol.enabled: true`, opt out per cluster/env via values):

```yaml
spec:
  targetRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: envoy-gateway
  proxyProtocol:
    optional: false
```

The envoy NLBs (envoy-gateway-nlb chart) enable proxy-protocol-v2 on their target groups, but envoy had no proxy protocol listener filter — every connection through the NLB was reset during the TLS handshake. This was the known follow-up from the chanzuckerberg/argus-infra-stacks#2546 review thread.

Uses `proxyProtocol` (EG ≥v1.3 API; verified present in the v1.6.2 CRDs we deploy) rather than the deprecated `enableProxyProtocol`. `proxyProtocol.optional` is exposed for permissive mode but defaults to strict.

Prod note: prod picks this up at HEAD on merge. Safe today — nothing reaches the prod envoy listeners until prod NLBs exist — and it means PPv2 handling is correct from day one when they do.

## Test plan
- `helm unittest`: 70/70 (renders by default, explicit-disable renders nothing, custom gateway name, optional passthrough).
- `helm lint` clean; rendered output validated against the v1.6.2 ClientTrafficPolicy CRD.
- Validated live on nonprod (via branch-pinned ApplicationSet, chanzuckerberg/argus-infra-stacks#2559): `https://access-gw.dev-core-platform.dev.czi.team` went from connection-reset to TLS handshake with the LE wildcard cert + envoy 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)