### PR TITLE
feat: rotationPolicy Always on the envoy gateway Certificate — unwedges adopted Secrets with mismatched keys

### DIFF
--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -86,6 +86,7 @@ spec:
   privateKey:
     algorithm: RSA
     size: 4096
+    rotationPolicy: Always
   secretName: {{ .Values.gatewayName }}-tls
   usages:
     - digital signature

--- a/envoy-gateway-resources/tests/gateway_test.yaml
+++ b/envoy-gateway-resources/tests/gateway_test.yaml
@@ -323,6 +323,9 @@ tests:
       - equal:
           path: spec.privateKey.size
           value: 4096
+      - equal:
+          path: spec.privateKey.rotationPolicy
+          value: Always
 
   - it: should use correct secret name for certificate
     set:


### PR DESCRIPTION
On one cluster the chart's wildcard Certificate has been stuck unable to issue: the TLS Secret it targets was originally created by an older, hand-made Certificate with an RSA-2048 key, and after that leftover was cleaned up cert-manager refused to take over — `spec.privateKey.rotationPolicy` is unset (= `Never`), so it will not regenerate a private key that doesn't match the spec'd RSA-4096. The result is a permanent `CannotRegenerateKey` / "User intervention required" wedge while the old cert silently ages toward expiry.

This sets `rotationPolicy: Always`, cert-manager's recommended setting: a fresh private key on every issuance. That immediately unwedges the affected cluster on next sync, and going forward it means any Secret adoption, key-size change, or compromised-key reissue just works instead of requiring someone to delete Secrets by hand.

No effect on serving: the key is swapped atomically together with the new certificate at renewal time.

Tested with helm unittest (74 passed) — assertion added that the rendered Certificate carries the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)