### PR TITLE
fix: set route53 solver region on the letsencrypt-prod-eg ClusterIssuer

### DIFF
--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -11,6 +11,7 @@
 | Property                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [alternateNames](#alternateNames ) | No      | array  | No         | -          | -                 |
+| - [awsRegion](#awsRegion )           | No      | string | No         | -          | -                 |
 | - [baseDomain](#baseDomain )         | No      | string | No         | -          | -                 |
 | - [clusterName](#clusterName )       | No      | string | No         | -          | -                 |
 | - [envoyService](#envoyService )     | No      | object | No         | -          | -                 |
@@ -34,21 +35,28 @@
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-## <a name="baseDomain"></a>2. Property `envoy-gateway-resources > baseDomain`
+## <a name="awsRegion"></a>2. Property `envoy-gateway-resources > awsRegion`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="clusterName"></a>3. Property `envoy-gateway-resources > clusterName`
+## <a name="baseDomain"></a>3. Property `envoy-gateway-resources > baseDomain`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="envoyService"></a>4. Property `envoy-gateway-resources > envoyService`
+## <a name="clusterName"></a>4. Property `envoy-gateway-resources > clusterName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="envoyService"></a>5. Property `envoy-gateway-resources > envoyService`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -60,21 +68,21 @@
 | ----------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [type](#envoyService_type ) | No      | string | No         | -          | -                 |
 
-### <a name="envoyService_type"></a>4.1. Property `envoy-gateway-resources > envoyService > type`
+### <a name="envoyService_type"></a>5.1. Property `envoy-gateway-resources > envoyService > type`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayName"></a>5. Property `envoy-gateway-resources > gatewayName`
+## <a name="gatewayName"></a>6. Property `envoy-gateway-resources > gatewayName`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="geoip"></a>6. Property `envoy-gateway-resources > geoip`
+## <a name="geoip"></a>7. Property `envoy-gateway-resources > geoip`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -87,7 +95,7 @@
 | - [blockedCountries](#geoip_blockedCountries ) | No      | array of string | No         | -          | -                 |
 | - [enabled](#geoip_enabled )                   | No      | boolean         | No         | -          | -                 |
 
-### <a name="geoip_blockedCountries"></a>6.1. Property `envoy-gateway-resources > geoip > blockedCountries`
+### <a name="geoip_blockedCountries"></a>7.1. Property `envoy-gateway-resources > geoip > blockedCountries`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -106,21 +114,21 @@
 | ------------------------------------------------------- | ----------- |
 | [blockedCountries items](#geoip_blockedCountries_items) | -           |
 
-#### <a name="geoip_blockedCountries_items"></a>6.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
+#### <a name="geoip_blockedCountries_items"></a>7.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="geoip_enabled"></a>6.2. Property `envoy-gateway-resources > geoip > enabled`
+### <a name="geoip_enabled"></a>7.2. Property `envoy-gateway-resources > geoip > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="proxyProtocol"></a>7. Property `envoy-gateway-resources > proxyProtocol`
+## <a name="proxyProtocol"></a>8. Property `envoy-gateway-resources > proxyProtocol`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -133,21 +141,21 @@
 | - [enabled](#proxyProtocol_enabled )   | No      | boolean | No         | -          | -                 |
 | - [optional](#proxyProtocol_optional ) | No      | boolean | No         | -          | -                 |
 
-### <a name="proxyProtocol_enabled"></a>7.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
+### <a name="proxyProtocol_enabled"></a>8.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-### <a name="proxyProtocol_optional"></a>7.2. Property `envoy-gateway-resources > proxyProtocol > optional`
+### <a name="proxyProtocol_optional"></a>8.2. Property `envoy-gateway-resources > proxyProtocol > optional`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="serviceAccount"></a>8. Property `envoy-gateway-resources > serviceAccount`
+## <a name="serviceAccount"></a>9. Property `envoy-gateway-resources > serviceAccount`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -160,7 +168,7 @@
 | - [annotations](#serviceAccount_annotations ) | No      | object | No         | -          | -                 |
 | - [name](#serviceAccount_name )               | No      | string | No         | -          | -                 |
 
-### <a name="serviceAccount_annotations"></a>8.1. Property `envoy-gateway-resources > serviceAccount > annotations`
+### <a name="serviceAccount_annotations"></a>9.1. Property `envoy-gateway-resources > serviceAccount > annotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -168,7 +176,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-### <a name="serviceAccount_name"></a>8.2. Property `envoy-gateway-resources > serviceAccount > name`
+### <a name="serviceAccount_name"></a>9.2. Property `envoy-gateway-resources > serviceAccount > name`
 
 |              |          |
 | ------------ | -------- |

--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -53,7 +53,8 @@ spec:
           dnsZones:
             - "{{ .Values.clusterName }}.{{ .Values.baseDomain }}"
         dns01:
-          route53: {}
+          route53:
+            region: {{ .Values.awsRegion }}
       - selector: {}
         http01:
           gatewayHTTPRoute:

--- a/envoy-gateway-resources/tests/gateway_test.yaml
+++ b/envoy-gateway-resources/tests/gateway_test.yaml
@@ -352,3 +352,22 @@ tests:
       - contains:
           path: spec.usages
           content: key encipherment
+
+  - it: should set the route53 solver region from awsRegion
+    set:
+      clusterName: test-cluster
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: spec.acme.solvers[0].dns01.route53.region
+          value: us-west-2
+
+  - it: should respect a custom awsRegion
+    set:
+      clusterName: test-cluster
+      awsRegion: us-east-1
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: spec.acme.solvers[0].dns01.route53.region
+          value: us-east-1

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -7,6 +7,9 @@
     "alternateNames": {
       "type": "array"
     },
+    "awsRegion": {
+      "type": "string"
+    },
     "baseDomain": {
       "type": "string"
     },

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -1,5 +1,6 @@
 clusterName: ""
 baseDomain: "dev.czi.team"
+awsRegion: "us-west-2"
 gatewayName: "envoy-gateway"
 alternateNames: []
 


### PR DESCRIPTION
## What

Adds `awsRegion` (default `us-west-2`) to envoy-gateway-resources and sets it as the route53 dns01 solver region on the `letsencrypt-prod-eg` ClusterIssuer.

cert-manager on several clusters rejects the solver without an explicit region — `ClusterIssuer ... spec.acme.solvers[0].dns01.route53.region: Required value` — leaving `envoy-gateway-resources` permanently OutOfSync/Degraded and the `envoy-gateway-tls` wildcard cert unissued (TLS handshake through the envoy NLB fails outright). Observed live on `dev-cilium-test` (chronic) and `in-cluster` on nonprod ArgoCD; clusters with newer cert-manager tolerate the empty solver, which is why e.g. dev-core-platform worked.

The default alone fixes every currently-affected cluster at HEAD. Per-cluster correctness for us-east-1 clusters comes from the companion ApplicationSet change injecting `awsRegion` from the `aws-region` cluster-secret label: chanzuckerberg/argus-infra-stacks#2563.

## Test plan
- `helm unittest` 72/72 (2 new: default region renders, custom region respected).
- `helm lint` clean; rendered solver: `route53: { region: us-east-1 }` with override.
- After merge: `dev-cilium-test-envoy-gateway-resources` and `in-cluster-envoy-gateway-resources` (nonprod) should go Synced and their wildcard certs issue (in-cluster additionally needs its IRSA role — tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)