### PR TITLE
feat(stack): make per-service ingress-to-gateway switch a one-line change (CCIE-6760)

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -299,16 +299,6 @@ https://{{ .Values.gateway.host }}/oauth2/callback
 Check if gateway config keys are provided (auto-enable detection)
 Returns: "true" if any gateway.* keys exist (excluding just "enabled")
 */}}
-{{- define "gateway.hasConfigKeys" -}}
-{{- $hasKeys := false -}}
-{{- if .Values.gateway -}}
-  {{- $gatewayKeys := keys (omit .Values.gateway "enabled") -}}
-  {{- if gt (len $gatewayKeys) 0 -}}
-    {{- $hasKeys = true -}}
-  {{- end -}}
-{{- end -}}
-{{- $hasKeys -}}
-{{- end -}}
 
 {{/*
 Create the full dashboard data structure as a Helm dictionary and return it as a JSON string.
@@ -1002,4 +992,54 @@ Expects a dict with keys: global, cronJob
     )
 -}}
 {{- $panelDict | toYaml -}}
+{{- end -}}
+
+{{/*
+Normalize a service's routing config (gateway vs ingress). Mutates the passed
+"values" dict in place:
+  include "stack.routing.normalize" (dict "serviceValues" $serviceValues "values" $values)
+
+Resolution order:
+ 1. A service-level gateway block (any key) enables the gateway unless it sets
+    enabled: false explicitly.
+ 2. Explicit service-level ingress.enabled: true wins over rule 1 unless the
+    gateway is also explicitly enabled (that conflict fails validation later).
+ 3. A service whose gateway ends up enabled by rules 1-2 has its ingress
+    disabled unless ingress.enabled is set explicitly.
+ 4. When the gateway is enabled and the service does not set gateway.paths /
+    gateway.rules, they are inherited from the service-level ingress block, so
+    converting a service is a one-line change. Explicit gateway.* always wins.
+ 5. A service that was OIDC-protected via ingress.oidcProtected must decide
+    gateway.oidcProtected explicitly when converting.
+*/}}
+{{- define "stack.routing.normalize" -}}
+{{- $sv := .serviceValues -}}
+{{- $v := .values -}}
+{{- $svGateway := dict -}}
+{{- if hasKey $sv "gateway" -}}{{- $svGateway = $sv.gateway -}}{{- end -}}
+{{- $svIngress := dict -}}
+{{- if hasKey $sv "ingress" -}}{{- $svIngress = $sv.ingress -}}{{- end -}}
+{{- $gatewayExplicit := hasKey $svGateway "enabled" -}}
+{{- $ingressExplicit := hasKey $svIngress "enabled" -}}
+{{- $gatewaySignal := hasKey $sv "gateway" -}}
+{{- if and $gatewaySignal (not (and $gatewayExplicit (eq $svGateway.enabled false))) -}}
+  {{- $_ := set $v.gateway "enabled" true -}}
+{{- end -}}
+{{- if and $ingressExplicit $svIngress.enabled (not $gatewayExplicit) -}}
+  {{- $_ := set $v.gateway "enabled" false -}}
+{{- end -}}
+{{- if and $v.gateway.enabled $gatewaySignal (not $ingressExplicit) -}}
+  {{- $_ := set $v.ingress "enabled" false -}}
+{{- end -}}
+{{- if $v.gateway.enabled -}}
+  {{- if and (not (hasKey $svGateway "paths")) (hasKey $svIngress "paths") -}}
+    {{- $_ := set $v.gateway "paths" $svIngress.paths -}}
+  {{- end -}}
+  {{- if and (not (hasKey $svGateway "rules")) (hasKey $svIngress "rules") -}}
+    {{- $_ := set $v.gateway "rules" $svIngress.rules -}}
+  {{- end -}}
+  {{- if and $v.ingress.oidcProtected (not (hasKey $svGateway "oidcProtected")) (not $v.gateway.oidcProtected) -}}
+    {{- fail (printf "service %s is OIDC-protected via ingress.oidcProtected. When converting to the gateway, set gateway.oidcProtected: true (with oidcProxyGateway configuration) to keep protection, or set gateway.oidcProtected: false explicitly to drop it." $v.name) -}}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stack/templates/gateway-oidc-secret.yaml
+++ b/stack/templates/gateway-oidc-secret.yaml
@@ -4,6 +4,7 @@
   {{- $values := fromYaml $globalValuesDict -}}
   {{- $values = set $values "name" $serviceName -}}
   {{- $values := mergeOverwrite $values $serviceValues -}}
+  {{- include "stack.routing.normalize" (dict "serviceValues" $serviceValues "values" $values) -}}
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}
 

--- a/stack/templates/gateway-oidc.yaml
+++ b/stack/templates/gateway-oidc.yaml
@@ -5,27 +5,7 @@
   {{- $values = set $values "name" $serviceName -}}
   {{- $values := mergeOverwrite $values $serviceValues -}}
 
-  {{/* Auto-enable gateway when config keys are provided (unless explicitly disabled) */}}
-  {{- if hasKey $serviceValues "gateway" -}}
-    {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
-    {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
-      {{- $_ := set $values.gateway "enabled" true -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{/* Auto-disable ingress when gateway is explicitly enabled at service level */}}
-  {{- if and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled") $serviceValues.gateway.enabled -}}
-    {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled")) -}}
-      {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{/* Auto-disable gateway when ingress is explicitly enabled at service level */}}
-  {{- if and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled -}}
-    {{- if not (and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled")) -}}
-      {{- $_ := set $values "gateway" (mergeOverwrite (default dict $values.gateway) (dict "enabled" false)) -}}
-    {{- end -}}
-  {{- end -}}
+  {{- include "stack.routing.normalize" (dict "serviceValues" $serviceValues "values" $values) -}}
 
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}

--- a/stack/templates/httproute.yaml
+++ b/stack/templates/httproute.yaml
@@ -5,27 +5,7 @@
   {{- $values = set $values "name" $serviceName -}}
   {{- $values := mergeOverwrite $values $serviceValues -}}
 
-  {{/* Auto-enable gateway when config keys are provided (unless explicitly disabled) */}}
-  {{- if hasKey $serviceValues "gateway" -}}
-    {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
-    {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
-      {{- $_ := set $values.gateway "enabled" true -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{/* Auto-disable ingress when gateway is explicitly enabled at service level */}}
-  {{- if and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled") $serviceValues.gateway.enabled -}}
-    {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled")) -}}
-      {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{/* Auto-disable gateway when ingress is explicitly enabled at service level */}}
-  {{- if and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled -}}
-    {{- if not (and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled")) -}}
-      {{- $_ := set $values "gateway" (mergeOverwrite (default dict $values.gateway) (dict "enabled" false)) -}}
-    {{- end -}}
-  {{- end -}}
+  {{- include "stack.routing.normalize" (dict "serviceValues" $serviceValues "values" $values) -}}
 
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -5,19 +5,7 @@
   {{- $values = set $values "name" $serviceName -}}
   {{- $values := mergeOverwrite $values $serviceValues -}}
 
-  {{/* Auto-disable ingress when gateway is explicitly enabled at service level */}}
-  {{- if and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled") $serviceValues.gateway.enabled -}}
-    {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled")) -}}
-      {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{/* Auto-disable gateway when ingress is explicitly enabled at service level */}}
-  {{- if and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled -}}
-    {{- if not (and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled")) -}}
-      {{- $_ := set $values "gateway" (mergeOverwrite (default dict $values.gateway) (dict "enabled" false)) -}}
-    {{- end -}}
-  {{- end -}}
+  {{- include "stack.routing.normalize" (dict "serviceValues" $serviceValues "values" $values) -}}
 
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -6,6 +6,7 @@
   {{- $values := fromYaml $globalValuesDict -}}
   {{- $values = set $values "name" $serviceName -}}
   {{- $values := mergeOverwrite $values $serviceValues -}}
+  {{- include "stack.routing.normalize" (dict "serviceValues" $serviceValues "values" $values) -}}
 
   {{- with $values -}}
   {{ $serviceScope := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" .}}

--- a/stack/tests/routing_migration_test.yaml
+++ b/stack/tests/routing_migration_test.yaml
@@ -178,3 +178,37 @@ tests:
       - template: ingress.yaml
         hasDocuments:
           count: 0
+
+  - it: should serve via ingress alone when no gateway config is present
+    set:
+      services:
+        backend:
+          ingress:
+            paths:
+              - path: /backend
+                pathType: Prefix
+    asserts:
+      - template: ingress.yaml
+        hasDocuments:
+          count: 1
+      - template: ingress.yaml
+        equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /backend
+      - template: httproute.yaml
+        hasDocuments:
+          count: 0
+
+  - it: should render no routing at all when ingress is explicitly disabled and gateway is absent
+    set:
+      services:
+        policy:
+          ingress:
+            enabled: false
+    asserts:
+      - template: ingress.yaml
+        hasDocuments:
+          count: 0
+      - template: httproute.yaml
+        hasDocuments:
+          count: 0

--- a/stack/tests/routing_migration_test.yaml
+++ b/stack/tests/routing_migration_test.yaml
@@ -1,0 +1,180 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test seamless ingress-to-gateway migration
+templates:
+  - httproute.yaml
+  - ingress.yaml
+tests:
+  - it: should convert a service with one line, inheriting ingress paths
+    set:
+      global:
+        gateway:
+          host: stack.example.com
+      services:
+        backend:
+          ingress:
+            paths:
+              - path: /backend
+                pathType: Prefix
+          gateway:
+            enabled: true
+    asserts:
+      - template: httproute.yaml
+        hasDocuments:
+          count: 1
+      - template: httproute.yaml
+        equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /backend
+      - template: httproute.yaml
+        equal:
+          path: spec.hostnames[0]
+          value: stack.example.com
+      - template: ingress.yaml
+        hasDocuments:
+          count: 0
+
+  - it: should disable the ingress when gateway config keys are provided without enabled
+    set:
+      global:
+        gateway:
+          host: stack.example.com
+      services:
+        backend:
+          ingress:
+            paths:
+              - path: /backend
+                pathType: Prefix
+          gateway:
+            paths:
+              - path: /backend
+                pathType: Prefix
+    asserts:
+      - template: httproute.yaml
+        hasDocuments:
+          count: 1
+      - template: ingress.yaml
+        hasDocuments:
+          count: 0
+
+  - it: should prefer explicit gateway.paths over inherited ingress.paths
+    set:
+      global:
+        gateway:
+          host: stack.example.com
+      services:
+        backend:
+          ingress:
+            paths:
+              - path: /old
+                pathType: Prefix
+          gateway:
+            enabled: true
+            paths:
+              - path: /new
+                pathType: Prefix
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /new
+
+  - it: should inherit ingress rules with custom hosts
+    set:
+      global:
+        gateway:
+          host: stack.example.com
+      services:
+        frontend:
+          ingress:
+            rules:
+              - host: vanity.example.com
+          gateway:
+            enabled: true
+    asserts:
+      - template: httproute.yaml
+        hasDocuments:
+          count: 2
+      - template: httproute.yaml
+        documentIndex: 1
+        equal:
+          path: spec.hostnames[0]
+          value: vanity.example.com
+
+  - it: should keep the ingress when explicitly enabled alongside gateway config keys
+    set:
+      global:
+        gateway:
+          host: stack.example.com
+      services:
+        backend:
+          ingress:
+            enabled: true
+            paths:
+              - path: /backend
+                pathType: Prefix
+          gateway:
+            paths:
+              - path: /backend
+                pathType: Prefix
+    asserts:
+      - template: ingress.yaml
+        hasDocuments:
+          count: 1
+      - template: httproute.yaml
+        hasDocuments:
+          count: 0
+
+  - it: should fail when both gateway and ingress are explicitly enabled
+    set:
+      services:
+        backend:
+          ingress:
+            enabled: true
+          gateway:
+            enabled: true
+    asserts:
+      - template: ingress.yaml
+        failedTemplate:
+          errorMessage: "gateway.enabled and ingress.enabled cannot both be true. Please enable only one routing method: either gateway or ingress."
+
+  - it: should fail converting an OIDC-protected ingress without an explicit gateway decision
+    set:
+      global:
+        gateway:
+          host: stack.example.com
+      services:
+        frontend:
+          ingress:
+            oidcProtected: true
+            paths:
+              - path: /
+                pathType: Prefix
+          gateway:
+            enabled: true
+    asserts:
+      - template: ingress.yaml
+        failedTemplate:
+          errorPattern: "service frontend is OIDC-protected via ingress.oidcProtected"
+
+  - it: should convert an OIDC-protected ingress when protection is explicitly dropped
+    set:
+      global:
+        gateway:
+          host: stack.example.com
+      services:
+        frontend:
+          ingress:
+            oidcProtected: true
+            paths:
+              - path: /
+                pathType: Prefix
+          gateway:
+            enabled: true
+            oidcProtected: false
+    asserts:
+      - template: httproute.yaml
+        hasDocuments:
+          count: 1
+      - template: ingress.yaml
+        hasDocuments:
+          count: 0


### PR DESCRIPTION
## Motivation

We're migrating every Argus-deployed service from nginx Ingress to Envoy Gateway HTTPRoutes ([CCIE-6630](https://czi.atlassian.net/browse/CCIE-6630)) - a lot of per-app PRs over the coming waves. Converting the first real service (argus-example-app's backend) showed the chart makes that harder than it should be:

- A service had to **restate its paths** under `gateway:` even though they're already in its `ingress:` block. Worse, forgetting to do so doesn't fail — the HTTPRoute silently defaults to `/` and **hijacks another service's traffic** on the shared stack hostname.
- Adding gateway config *without* the literal `enabled: true` left **both** the Ingress and the HTTPRoute rendered, failing with a mutual-exclusion error that doesn't explain what to do.
- An OIDC-protected service could be converted and **silently lose its auth** — `ingress.oidcProtected` and `gateway.oidcProtected` are unrelated keys.

Every one of these is a paper-cut per app and a real outage risk multiplied by the number of services in the waves.

## What this does

Converting a service is now literally one line:

```yaml
services:
  backend:
    ingress:          # existing config, untouched
      paths:
        - path: /backend
          pathType: Prefix
    gateway:
      enabled: true   # <- the only new line
```

The chart now:
1. **Inherits `ingress.paths` and `ingress.rules` into the gateway config** when the service doesn't set its own (explicit `gateway.*` always wins).
2. **Disables the inherited ingress whenever the gateway is enabled at the service level** — by flag or by config keys — unless `ingress.enabled` is set explicitly. No more both-rendered dead end.
3. **Refuses to silently drop OIDC**: converting a service that had `ingress.oidcProtected: true` fails with instructions unless the author explicitly sets `gateway.oidcProtected` one way or the other.

## How

The enable/disable/inherit logic was previously copy-pasted (with drift) across the routing templates — and two of them (`gateway-oidc-secret.yaml`, `oidc_proxy.yaml`) had **no normalization at all**, so an auto-enabled gateway could render its OIDC route without its OIDC secret, and a converted service could still render the nginx oauth2-proxy. All five templates now call a single documented helper (`stack.routing.normalize`), so they always agree on which routing system a service uses.

## Testing

- New `tests/routing_migration_test.yaml`: one-line conversion inherits paths; config-keys-only conversion no longer double-renders; explicit `gateway.paths` beats inherited; `ingress.rules` (vanity hosts) inherit; explicit `ingress.enabled: true` still wins; both-explicit still fails; OIDC guard fails with an actionable message and passes when decided explicitly.
- All 120 pre-existing tests pass unchanged (the refactor is backward-compatible for every previously-tested behavior).
- Rendered argus-example-app's real `.infra` config with the exact per-stack values Argus injects: `gateway: {enabled: true}` alone produces the correct `/backend` HTTPRoute on the stack hostname and zero Ingress objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIE-6630]: https://czi.atlassian.net/browse/CCIE-6630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ