### PR TITLE
fix: derive envoy-gateway-resources domains from baseDomain alone

### DIFF
--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -13,7 +13,6 @@
 | - [alternateNames](#alternateNames ) | No      | array  | No         | -          | -                 |
 | - [awsRegion](#awsRegion )           | No      | string | No         | -          | -                 |
 | - [baseDomain](#baseDomain )         | No      | string | No         | -          | -                 |
-| - [clusterName](#clusterName )       | No      | string | No         | -          | -                 |
 | - [envoyService](#envoyService )     | No      | object | No         | -          | -                 |
 | - [gatewayName](#gatewayName )       | No      | string | No         | -          | -                 |
 | - [geoip](#geoip )                   | No      | object | No         | -          | -                 |
@@ -49,14 +48,7 @@
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="clusterName"></a>4. Property `envoy-gateway-resources > clusterName`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-## <a name="envoyService"></a>5. Property `envoy-gateway-resources > envoyService`
+## <a name="envoyService"></a>4. Property `envoy-gateway-resources > envoyService`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -68,21 +60,21 @@
 | ----------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [type](#envoyService_type ) | No      | string | No         | -          | -                 |
 
-### <a name="envoyService_type"></a>5.1. Property `envoy-gateway-resources > envoyService > type`
+### <a name="envoyService_type"></a>4.1. Property `envoy-gateway-resources > envoyService > type`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayName"></a>6. Property `envoy-gateway-resources > gatewayName`
+## <a name="gatewayName"></a>5. Property `envoy-gateway-resources > gatewayName`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="geoip"></a>7. Property `envoy-gateway-resources > geoip`
+## <a name="geoip"></a>6. Property `envoy-gateway-resources > geoip`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -95,7 +87,7 @@
 | - [blockedCountries](#geoip_blockedCountries ) | No      | array of string | No         | -          | -                 |
 | - [enabled](#geoip_enabled )                   | No      | boolean         | No         | -          | -                 |
 
-### <a name="geoip_blockedCountries"></a>7.1. Property `envoy-gateway-resources > geoip > blockedCountries`
+### <a name="geoip_blockedCountries"></a>6.1. Property `envoy-gateway-resources > geoip > blockedCountries`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -114,21 +106,21 @@
 | ------------------------------------------------------- | ----------- |
 | [blockedCountries items](#geoip_blockedCountries_items) | -           |
 
-#### <a name="geoip_blockedCountries_items"></a>7.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
+#### <a name="geoip_blockedCountries_items"></a>6.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="geoip_enabled"></a>7.2. Property `envoy-gateway-resources > geoip > enabled`
+### <a name="geoip_enabled"></a>6.2. Property `envoy-gateway-resources > geoip > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="proxyProtocol"></a>8. Property `envoy-gateway-resources > proxyProtocol`
+## <a name="proxyProtocol"></a>7. Property `envoy-gateway-resources > proxyProtocol`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -141,21 +133,21 @@
 | - [enabled](#proxyProtocol_enabled )   | No      | boolean | No         | -          | -                 |
 | - [optional](#proxyProtocol_optional ) | No      | boolean | No         | -          | -                 |
 
-### <a name="proxyProtocol_enabled"></a>8.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
+### <a name="proxyProtocol_enabled"></a>7.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-### <a name="proxyProtocol_optional"></a>8.2. Property `envoy-gateway-resources > proxyProtocol > optional`
+### <a name="proxyProtocol_optional"></a>7.2. Property `envoy-gateway-resources > proxyProtocol > optional`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="serviceAccount"></a>9. Property `envoy-gateway-resources > serviceAccount`
+## <a name="serviceAccount"></a>8. Property `envoy-gateway-resources > serviceAccount`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -168,7 +160,7 @@
 | - [annotations](#serviceAccount_annotations ) | No      | object | No         | -          | -                 |
 | - [name](#serviceAccount_name )               | No      | string | No         | -          | -                 |
 
-### <a name="serviceAccount_annotations"></a>9.1. Property `envoy-gateway-resources > serviceAccount > annotations`
+### <a name="serviceAccount_annotations"></a>8.1. Property `envoy-gateway-resources > serviceAccount > annotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -176,7 +168,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-### <a name="serviceAccount_name"></a>9.2. Property `envoy-gateway-resources > serviceAccount > name`
+### <a name="serviceAccount_name"></a>8.2. Property `envoy-gateway-resources > serviceAccount > name`
 
 |              |          |
 | ------------ | -------- |

--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -27,7 +27,7 @@ spec:
     - name: https
       protocol: HTTPS
       port: 443
-      hostname: "*.{{ .Values.clusterName }}.{{ .Values.baseDomain }}"
+      hostname: "*.{{ .Values.baseDomain }}"
       allowedRoutes:
         namespaces:
           from: All
@@ -51,7 +51,7 @@ spec:
     solvers:
       - selector:
           dnsZones:
-            - "{{ .Values.clusterName }}.{{ .Values.baseDomain }}"
+            - "{{ .Values.baseDomain }}"
         dns01:
           route53:
             region: {{ .Values.awsRegion }}
@@ -70,10 +70,10 @@ metadata:
   name: {{ .Values.gatewayName }}-wildcard-cert
   namespace: envoy-gateway
 spec:
-  commonName: "*.{{ .Values.clusterName }}.{{ .Values.baseDomain }}"
+  commonName: "*.{{ .Values.baseDomain }}"
   dnsNames:
-    - "*.{{ .Values.clusterName }}.{{ .Values.baseDomain }}"
-    - "{{ .Values.clusterName }}.{{ .Values.baseDomain }}"
+    - "*.{{ .Values.baseDomain }}"
+    - "{{ .Values.baseDomain }}"
 {{- range .Values.alternateNames }}
     - "{{ . }}"
 {{- end }}

--- a/envoy-gateway-resources/tests/gateway_test.yaml
+++ b/envoy-gateway-resources/tests/gateway_test.yaml
@@ -7,8 +7,7 @@ tests:
   - it: should render all gateway resources
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
-      baseDomain: dev.czi.team
+      baseDomain: test-cluster.dev.czi.team
     asserts:
       - hasDocuments:
           count: 4
@@ -16,7 +15,7 @@ tests:
   - it: should render GatewayClass as first document
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 0
     asserts:
       - isKind:
@@ -32,7 +31,7 @@ tests:
   - it: should render Gateway as second document
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 1
     asserts:
       - isKind:
@@ -47,7 +46,7 @@ tests:
   - it: should use correct gateway name
     set:
       gatewayName: my-custom-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 1
     asserts:
       - equal:
@@ -57,7 +56,7 @@ tests:
   - it: should use eg GatewayClass
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 1
     asserts:
       - equal:
@@ -67,7 +66,7 @@ tests:
   - it: should always include infrastructure parametersRef (regardless of geoip)
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
       geoip.enabled: false
     documentIndex: 1
     asserts:
@@ -77,7 +76,7 @@ tests:
   - it: should reference EnvoyProxy resource
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
       geoip.enabled: true
     documentIndex: 1
     asserts:
@@ -94,7 +93,7 @@ tests:
   - it: should use correct EnvoyProxy name matching gatewayName
     set:
       gatewayName: my-custom-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
       geoip.enabled: true
     documentIndex: 1
     asserts:
@@ -106,7 +105,7 @@ tests:
   - it: should have HTTP listener on port 80
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 1
     asserts:
       - equal:
@@ -125,8 +124,7 @@ tests:
   - it: should have HTTPS listener on port 443
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
-      baseDomain: dev.czi.team
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 1
     asserts:
       - equal:
@@ -142,11 +140,10 @@ tests:
           path: spec.listeners[1].allowedRoutes.namespaces.from
           value: All
 
-  - it: should configure HTTPS hostname from clusterName and baseDomain
+  - it: should configure HTTPS hostname from baseDomain
     set:
       gatewayName: test-gateway
-      clusterName: my-cluster
-      baseDomain: example.com
+      baseDomain: my-cluster.example.com
     documentIndex: 1
     asserts:
       - equal:
@@ -156,7 +153,7 @@ tests:
   - it: should configure TLS with Terminate mode
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 1
     asserts:
       - equal:
@@ -166,7 +163,7 @@ tests:
   - it: should reference correct TLS secret
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 1
     asserts:
       - equal:
@@ -183,7 +180,7 @@ tests:
   - it: should render ClusterIssuer as third document
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 2
     asserts:
       - isKind:
@@ -195,7 +192,7 @@ tests:
   - it: should use Let's Encrypt production server
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 2
     asserts:
       - equal:
@@ -205,7 +202,7 @@ tests:
   - it: should have correct email for Let's Encrypt
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 2
     asserts:
       - equal:
@@ -215,8 +212,7 @@ tests:
   - it: should configure DNS01 solver with Route53
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
-      baseDomain: example.com
+      baseDomain: test-cluster.example.com
     documentIndex: 2
     asserts:
       - equal:
@@ -228,7 +224,7 @@ tests:
   - it: should configure HTTP01 solver with gateway reference
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 2
     asserts:
       - equal:
@@ -248,7 +244,7 @@ tests:
   - it: should render Certificate as fourth document
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 3
     asserts:
       - isKind:
@@ -260,7 +256,7 @@ tests:
   - it: should use correct certificate name
     set:
       gatewayName: my-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 3
     asserts:
       - equal:
@@ -270,8 +266,7 @@ tests:
   - it: should configure wildcard certificate for cluster domain
     set:
       gatewayName: test-gateway
-      clusterName: my-cluster
-      baseDomain: example.com
+      baseDomain: my-cluster.example.com
     documentIndex: 3
     asserts:
       - equal:
@@ -287,8 +282,7 @@ tests:
   - it: should include alternate names in certificate
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
-      baseDomain: example.com
+      baseDomain: test-cluster.example.com
       alternateNames:
         - alt1.example.com
         - alt2.example.com
@@ -304,7 +298,7 @@ tests:
   - it: should reference ClusterIssuer in certificate
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 3
     asserts:
       - equal:
@@ -320,7 +314,7 @@ tests:
   - it: should use RSA 4096 private key
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 3
     asserts:
       - equal:
@@ -333,7 +327,7 @@ tests:
   - it: should use correct secret name for certificate
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 3
     asserts:
       - equal:
@@ -343,7 +337,7 @@ tests:
   - it: should include required usages
     set:
       gatewayName: test-gateway
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 3
     asserts:
       - contains:
@@ -355,7 +349,7 @@ tests:
 
   - it: should set the route53 solver region from awsRegion
     set:
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
     documentIndex: 2
     asserts:
       - equal:
@@ -364,7 +358,7 @@ tests:
 
   - it: should respect a custom awsRegion
     set:
-      clusterName: test-cluster
+      baseDomain: test-cluster.dev.czi.team
       awsRegion: us-east-1
     documentIndex: 2
     asserts:

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -13,9 +13,6 @@
     "baseDomain": {
       "type": "string"
     },
-    "clusterName": {
-      "type": "string"
-    },
     "envoyService": {
       "type": "object",
       "properties": {

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -1,5 +1,4 @@
-clusterName: ""
-baseDomain: "dev.czi.team"
+baseDomain: "example.dev.czi.team"
 awsRegion: "us-west-2"
 gatewayName: "envoy-gateway"
 alternateNames: []


### PR DESCRIPTION
## What

Same fix the envoy-gateway-nlb chart got in #475, now for envoy-gateway-resources: `baseDomain` is the cluster's **full DNS zone** (the `base-domain` cluster-secret label), all domain composition uses it directly, and `clusterName` is removed.

## Why

The prod ApplicationSet injects `clusterName: <name>` + `baseDomain: <base-domain label>`, and prod labels are full zones — so the chart's `<clusterName>.<baseDomain>` composition produces **doubled domains fleet-wide**. Verified live on prod-biohub: the Gateway HTTPS listener and issued wildcard cert are for `*.prod-biohub.prod-biohub.prod.czi.team`. Real hostnames (`x.prod-biohub.prod.czi.team`) match neither the listener SNI nor the cert, so HTTPS through the new envoy NLBs can never work in prod as-is. The nonprod mgmt cluster has the sibling symptom (`*.in-cluster.dev.czi.team` instead of `*.core-platform.dev.czi.team`).

## Rollout

Merging this fixes prod immediately at HEAD: the prod ApplicationSet already passes the correct full-zone `baseDomain`; the now-unused `clusterName` value is ignored. cert-manager re-issues the wildcard certs for the corrected names and the Gateway listeners update.

Nonprod's ApplicationSet still derives `baseDomain` from name prefixes (env zone), so its three clusters render `*.dev.czi.team` transiently until the companion appset change merges (argus-infra-stacks PR, linked in comments) — merge both promptly. Nothing serves through nonprod envoy except validation probes.

## Test plan
- `helm unittest` 72/72 (domain expectations rewritten to full-zone `baseDomain`), `helm lint` clean.
- Render with `baseDomain=core-platform.dev.czi.team` produces listener hostname / cert CN `*.core-platform.dev.czi.team` and dnsZone `core-platform.dev.czi.team`.
- After both merges: cert_check on prod-biohub + in-cluster expecting corrected dnsNames; TLS probe through the prod NLBs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)