### PR TITLE
feat: prometheus scrape annotations on the envoy proxy Service — prod alloy discovers via Service, not pods (CCIE-6640)

### DIFF
--- a/envoy-gateway-resources/templates/envoyproxy.yaml
+++ b/envoy-gateway-resources/templates/envoyproxy.yaml
@@ -10,6 +10,10 @@ spec:
       envoyServiceAccount:
         name: {{ .Values.serviceAccount.name }}
       envoyService:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "19001"
+          prometheus.io/path: /stats/prometheus
         type: {{ .Values.envoyService.type }}
       envoyDeployment:
         pod:

--- a/envoy-gateway-resources/tests/envoyproxy_test.yaml
+++ b/envoy-gateway-resources/tests/envoyproxy_test.yaml
@@ -68,6 +68,28 @@ tests:
           path: spec.provider.kubernetes.envoyDeployment.pod.annotations["prometheus.io/path"]
           value: /stats/prometheus
 
+  - it: should always set prometheus scrape annotations on the proxy service
+    set:
+      geoip.enabled: false
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.annotations["prometheus.io/port"]
+          value: "19001"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.annotations["prometheus.io/path"]
+          value: /stats/prometheus
+
+  - it: should set prometheus scrape annotations on the proxy service when geoip is enabled too
+    set:
+      geoip.enabled: true
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.annotations["prometheus.io/scrape"]
+          value: "true"
+
   # Basic EnvoyProxy resource tests when geoip enabled
   - it: should render EnvoyProxy when geoip.enabled is true
     set:


### PR DESCRIPTION
#482 put the prometheus scrape annotations on the envoy proxy **pods**, and nonprod validation passed — but prod stayed dark: zero `envoy_*` series in central AMP even after the proxy pods rolled with the annotations and the remote-write allowlist (argus-infra-stacks #2580) merged.

The reason is a discovery asymmetry between the two metrics paths. The nonprod local prometheus-server runs a `kubernetes-pods` job that honors pod annotations. Prod grafana-alloy does not: its only annotation-driven job is `scrapeEndpoints`, which keys on `__meta_kubernetes_service_annotation_prometheus_io_scrape` — the **Service's** annotations (grafana-alloy `configmap.yaml`, `discovery.relabel "endpoints"`). Pod annotations are invisible to it.

This adds the same three annotations to the Envoy-Gateway-managed proxy Service via `envoyService.annotations` on the EnvoyProxy resource, right next to the existing `envoyService.type`. Alloy's endpoints job then discovers each ready proxy pod through the Service and rewrites the scrape target to `<pod-ip>:19001/stats/prometheus` per the `prometheus.io/port`/`path` annotations — the same pattern the fleet already uses for nginx-ingress metrics. The pod annotations stay, so the nonprod local-prometheus path keeps working unchanged.

Tested with helm unittest (76 passed): new assertions that the Service annotations render with and without geoip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)