### PR TITLE
feat: vanity-domain HTTPS listeners so public domains can migrate to Envoy Gateway (CCIE-6643)

### DIFF
--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -8,18 +8,18 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                             | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [alternateNames](#alternateNames ) | No      | array  | No         | -          | -                 |
-| - [awsRegion](#awsRegion )           | No      | string | No         | -          | -                 |
-| - [baseDomain](#baseDomain )         | No      | string | No         | -          | -                 |
-| - [envoyService](#envoyService )     | No      | object | No         | -          | -                 |
-| - [gatewayName](#gatewayName )       | No      | string | No         | -          | -                 |
-| - [geoip](#geoip )                   | No      | object | No         | -          | -                 |
-| - [proxyProtocol](#proxyProtocol )   | No      | object | No         | -          | -                 |
-| - [serviceAccount](#serviceAccount ) | No      | object | No         | -          | -                 |
+| Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [additionalListeners](#additionalListeners ) | No      | array  | No         | -          | -                 |
+| - [awsRegion](#awsRegion )                     | No      | string | No         | -          | -                 |
+| - [baseDomain](#baseDomain )                   | No      | string | No         | -          | -                 |
+| - [envoyService](#envoyService )               | No      | object | No         | -          | -                 |
+| - [gatewayName](#gatewayName )                 | No      | string | No         | -          | -                 |
+| - [geoip](#geoip )                             | No      | object | No         | -          | -                 |
+| - [proxyProtocol](#proxyProtocol )             | No      | object | No         | -          | -                 |
+| - [serviceAccount](#serviceAccount )           | No      | object | No         | -          | -                 |
 
-## <a name="alternateNames"></a>1. Property `envoy-gateway-resources > alternateNames`
+## <a name="additionalListeners"></a>1. Property `envoy-gateway-resources > additionalListeners`
 
 |              |         |
 | ------------ | ------- |

--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -39,6 +39,21 @@ spec:
           - group: ''
             kind: Secret
             name: {{ .Values.gatewayName }}-tls
+    {{- range .Values.additionalListeners }}
+    - name: https-{{ .name }}
+      protocol: HTTPS
+      port: 443
+      hostname: {{ .hostname | quote }}
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ''
+            kind: Secret
+            name: {{ $.Values.gatewayName }}-{{ .name }}-tls
+    {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -54,9 +69,25 @@ spec:
       - selector:
           dnsZones:
             - "{{ .Values.baseDomain }}"
+            {{- range .Values.additionalListeners }}
+            {{- if not .route53Role }}
+            - {{ trimPrefix "*." .hostname | quote }}
+            {{- end }}
+            {{- end }}
         dns01:
           route53:
             region: {{ .Values.awsRegion }}
+      {{- range .Values.additionalListeners }}
+      {{- if .route53Role }}
+      - selector:
+          dnsZones:
+            - {{ trimPrefix "*." .hostname | quote }}
+        dns01:
+          route53:
+            region: {{ $.Values.awsRegion }}
+            role: {{ .route53Role | quote }}
+      {{- end }}
+      {{- end }}
       - selector: {}
         http01:
           gatewayHTTPRoute:
@@ -76,9 +107,6 @@ spec:
   dnsNames:
     - "*.{{ .Values.baseDomain }}"
     - "{{ .Values.baseDomain }}"
-{{- range .Values.alternateNames }}
-    - "{{ . }}"
-{{- end }}
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
@@ -91,4 +119,29 @@ spec:
   usages:
     - digital signature
     - key encipherment
+{{- range .Values.additionalListeners }}
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $.Values.gatewayName }}-{{ .name }}-cert
+  namespace: envoy-gateway
+spec:
+  commonName: {{ .hostname | quote }}
+  dnsNames:
+    - {{ .hostname | quote }}
+    {{- if hasPrefix "*." .hostname }}
+    - {{ trimPrefix "*." .hostname | quote }}
+    {{- end }}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod-eg
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  secretName: {{ $.Values.gatewayName }}-{{ .name }}-tls
+  usages:
+    - digital signature
+    - key encipherment
+{{- end }}

--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -140,6 +140,7 @@ spec:
   privateKey:
     algorithm: RSA
     size: 4096
+    rotationPolicy: Always
   secretName: {{ $.Values.gatewayName }}-{{ .name }}-tls
   usages:
     - digital signature

--- a/envoy-gateway-resources/tests/additional_listeners_test.yaml
+++ b/envoy-gateway-resources/tests/additional_listeners_test.yaml
@@ -1,0 +1,108 @@
+suite: test additional vanity-domain listeners
+templates:
+  - gateway.yaml
+tests:
+  - it: should render no extra listeners or certificates by default
+    set:
+      baseDomain: test-cluster.dev.czi.team
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: should add a listener and certificate per vanity domain
+    set:
+      baseDomain: prod-central.prod.czi.team
+      additionalListeners:
+        - name: tools
+          hostname: tools.czi.team
+        - name: rnaquarium
+          hostname: "*.rnaquarium.org"
+    asserts:
+      - hasDocuments:
+          count: 6
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].name
+          value: https-tools
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].hostname
+          value: tools.czi.team
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].tls.certificateRefs[0].name
+          value: envoy-gateway-tools-tls
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[3].hostname
+          value: "*.rnaquarium.org"
+
+  - it: should issue an exact-host certificate with a single dnsName
+    set:
+      baseDomain: prod-central.prod.czi.team
+      additionalListeners:
+        - name: tools
+          hostname: tools.czi.team
+    asserts:
+      - documentIndex: 4
+        equal:
+          path: metadata.name
+          value: envoy-gateway-tools-cert
+      - documentIndex: 4
+        equal:
+          path: spec.dnsNames
+          value:
+            - tools.czi.team
+      - documentIndex: 4
+        equal:
+          path: spec.secretName
+          value: envoy-gateway-tools-tls
+
+  - it: should issue a wildcard certificate covering apex and wildcard
+    set:
+      baseDomain: prod-biohub.prod.czi.team
+      additionalListeners:
+        - name: rnaquarium
+          hostname: "*.rnaquarium.org"
+    asserts:
+      - documentIndex: 4
+        equal:
+          path: spec.dnsNames
+          value:
+            - "*.rnaquarium.org"
+            - rnaquarium.org
+
+  - it: should extend the dns01 solver zones with vanity domains
+    set:
+      baseDomain: prod-central.prod.czi.team
+      additionalListeners:
+        - name: tools
+          hostname: tools.czi.team
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: spec.acme.solvers[0].selector.dnsZones
+          value:
+            - prod-central.prod.czi.team
+            - tools.czi.team
+
+  - it: should give cross-account zones their own solver with the assumed role
+    set:
+      baseDomain: prod-biohub.prod.czi.team
+      additionalListeners:
+        - name: rnaquarium
+          hostname: "*.rnaquarium.org"
+          route53Role: arn:aws:iam::999999999999:role/czbiohub-dns01
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: spec.acme.solvers[1].selector.dnsZones
+          value:
+            - rnaquarium.org
+      - documentIndex: 2
+        equal:
+          path: spec.acme.solvers[1].dns01.route53.role
+          value: arn:aws:iam::999999999999:role/czbiohub-dns01
+      - documentIndex: 2
+        notExists:
+          path: spec.acme.solvers[0].selector.dnsZones[1]

--- a/envoy-gateway-resources/tests/gateway_test.yaml
+++ b/envoy-gateway-resources/tests/gateway_test.yaml
@@ -279,22 +279,6 @@ tests:
           path: spec.dnsNames
           content: my-cluster.example.com
 
-  - it: should include alternate names in certificate
-    set:
-      gatewayName: test-gateway
-      baseDomain: test-cluster.example.com
-      alternateNames:
-        - alt1.example.com
-        - alt2.example.com
-    documentIndex: 3
-    asserts:
-      - contains:
-          path: spec.dnsNames
-          content: alt1.example.com
-      - contains:
-          path: spec.dnsNames
-          content: alt2.example.com
-
   - it: should reference ClusterIssuer in certificate
     set:
       gatewayName: test-gateway

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -4,7 +4,7 @@
   "title": "envoy-gateway-resources",
   "type": "object",
   "properties": {
-    "alternateNames": {
+    "additionalListeners": {
       "type": "array"
     },
     "awsRegion": {

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -1,7 +1,16 @@
 baseDomain: "example.dev.czi.team"
 awsRegion: "us-west-2"
 gatewayName: "envoy-gateway"
-alternateNames: []
+# Extra HTTPS listeners on the Gateway for public/vanity domains, each with its
+# own Let's Encrypt certificate (dns01). hostname may be exact or a *. wildcard.
+# route53Role: optional IAM role ARN for dns01 when the hosted zone lives in
+# another account (the role must be assumable by cert-manager).
+additionalListeners: []
+#  - name: tools
+#    hostname: tools.czi.team
+#  - name: rnaquarium
+#    hostname: "*.rnaquarium.org"
+#    route53Role: arn:aws:iam::123456789012:role/czbiohub-dns01
 
 serviceAccount:
   name: envoy-gateway-proxy


### PR DESCRIPTION
## Motivation — vanity domains can't migrate today

Every cluster's Gateway has exactly one HTTPS listener, bound to `*.<cluster zone>` with the cluster wildcard cert. That covers ~85% of the fleet's 461 ingress hostnames — but the other **67 are public/vanity domains** (`tools.czi.team`, `cellxgene.cziscience.com`, `biohub.ai`, `*.rnaquarium.org`, …) that match no listener: envoy cannot even terminate TLS for them, so the apps behind them **cannot migrate off nginx at all**. This blocks Wave 2 (`prod-central`'s `tools.czi.team`) and most of Wave 9 ([CCIE-6643](https://czi.atlassian.net/browse/CCIE-6643)).

## What this does

Adds an `additionalListeners` value to envoy-gateway-resources — one entry per vanity domain, set per cluster:

```yaml
additionalListeners:
  - name: tools
    hostname: tools.czi.team
  - name: rnaquarium
    hostname: "*.rnaquarium.org"
    route53Role: arn:aws:iam::<acct>:role/<dns01-role>   # zones owned by another account
```

Each entry renders three things:

1. an **HTTPS listener** on the Gateway (`https-<name>`, port 443, SNI-matched to the hostname)
2. an **explicit cert-manager Certificate** for the domain (wildcard hostnames also cover the apex), issued by the existing `letsencrypt-prod-eg` ClusterIssuer into its own secret — certs are explicit objects, consistent with how the cluster wildcard cert works, rather than introducing the cert-manager Gateway shim
3. a **dns01 zone selector** on the ClusterIssuer so issuance works *before* the domain's DNS moves to envoy (http01 can't — the vanity DNS still points at nginx until cutover). Zones owned by other accounts (czbiohub-sf) get their own solver with an assumed `route53Role`

The unused `alternateNames` value (extra SANs on the wildcard cert; zero usage fleet-wide) is removed in favor of per-domain certs.

## Ownership boundary (per review discussion)

Per-app, per-hostname routing **stays self-serve** in the app's stack chart — set `services.<name>.gateway.host` / `.rules[].host` and Gateway API longest-suffix-matches it to a listener. Any hostname under the cluster's own zone needs no platform change (the wildcard listener covers it).

What lands here, per cluster, is only a net-new vanity **parent** domain, and only once per domain. nginx makes vanity domains self-serve today because an Ingress fuses route+TLS and ingress-shim auto-certs each one via http01; Gateway API deliberately splits the listener (TLS termination on the shared, one-per-cluster Gateway) from the HTTPRoute (tenant routing), so a listener can't be conjured from a route. The upside of the split: one shared wildcard cert per parent instead of today's N duplicate per-app certs for the same domain.

A fully self-serve path does exist — `XListenerSet` (tenant-attached listeners; the CRD is installed) — but it's experimental, not enabled (the Gateway's `allowedListeners` is empty, EG's `extensionApis` unset), cert-manager's gateway-shim doesn't clearly cover it yet, and it hands tenants write access to shared Gateway TLS (SNI/cert-contention blast radius). Deferred as a clean per-cluster upgrade later — flip `allowedListeners`, the HTTPRoute side never changes — if per-parent friction proves real.

## What this deliberately does not do yet

- **No per-cluster values land here** — listeners roll out with their migration waves. Same-account vanity zones work with cert-manager's existing wildcard Route53 IAM; only zones in *another* account (czbiohub-sf) need IAM extended (a dns01 assume-role) before their listener is enabled, or a stuck Certificate results.
- The ~12 long-tail one-off hostnames from the inventory still need owner triage before getting listeners.

## Testing

- 78/78 helm-unittest, including 6 new: no-op default (4 docs unchanged), listener + certRef per domain, exact-host vs wildcard certificate dnsNames, dns01 zone extension, and cross-account solver with role isolation.
- Full render with a Wave-2-shaped config (`tools.czi.team` + cross-account `*.rnaquarium.org`) verified: 3 certificates, 4 listeners, solver separation correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIE-6643]: https://czi.atlassian.net/browse/CCIE-6643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ