### PR TITLE
feat: prometheus scrape annotations on envoy proxy pods (CCIE-6640)

### DIFF
--- a/envoy-gateway-resources/templates/envoyproxy.yaml
+++ b/envoy-gateway-resources/templates/envoyproxy.yaml
@@ -11,8 +11,13 @@ spec:
         name: {{ .Values.serviceAccount.name }}
       envoyService:
         type: {{ .Values.envoyService.type }}
-      {{- if .Values.geoip.enabled }}
       envoyDeployment:
+        pod:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "19001"
+            prometheus.io/path: /stats/prometheus
+        {{- if .Values.geoip.enabled }}
         patch:
           type: StrategicMerge
           value:

--- a/envoy-gateway-resources/tests/envoyproxy_test.yaml
+++ b/envoy-gateway-resources/tests/envoyproxy_test.yaml
@@ -52,7 +52,21 @@ tests:
       geoip.enabled: false
     asserts:
       - notExists:
-          path: spec.provider.kubernetes.envoyDeployment
+          path: spec.provider.kubernetes.envoyDeployment.patch
+
+  - it: should always set prometheus scrape annotations on the proxy pods
+    set:
+      geoip.enabled: false
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.pod.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.pod.annotations["prometheus.io/port"]
+          value: "19001"
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.pod.annotations["prometheus.io/path"]
+          value: /stats/prometheus
 
   # Basic EnvoyProxy resource tests when geoip enabled
   - it: should render EnvoyProxy when geoip.enabled is true


### PR DESCRIPTION
## Motivation

The Envoy Gateway migration ([CCIE-6640](https://czi.atlassian.net/browse/CCIE-6640)) needs envoy traffic metrics in central Prometheus before the Phase 1 pilot — without them we can't validate migrated apps or build the envoy equivalent of the nginx dashboards. The envoy proxies already expose Prometheus metrics on `:19001/stats/prometheus` (Envoy Gateway's default), but nothing scrapes them: grafana-alloy's endpoint scrape job discovers pods by `prometheus.io/*` annotations, and the proxy pods don't carry any.

## What this does

Adds the standard scrape annotations to the proxy pod template via the EnvoyProxy spec, unconditionally:

```yaml
envoyDeployment:
  pod:
    annotations:
      prometheus.io/scrape: "true"
      prometheus.io/port: "19001"
      prometheus.io/path: /stats/prometheus
```

The existing GeoIP `patch` block stays gated behind `geoip.enabled` — only its nesting changed so both can coexist under `envoyDeployment`.

Scraping starts the moment each cluster's alloy sees the new pod annotations; the series only reach central Prometheus once `envoy_.*` is added to alloy's remote-write allowlist (companion argus-infra-stacks PRs for nonprod and prod, linked in comments). Annotations-without-allowlist is harmless — alloy scrapes and drops.

## Testing

- `helm unittest` green; the geoip-disabled test now asserts the `patch` (not the whole `envoyDeployment`) is absent, and a new test pins all three annotations.
- Rendered both geoip modes: annotations present in each, patch only when geoip is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIE-6640]: https://czi.atlassian.net/browse/CCIE-6640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ