### PR TITLE
fix: point external-dns at the envoy NLB for HTTPRoute hostnames

### DIFF
--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -10,6 +10,8 @@ kind: Gateway
 metadata:
   name: {{ .Values.gatewayName }}
   namespace: envoy-gateway
+  annotations:
+    external-dns.alpha.kubernetes.io/target: access-gw.{{ .Values.baseDomain }}
 spec:
   gatewayClassName: eg
   infrastructure:

--- a/envoy-gateway-resources/tests/gateway_test.yaml
+++ b/envoy-gateway-resources/tests/gateway_test.yaml
@@ -365,3 +365,12 @@ tests:
       - equal:
           path: spec.acme.solvers[0].dns01.route53.region
           value: us-east-1
+
+  - it: should point external-dns at the cluster NLB hostname
+    set:
+      baseDomain: test-cluster.dev.czi.team
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/target"]
+          value: access-gw.test-cluster.dev.czi.team


### PR DESCRIPTION
## What

Adds `external-dns.alpha.kubernetes.io/target: access-gw.<baseDomain>` to the Gateway in envoy-gateway-resources.

## Why

First HTTPRoute test on dev-core-platform (`echo.dev-core-platform.dev.czi.team`) surfaced this: the record resolved to `10.100.49.130` — the envoy proxy Service's **ClusterIP** — and was unreachable from the internet, while the same route served `200` through the NLB.

Chain: the chart intentionally runs the EG-managed proxy Service as ClusterIP (the dedicated `envoy-gateway-nlb` NLB fronts the proxy), so the Gateway's `status.addresses` is that ClusterIP. external-dns's `gateway-httproute` source resolves route targets as: the `target` annotation **on the Gateway** if present, else the Gateway's status addresses (verified in v0.19.0 `source/gateway.go` — the version our clusters run). With no annotation, every HTTPRoute hostname gets a public A record pointing at an internal ClusterIP.

With the annotation, every HTTPRoute hostname on every cluster becomes a CNAME to that cluster's NLB — the reason `access-gw.*` was made a concrete CNAME-able record rather than a wildcard. No per-route or per-app annotations needed; applies fleet-wide on sync, and external-dns replaces the existing bad A records on its next reconcile (`policy: sync`).

## Test plan
- `helm unittest` 73/73 (new test: annotation renders `access-gw.<baseDomain>` on the Gateway document).
- `helm lint` clean.
- After merge: `dig echo.dev-core-platform.dev.czi.team` should return a CNAME to `access-gw.dev-core-platform.dev.czi.team` → NLB IPs, and `curl https://echo.dev-core-platform.dev.czi.team/` should return the echo payload from the public internet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)