### PR TITLE
feat(stack): default 60s DNS TTL on Ingress and HTTPRoute records (CCIE-6707)

### DIFF
--- a/stack/README.md
+++ b/stack/README.md
@@ -706,6 +706,17 @@ Must be one of:
 
 **Description:** Annotations to add to HTTPRoute resources
 
+| Property                                                                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#cronJobs_pattern1_gateway_annotations_external-dnsalphakubernetesio/ttl ) | No      | string | No         | -          | -                 |
+
+###### <a name="cronJobs_pattern1_gateway_annotations_external-dnsalphakubernetesio/ttl"></a>2.1.16.1.1. Property `stack > cronJobs > ^.*$ > gateway > annotations > external-dns.alpha.kubernetes.io/ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
 ##### <a name="cronJobs_pattern1_gateway_enabled"></a>2.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > enabled`
 
 |              |           |
@@ -1149,6 +1160,7 @@ Must be one of:
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#cronJobs_pattern1_ingress_annotations_external-dnsalphakubernetesio/ttl )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/affinity](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-connect-timeout](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout )   | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-read-timeout](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout )         | No      | string | No         | -          | -                 |
@@ -1156,42 +1168,49 @@ Must be one of:
 | - [nginx.ingress.kubernetes.io/session-cookie-max-age](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age ) | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/session-cookie-name](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name )       | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity"></a>2.1.20.1.1. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
+###### <a name="cronJobs_pattern1_ingress_annotations_external-dnsalphakubernetesio/ttl"></a>2.1.20.1.1. Property `stack > cronJobs > ^.*$ > ingress > annotations > external-dns.alpha.kubernetes.io/ttl`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>2.1.20.1.2. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity"></a>2.1.20.1.2. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>2.1.20.1.3. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>2.1.20.1.3. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>2.1.20.1.4. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>2.1.20.1.4. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>2.1.20.1.5. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>2.1.20.1.5. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>2.1.20.1.6. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>2.1.20.1.6. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>2.1.20.1.7. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
 
 |              |          |
 | ------------ | -------- |
@@ -4057,6 +4076,17 @@ Must be one of:
 
 **Description:** Annotations to add to HTTPRoute resources
 
+| Property                                                                                                 | Pattern | Type   | Deprecated | Definition | Title/Description |
+| -------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#global_gateway_annotations_external-dnsalphakubernetesio/ttl ) | No      | string | No         | -          | -                 |
+
+##### <a name="global_gateway_annotations_external-dnsalphakubernetesio/ttl"></a>3.16.1.1. Property `stack > global > gateway > annotations > external-dns.alpha.kubernetes.io/ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
 #### <a name="global_gateway_enabled"></a>3.16.2. Property `stack > global > gateway > enabled`
 
 |              |           |
@@ -4500,6 +4530,7 @@ Must be one of:
 
 | Property                                                                                                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#global_ingress_annotations_external-dnsalphakubernetesio/ttl )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/affinity](#global_ingress_annotations_nginxingresskubernetesio/affinity )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-connect-timeout](#global_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout )   | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-read-timeout](#global_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout )         | No      | string | No         | -          | -                 |
@@ -4507,42 +4538,49 @@ Must be one of:
 | - [nginx.ingress.kubernetes.io/session-cookie-max-age](#global_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age ) | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/session-cookie-name](#global_ingress_annotations_nginxingresskubernetesio/session-cookie-name )       | No      | string | No         | -          | -                 |
 
-##### <a name="global_ingress_annotations_nginxingresskubernetesio/affinity"></a>3.20.1.1. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
+##### <a name="global_ingress_annotations_external-dnsalphakubernetesio/ttl"></a>3.20.1.1. Property `stack > global > ingress > annotations > external-dns.alpha.kubernetes.io/ttl`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="global_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>3.20.1.2. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
+##### <a name="global_ingress_annotations_nginxingresskubernetesio/affinity"></a>3.20.1.2. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="global_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>3.20.1.3. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
+##### <a name="global_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>3.20.1.3. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="global_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>3.20.1.4. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
+##### <a name="global_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>3.20.1.4. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="global_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>3.20.1.5. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+##### <a name="global_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>3.20.1.5. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="global_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>3.20.1.6. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
+##### <a name="global_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>3.20.1.6. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="global_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>3.20.1.7. Property `stack > global > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
 
 |              |          |
 | ------------ | -------- |
@@ -7426,6 +7464,17 @@ Must be one of:
 
 **Description:** Annotations to add to HTTPRoute resources
 
+| Property                                                                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#cronJobs_pattern1_gateway_annotations_external-dnsalphakubernetesio/ttl ) | No      | string | No         | -          | -                 |
+
+###### <a name="cronJobs_pattern1_gateway_annotations_external-dnsalphakubernetesio/ttl"></a>4.1.16.1.1. Property `stack > cronJobs > ^.*$ > gateway > annotations > external-dns.alpha.kubernetes.io/ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
 ##### <a name="cronJobs_pattern1_gateway_enabled"></a>4.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > enabled`
 
 |              |           |
@@ -7869,6 +7918,7 @@ Must be one of:
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#cronJobs_pattern1_ingress_annotations_external-dnsalphakubernetesio/ttl )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/affinity](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-connect-timeout](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout )   | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-read-timeout](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout )         | No      | string | No         | -          | -                 |
@@ -7876,42 +7926,49 @@ Must be one of:
 | - [nginx.ingress.kubernetes.io/session-cookie-max-age](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age ) | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/session-cookie-name](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name )       | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity"></a>4.1.20.1.1. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
+###### <a name="cronJobs_pattern1_ingress_annotations_external-dnsalphakubernetesio/ttl"></a>4.1.20.1.1. Property `stack > cronJobs > ^.*$ > ingress > annotations > external-dns.alpha.kubernetes.io/ttl`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>4.1.20.1.2. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity"></a>4.1.20.1.2. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>4.1.20.1.3. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>4.1.20.1.3. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>4.1.20.1.4. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>4.1.20.1.4. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>4.1.20.1.5. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>4.1.20.1.5. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>4.1.20.1.6. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>4.1.20.1.6. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>4.1.20.1.7. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
 
 |              |          |
 | ------------ | -------- |
@@ -11259,6 +11316,17 @@ Must be one of:
 
 **Description:** Annotations to add to HTTPRoute resources
 
+| Property                                                                                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#cronJobs_pattern1_gateway_annotations_external-dnsalphakubernetesio/ttl ) | No      | string | No         | -          | -                 |
+
+###### <a name="cronJobs_pattern1_gateway_annotations_external-dnsalphakubernetesio/ttl"></a>7.1.16.1.1. Property `stack > cronJobs > ^.*$ > gateway > annotations > external-dns.alpha.kubernetes.io/ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
 ##### <a name="cronJobs_pattern1_gateway_enabled"></a>7.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > enabled`
 
 |              |           |
@@ -11702,6 +11770,7 @@ Must be one of:
 
 | Property                                                                                                                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [external-dns.alpha.kubernetes.io/ttl](#cronJobs_pattern1_ingress_annotations_external-dnsalphakubernetesio/ttl )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/affinity](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity )                             | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-connect-timeout](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout )   | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/proxy-read-timeout](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout )         | No      | string | No         | -          | -                 |
@@ -11709,42 +11778,49 @@ Must be one of:
 | - [nginx.ingress.kubernetes.io/session-cookie-max-age](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age ) | No      | string | No         | -          | -                 |
 | - [nginx.ingress.kubernetes.io/session-cookie-name](#cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name )       | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity"></a>7.1.20.1.1. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
+###### <a name="cronJobs_pattern1_ingress_annotations_external-dnsalphakubernetesio/ttl"></a>7.1.20.1.1. Property `stack > cronJobs > ^.*$ > ingress > annotations > external-dns.alpha.kubernetes.io/ttl`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>7.1.20.1.2. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/affinity"></a>7.1.20.1.2. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/affinity`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>7.1.20.1.3. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-connect-timeout"></a>7.1.20.1.3. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-connect-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>7.1.20.1.4. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-read-timeout"></a>7.1.20.1.4. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-read-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>7.1.20.1.5. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/proxy-send-timeout"></a>7.1.20.1.5. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/proxy-send-timeout`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>7.1.20.1.6. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-max-age"></a>7.1.20.1.6. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-max-age`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_ingress_annotations_nginxingresskubernetesio/session-cookie-name"></a>7.1.20.1.7. Property `stack > cronJobs > ^.*$ > ingress > annotations > nginx.ingress.kubernetes.io/session-cookie-name`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/tests/dns_ttl_oidc_test.yaml
+++ b/stack/tests/dns_ttl_oidc_test.yaml
@@ -1,0 +1,29 @@
+suite: test DNS TTL annotation on OIDC HTTPRoutes
+templates:
+  - gateway-oidc.yaml
+tests:
+  - it: should set a 60s DNS TTL on OIDC-protected HTTPRoutes
+    set:
+      global:
+        ingress:
+          enabled: false
+        appSecrets:
+          clusterCLISecret:
+            secretKey: /argus/test
+            secretName: test-secret
+      services:
+        web:
+          gateway:
+            enabled: true
+            oidcProtected: true
+            host: web.example.com
+          oidcProxyGateway:
+            clientID: test-client
+            provider:
+              issuer: https://czi.okta.com
+    asserts:
+      - template: gateway-oidc.yaml
+        documentIndex: 0
+        equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/ttl"]
+          value: "60"

--- a/stack/tests/dns_ttl_test.yaml
+++ b/stack/tests/dns_ttl_test.yaml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test DNS TTL annotation defaults
+templates:
+  - ingress.yaml
+  - httproute.yaml
+tests:
+  - it: should set a 60s DNS TTL on Ingresses by default
+    set:
+      services:
+        web:
+          ingress:
+            host: web.example.com
+    asserts:
+      - template: ingress.yaml
+        equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/ttl"]
+          value: "60"
+
+  - it: should set a 60s DNS TTL on primary and rule HTTPRoutes by default
+    set:
+      global:
+        ingress:
+          enabled: false
+      services:
+        web:
+          gateway:
+            enabled: true
+            host: web.example.com
+            rules:
+              - host: vanity.example.com
+    asserts:
+      - template: httproute.yaml
+        documentIndex: 0
+        equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/ttl"]
+          value: "60"
+      - template: httproute.yaml
+        documentIndex: 1
+        equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/ttl"]
+          value: "60"
+
+  - it: should let a per-service annotation override the default TTL
+    set:
+      global:
+        ingress:
+          enabled: false
+      services:
+        web:
+          gateway:
+            enabled: true
+            host: web.example.com
+            annotations:
+              external-dns.alpha.kubernetes.io/ttl: "300"
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/ttl"]
+          value: "300"
+
+  - it: should let a global annotation override the default TTL
+    set:
+      global:
+        gateway:
+          annotations:
+            external-dns.alpha.kubernetes.io/ttl: "120"
+        ingress:
+          enabled: false
+      services:
+        web:
+          gateway:
+            enabled: true
+            host: web.example.com
+    asserts:
+      - template: httproute.yaml
+        equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/ttl"]
+          value: "120"

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -247,7 +247,12 @@
           "properties": {
             "annotations": {
               "description": "Annotations to add to HTTPRoute resources",
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "external-dns.alpha.kubernetes.io/ttl": {
+                  "type": "string"
+                }
+              }
             },
             "enabled": {
               "description": "Enable Gateway API HTTPRoute (alternative to Ingress)",
@@ -409,6 +414,9 @@
             "annotations": {
               "type": "object",
               "properties": {
+                "external-dns.alpha.kubernetes.io/ttl": {
+                  "type": "string"
+                },
                 "nginx.ingress.kubernetes.io/affinity": {
                   "type": "string"
                 },

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -201,6 +201,7 @@ global: # @schema description: Global configuration for the stack - this serves 
     rules: [] # @schema description: List of ingress rules
     oidcProtected: false # @schema description: Enable OIDC protection (route to oauth2-proxy when using Ingress)
     annotations:
+      external-dns.alpha.kubernetes.io/ttl: "60"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
@@ -224,7 +225,8 @@ global: # @schema description: Global configuration for the stack - this serves 
         pathType: Prefix # @schema description: HTTPRoute path type (Exact or Prefix)
     rules: [] # @schema description: List of additional HTTPRoute rules with custom hosts
     oidcProtected: false # @schema description: Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)
-    annotations: {} # @schema description: Annotations to add to HTTPRoute resources
+    annotations: # @schema description: Annotations to add to HTTPRoute resources
+      external-dns.alpha.kubernetes.io/ttl: "60"
   
   nodeSelector:
     kubernetes.io/arch: arm64 # @schema description: Node selector for architecture


### PR DESCRIPTION
## Motivation

When an app migrates from nginx Ingress to a Gateway HTTPRoute in a single PR, there's a downtime window: the moment the sync lands, nginx stops serving the route, but clients keep resolving the old DNS record until its TTL drains — today that's up to ~6 minutes of 404s per app (observed live during the nonprod healthcheck cutover, [CCIE-6707](https://czi.atlassian.net/browse/CCIE-6707)).

The window is governed by the TTL of the record clients have cached at flip time — the one the **Ingress** created — while the HTTPRoute-side TTL governs rollbacks and later changes. So the annotation goes on both sides.

## What this does

Adds `external-dns.alpha.kubernetes.io/ttl: "60"` to the chart's **default annotation maps** — `global.ingress.annotations` (which already carries the default nginx annotations, so this follows the established pattern) and `global.gateway.annotations`. Pure values data; no template changes. It flows to:

- Ingresses (the forward-migration half — once an app picks this up, its records drop to 60s ahead of its migration)
- All HTTPRoutes: `httproute.yaml` primary + custom-host rules, and the OIDC-protected routes in `gateway-oidc.yaml` (the rollback/future-change half)

Overrides use standard values-map merging: per-service or global, set the annotation to a different value and it wins (both covered by tests). external-dns *updates* existing records when the annotation appears — no recreation, just a TTL change on its next reconcile.

## The caveat that shapes rollout

Apps pin their stack chart version in `.infra/*/Chart.yaml`, so this only takes effect per-app when they bump the chart — which makes "bump the stack chart" a natural first step of each app's migration prep (the lowered Ingress TTL then needs one old-TTL cycle, ≤5 min, to propagate before the cutover PR). ApplicationSet-driven stacks that ride HEAD (cluster-healthcheck) get it on merge.

With this in place, the default single-PR migration's worst case drops from ~6 minutes to ~1–2 minutes (external-dns interval + 60s). For apps where even that is unacceptable (long-lived connections, prod user traffic), the make-before-break recipe is the complement — tracked separately.

## Testing

- 125/125 helm-unittest, including 5 for this change: TTL default on Ingress / primary + rule HTTPRoutes / OIDC routes, per-service annotation override, and global annotation override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIE-6707]: https://czi.atlassian.net/browse/CCIE-6707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ