### PR TITLE
feat: Self-serve vanity-domain TLS via Gateway API ListenerSet (CCIE-6643)

### DIFF
--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -157,29 +157,6 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [matchLabels](#listenerSets_namespaceSelector_matchLabels ) | No      | object | No         | -          | -                 |
-
-#### <a name="listenerSets_namespaceSelector_matchLabels"></a>7.3.1. Property `envoy-gateway-resources > listenerSets > namespaceSelector > matchLabels`
-
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
-
-| Property                                                                                                                                  | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [argus.chanzuckerberg.com/allow-listener-sets](#listenerSets_namespaceSelector_matchLabels_arguschanzuckerbergcom/allow-listener-sets ) | No      | string | No         | -          | -                 |
-
-##### <a name="listenerSets_namespaceSelector_matchLabels_arguschanzuckerbergcom/allow-listener-sets"></a>7.3.1.1. Property `envoy-gateway-resources > listenerSets > namespaceSelector > matchLabels > argus.chanzuckerberg.com/allow-listener-sets`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
 ## <a name="proxyProtocol"></a>8. Property `envoy-gateway-resources > proxyProtocol`
 
 |                           |                  |

--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -16,6 +16,7 @@
 | - [envoyService](#envoyService )     | No      | object | No         | -          | -                 |
 | - [gatewayName](#gatewayName )       | No      | string | No         | -          | -                 |
 | - [geoip](#geoip )                   | No      | object | No         | -          | -                 |
+| - [listenerSets](#listenerSets )     | No      | object | No         | -          | -                 |
 | - [proxyProtocol](#proxyProtocol )   | No      | object | No         | -          | -                 |
 | - [serviceAccount](#serviceAccount ) | No      | object | No         | -          | -                 |
 
@@ -120,7 +121,66 @@
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="proxyProtocol"></a>7. Property `envoy-gateway-resources > proxyProtocol`
+## <a name="listenerSets"></a>7. Property `envoy-gateway-resources > listenerSets`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [enabled](#listenerSets_enabled )                     | No      | boolean | No         | -          | -                 |
+| - [from](#listenerSets_from )                           | No      | string  | No         | -          | -                 |
+| - [namespaceSelector](#listenerSets_namespaceSelector ) | No      | object  | No         | -          | -                 |
+
+### <a name="listenerSets_enabled"></a>7.1. Property `envoy-gateway-resources > listenerSets > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+### <a name="listenerSets_from"></a>7.2. Property `envoy-gateway-resources > listenerSets > from`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="listenerSets_namespaceSelector"></a>7.3. Property `envoy-gateway-resources > listenerSets > namespaceSelector`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [matchLabels](#listenerSets_namespaceSelector_matchLabels ) | No      | object | No         | -          | -                 |
+
+#### <a name="listenerSets_namespaceSelector_matchLabels"></a>7.3.1. Property `envoy-gateway-resources > listenerSets > namespaceSelector > matchLabels`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                                                                                                  | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [argus.chanzuckerberg.com/allow-listener-sets](#listenerSets_namespaceSelector_matchLabels_arguschanzuckerbergcom/allow-listener-sets ) | No      | string | No         | -          | -                 |
+
+##### <a name="listenerSets_namespaceSelector_matchLabels_arguschanzuckerbergcom/allow-listener-sets"></a>7.3.1.1. Property `envoy-gateway-resources > listenerSets > namespaceSelector > matchLabels > argus.chanzuckerberg.com/allow-listener-sets`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="proxyProtocol"></a>8. Property `envoy-gateway-resources > proxyProtocol`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -133,21 +193,21 @@
 | - [enabled](#proxyProtocol_enabled )   | No      | boolean | No         | -          | -                 |
 | - [optional](#proxyProtocol_optional ) | No      | boolean | No         | -          | -                 |
 
-### <a name="proxyProtocol_enabled"></a>7.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
+### <a name="proxyProtocol_enabled"></a>8.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-### <a name="proxyProtocol_optional"></a>7.2. Property `envoy-gateway-resources > proxyProtocol > optional`
+### <a name="proxyProtocol_optional"></a>8.2. Property `envoy-gateway-resources > proxyProtocol > optional`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="serviceAccount"></a>8. Property `envoy-gateway-resources > serviceAccount`
+## <a name="serviceAccount"></a>9. Property `envoy-gateway-resources > serviceAccount`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -160,7 +220,7 @@
 | - [annotations](#serviceAccount_annotations ) | No      | object | No         | -          | -                 |
 | - [name](#serviceAccount_name )               | No      | string | No         | -          | -                 |
 
-### <a name="serviceAccount_annotations"></a>8.1. Property `envoy-gateway-resources > serviceAccount > annotations`
+### <a name="serviceAccount_annotations"></a>9.1. Property `envoy-gateway-resources > serviceAccount > annotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -168,7 +228,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-### <a name="serviceAccount_name"></a>8.2. Property `envoy-gateway-resources > serviceAccount > name`
+### <a name="serviceAccount_name"></a>9.2. Property `envoy-gateway-resources > serviceAccount > name`
 
 |              |          |
 | ------------ | -------- |

--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -14,6 +14,15 @@ metadata:
     external-dns.alpha.kubernetes.io/target: access-gw.{{ .Values.baseDomain }}
 spec:
   gatewayClassName: eg
+  {{- if .Values.listenerSets.enabled }}
+  allowedListeners:
+    namespaces:
+      from: {{ .Values.listenerSets.from }}
+      {{- if eq .Values.listenerSets.from "Selector" }}
+      selector:
+        {{- toYaml .Values.listenerSets.namespaceSelector | nindent 8 }}
+      {{- end }}
+  {{- end }}
   infrastructure:
     parametersRef:
       group: gateway.envoyproxy.io

--- a/envoy-gateway-resources/tests/listener_sets_test.yaml
+++ b/envoy-gateway-resources/tests/listener_sets_test.yaml
@@ -1,0 +1,48 @@
+suite: test allowedListeners for tenant ListenerSets
+templates:
+  - gateway.yaml
+tests:
+  - it: should not set allowedListeners by default
+    set:
+      baseDomain: test-cluster.dev.czi.team
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Gateway
+      - documentIndex: 1
+        notExists:
+          path: spec.allowedListeners
+
+  - it: should allow ListenerSets from a namespace selector when enabled
+    set:
+      baseDomain: prod-central.prod.czi.team
+      listenerSets:
+        enabled: true
+        from: Selector
+        namespaceSelector:
+          matchLabels:
+            argus.chanzuckerberg.com/allow-listener-sets: "true"
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.allowedListeners.namespaces.from
+          value: Selector
+      - documentIndex: 1
+        equal:
+          path: spec.allowedListeners.namespaces.selector.matchLabels["argus.chanzuckerberg.com/allow-listener-sets"]
+          value: "true"
+
+  - it: should omit the selector when from is All
+    set:
+      baseDomain: prod-central.prod.czi.team
+      listenerSets:
+        enabled: true
+        from: All
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.allowedListeners.namespaces.from
+          value: All
+      - documentIndex: 1
+        notExists:
+          path: spec.allowedListeners.namespaces.selector

--- a/envoy-gateway-resources/tests/listener_sets_test.yaml
+++ b/envoy-gateway-resources/tests/listener_sets_test.yaml
@@ -2,13 +2,24 @@ suite: test allowedListeners for tenant ListenerSets
 templates:
   - gateway.yaml
 tests:
-  - it: should not set allowedListeners by default
+  - it: should allow ListenerSets from all namespaces by default
     set:
       baseDomain: test-cluster.dev.czi.team
     asserts:
       - documentIndex: 1
         isKind:
           of: Gateway
+      - documentIndex: 1
+        equal:
+          path: spec.allowedListeners.namespaces.from
+          value: All
+
+  - it: should omit allowedListeners when explicitly disabled
+    set:
+      baseDomain: test-cluster.dev.czi.team
+      listenerSets:
+        enabled: false
+    asserts:
       - documentIndex: 1
         notExists:
           path: spec.allowedListeners

--- a/envoy-gateway-resources/tests/listener_sets_test.yaml
+++ b/envoy-gateway-resources/tests/listener_sets_test.yaml
@@ -32,12 +32,11 @@ tests:
           path: spec.allowedListeners.namespaces.selector.matchLabels["argus.chanzuckerberg.com/allow-listener-sets"]
           value: "true"
 
-  - it: should omit the selector when from is All
+  - it: should allow ListenerSets from all namespaces by default when enabled
     set:
       baseDomain: prod-central.prod.czi.team
       listenerSets:
         enabled: true
-        from: All
     asserts:
       - documentIndex: 1
         equal:

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -38,6 +38,30 @@
         }
       }
     },
+    "listenerSets": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "from": {
+          "type": "string"
+        },
+        "namespaceSelector": {
+          "type": "object",
+          "properties": {
+            "matchLabels": {
+              "type": "object",
+              "properties": {
+                "argus.chanzuckerberg.com/allow-listener-sets": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "proxyProtocol": {
       "type": "object",
       "properties": {

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -48,17 +48,7 @@
           "type": "string"
         },
         "namespaceSelector": {
-          "type": "object",
-          "properties": {
-            "matchLabels": {
-              "type": "object",
-              "properties": {
-                "argus.chanzuckerberg.com/allow-listener-sets": {
-                  "type": "string"
-                }
-              }
-            }
-          }
+          "type": "object"
         }
       }
     },

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -5,10 +5,8 @@ alternateNames: []
 
 listenerSets:
   enabled: false
-  from: Selector
-  namespaceSelector:
-    matchLabels:
-      argus.chanzuckerberg.com/allow-listener-sets: "true"
+  from: All
+  namespaceSelector: {}
 
 serviceAccount:
   name: envoy-gateway-proxy

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -3,6 +3,13 @@ awsRegion: "us-west-2"
 gatewayName: "envoy-gateway"
 alternateNames: []
 
+listenerSets:
+  enabled: false
+  from: Selector
+  namespaceSelector:
+    matchLabels:
+      argus.chanzuckerberg.com/allow-listener-sets: "true"
+
 serviceAccount:
   name: envoy-gateway-proxy
   annotations: {}

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -4,7 +4,7 @@ gatewayName: "envoy-gateway"
 alternateNames: []
 
 listenerSets:
-  enabled: false
+  enabled: true
   from: All
   namespaceSelector: {}
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -684,17 +684,18 @@ Must be one of:
 
 **Description:** Gateway API HTTPRoute configuration
 
-| Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                 |
-| ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                         |
-| - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                             |
-| - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                         |
-| - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                 |
-| - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                            |
-| - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration) |
-| - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                           |
-| - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                              |
-| - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                              |
+| Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                         |
+| ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                 |
+| - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                     |
+| - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                 |
+| - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                         |
+| - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                    |
+| - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                         |
+| - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                   |
+| - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                                                                      |
+| - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                      |
+| - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20) |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>2.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
 
@@ -839,6 +840,49 @@ Must be one of:
 | **Required** | No       |
 
 **Description:** Optional section name (listener name) on the Gateway
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>2.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)
+
+| Property                                                            | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                        |
+| ------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [clusterIssuer](#cronJobs_pattern1_gateway_vanity_clusterIssuer ) | No      | string  | No         | -          | cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate                                                                    |
+| - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
+| - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
+
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>2.1.16.10.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
+
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>2.1.16.10.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
+
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>2.1.16.10.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs
 
 #### <a name="cronJobs_pattern1_grafanaDashboard"></a>2.1.17. Property `stack > cronJobs > ^.*$ > grafanaDashboard`
 
@@ -4054,17 +4098,18 @@ Must be one of:
 
 **Description:** Gateway API HTTPRoute configuration
 
-| Property                                                | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                 |
-| ------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------- |
-| - [annotations](#global_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                         |
-| - [enabled](#global_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                             |
-| - [gatewayName](#global_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                         |
-| - [gatewayNamespace](#global_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                 |
-| - [host](#global_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                            |
-| - [oidcProtected](#global_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration) |
-| - [paths](#global_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                           |
-| - [rules](#global_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                              |
-| - [sectionName](#global_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                              |
+| Property                                                | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                         |
+| ------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#global_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                 |
+| - [enabled](#global_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                     |
+| - [gatewayName](#global_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                 |
+| - [gatewayNamespace](#global_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                         |
+| - [host](#global_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                    |
+| - [oidcProtected](#global_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                         |
+| - [paths](#global_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                   |
+| - [rules](#global_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                                                                      |
+| - [sectionName](#global_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                      |
+| - [vanity](#global_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20) |
 
 #### <a name="global_gateway_annotations"></a>3.16.1. Property `stack > global > gateway > annotations`
 
@@ -4209,6 +4254,49 @@ Must be one of:
 | **Required** | No       |
 
 **Description:** Optional section name (listener name) on the Gateway
+
+#### <a name="global_gateway_vanity"></a>3.16.10. Property `stack > global > gateway > vanity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)
+
+| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                        |
+| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [clusterIssuer](#global_gateway_vanity_clusterIssuer ) | No      | string  | No         | -          | cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate                                                                    |
+| - [enabled](#global_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
+| - [hostname](#global_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
+
+##### <a name="global_gateway_vanity_clusterIssuer"></a>3.16.10.1. Property `stack > global > gateway > vanity > clusterIssuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
+
+##### <a name="global_gateway_vanity_enabled"></a>3.16.10.2. Property `stack > global > gateway > vanity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
+
+##### <a name="global_gateway_vanity_hostname"></a>3.16.10.3. Property `stack > global > gateway > vanity > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs
 
 ### <a name="global_grafanaDashboard"></a>3.17. Property `stack > global > grafanaDashboard`
 
@@ -7442,17 +7530,18 @@ Must be one of:
 
 **Description:** Gateway API HTTPRoute configuration
 
-| Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                 |
-| ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                         |
-| - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                             |
-| - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                         |
-| - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                 |
-| - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                            |
-| - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration) |
-| - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                           |
-| - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                              |
-| - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                              |
+| Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                         |
+| ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                 |
+| - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                     |
+| - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                 |
+| - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                         |
+| - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                    |
+| - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                         |
+| - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                   |
+| - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                                                                      |
+| - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                      |
+| - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20) |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>4.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
 
@@ -7597,6 +7686,49 @@ Must be one of:
 | **Required** | No       |
 
 **Description:** Optional section name (listener name) on the Gateway
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>4.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)
+
+| Property                                                            | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                        |
+| ------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [clusterIssuer](#cronJobs_pattern1_gateway_vanity_clusterIssuer ) | No      | string  | No         | -          | cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate                                                                    |
+| - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
+| - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
+
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>4.1.16.10.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
+
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>4.1.16.10.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
+
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>4.1.16.10.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs
 
 #### <a name="cronJobs_pattern1_grafanaDashboard"></a>4.1.17. Property `stack > cronJobs > ^.*$ > grafanaDashboard`
 
@@ -11294,17 +11426,18 @@ Must be one of:
 
 **Description:** Gateway API HTTPRoute configuration
 
-| Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                 |
-| ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                         |
-| - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                             |
-| - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                         |
-| - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                 |
-| - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                            |
-| - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration) |
-| - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                           |
-| - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                              |
-| - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                              |
+| Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                         |
+| ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                 |
+| - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                     |
+| - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                 |
+| - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                         |
+| - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                    |
+| - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                         |
+| - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                   |
+| - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts                                                                                      |
+| - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                      |
+| - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20) |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>7.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
 
@@ -11449,6 +11582,49 @@ Must be one of:
 | **Required** | No       |
 
 **Description:** Optional section name (listener name) on the Gateway
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>7.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)
+
+| Property                                                            | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                        |
+| ------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [clusterIssuer](#cronJobs_pattern1_gateway_vanity_clusterIssuer ) | No      | string  | No         | -          | cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate                                                                    |
+| - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
+| - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
+
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>7.1.16.10.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
+
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>7.1.16.10.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
+
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>7.1.16.10.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs
 
 #### <a name="cronJobs_pattern1_grafanaDashboard"></a>7.1.17. Property `stack > cronJobs > ^.*$ > grafanaDashboard`
 

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -81,6 +81,14 @@ external-dns.alpha.kubernetes.io/target: "access.{{ include "clusterBaseDomain" 
 {{- end }}
 
 {{/*
+Name of the vanity-domain ListenerSet. Referenced by both the ListenerSet itself
+and the HTTPRoute parentRef, so keep it in one place.
+*/}}
+{{- define "service.vanityListenerSetName" -}}
+{{ include "service.fullname" . }}-vanity
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "stack.chart" -}}

--- a/stack/templates/httproute.yaml
+++ b/stack/templates/httproute.yaml
@@ -53,7 +53,7 @@ spec:
     {{- if .Values.gateway.vanity.enabled }}
     - group: gateway.networking.k8s.io
       kind: ListenerSet
-      name: {{ include "service.fullname" . }}-vanity
+      name: {{ include "service.vanityListenerSetName" . }}
     {{- else }}
     - name: {{ .Values.gateway.gatewayName }}
       namespace: {{ .Values.gateway.gatewayNamespace }}

--- a/stack/templates/httproute.yaml
+++ b/stack/templates/httproute.yaml
@@ -50,11 +50,17 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if .Values.gateway.vanity.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ include "service.fullname" . }}-vanity
+    {{- else }}
     - name: {{ .Values.gateway.gatewayName }}
       namespace: {{ .Values.gateway.gatewayNamespace }}
       {{- if .Values.gateway.sectionName }}
       sectionName: {{ .Values.gateway.sectionName }}
       {{- end }}
+    {{- end }}
   hostnames:
     - {{ $service.Values.gateway.host }}
   rules:

--- a/stack/templates/listenerset.yaml
+++ b/stack/templates/listenerset.yaml
@@ -21,7 +21,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet
 metadata:
-  name: {{ include "service.fullname" . }}-vanity
+  name: {{ include "service.vanityListenerSetName" . }}
   labels:
     {{- include "service.labels" . | nindent 4 }}
   annotations:
@@ -42,7 +42,7 @@ spec:
         certificateRefs:
           - group: ''
             kind: Secret
-            name: {{ include "service.fullname" . }}-vanity-tls
+            name: {{ include "service.vanityListenerSetName" . }}-tls
 {{- end }}
 {{- end }}
 {{ end }}

--- a/stack/templates/listenerset.yaml
+++ b/stack/templates/listenerset.yaml
@@ -1,0 +1,48 @@
+{{- $global := . -}}
+{{ range $serviceName, $serviceValues := .Values.services }}
+  {{- $globalValuesDict := $global.Values.global | toYaml -}}
+  {{- $values := fromYaml $globalValuesDict -}}
+  {{- $values = set $values "name" $serviceName -}}
+  {{- $values := mergeOverwrite $values $serviceValues -}}
+
+  {{/* Auto-enable gateway when config keys are provided (unless explicitly disabled) */}}
+  {{- if hasKey $serviceValues "gateway" -}}
+    {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
+    {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
+      {{- $_ := set $values.gateway "enabled" true -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
+{{- with $service }}
+{{- if and .Values.gateway.enabled .Values.gateway.vanity.enabled -}}
+{{- $hostname := .Values.gateway.vanity.hostname | default .Values.gateway.host -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ include "service.fullname" . }}-vanity
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.gateway.vanity.clusterIssuer | quote }}
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.gateway.gatewayName }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: {{ $hostname | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ''
+            kind: Secret
+            name: {{ include "service.fullname" . }}-vanity-tls
+{{- end }}
+{{- end }}
+{{ end }}

--- a/stack/tests/gateway_test.yaml
+++ b/stack/tests/gateway_test.yaml
@@ -348,3 +348,35 @@ tests:
         equal:
           path: metadata.labels["argus/env-name"]
           value: "production"
+
+  - it: should attach the HTTPRoute to the ListenerSet when vanity is enabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: tools.czi.team
+          vanity:
+            enabled: true
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 0
+        equal:
+          path: spec.parentRefs[0].kind
+          value: ListenerSet
+      - documentIndex: 0
+        equal:
+          path: spec.parentRefs[0].group
+          value: gateway.networking.k8s.io
+      - documentIndex: 0
+        matchRegex:
+          path: spec.parentRefs[0].name
+          pattern: -vanity$
+      - documentIndex: 0
+        notExists:
+          path: spec.parentRefs[0].namespace

--- a/stack/tests/gateway_vanity_test.yaml
+++ b/stack/tests/gateway_vanity_test.yaml
@@ -1,0 +1,110 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test vanity-domain ListenerSet
+templates:
+  - listenerset.yaml
+tests:
+  - it: should not create a ListenerSet when vanity is disabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a ListenerSet when the gateway is disabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: false
+          vanity:
+            enabled: true
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ListenerSet attaching to the shared Gateway with a shim-issued cert
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: tools.czi.team
+          gatewayName: envoy-gateway
+          gatewayNamespace: envoy-gateway
+          vanity:
+            enabled: true
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        isKind:
+          of: ListenerSet
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod-eg
+      - documentIndex: 0
+        equal:
+          path: spec.parentRef.kind
+          value: Gateway
+      - documentIndex: 0
+        equal:
+          path: spec.parentRef.name
+          value: envoy-gateway
+      - documentIndex: 0
+        equal:
+          path: spec.listeners[0].hostname
+          value: tools.czi.team
+      - documentIndex: 0
+        equal:
+          path: spec.listeners[0].tls.mode
+          value: Terminate
+      - documentIndex: 0
+        matchRegex:
+          path: spec.listeners[0].tls.certificateRefs[0].name
+          pattern: -vanity-tls$
+      - documentIndex: 0
+        matchRegex:
+          path: metadata.name
+          pattern: -vanity$
+
+  - it: should use the hostname override (wildcard) when set
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: app.rnaquarium.org
+          vanity:
+            enabled: true
+            hostname: "*.rnaquarium.org"
+            clusterIssuer: letsencrypt-prod-dns01
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.listeners[0].hostname
+          value: "*.rnaquarium.org"
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod-dns01

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -298,6 +298,24 @@
             "sectionName": {
               "description": "Optional section name (listener name) on the Gateway",
               "type": "string"
+            },
+            "vanity": {
+              "description": "Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway \u003e= v1.8 and cert-manager \u003e= v1.20)",
+              "type": "object",
+              "properties": {
+                "clusterIssuer": {
+                  "description": "cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate",
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway",
+                  "type": "boolean"
+                },
+                "hostname": {
+                  "description": "Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs",
+                  "type": "string"
+                }
+              }
             }
           }
         },

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -225,9 +225,13 @@ global: # @schema description: Global configuration for the stack - this serves 
         pathType: Prefix # @schema description: HTTPRoute path type (Exact or Prefix)
     rules: [] # @schema description: List of additional HTTPRoute rules with custom hosts
     oidcProtected: false # @schema description: Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)
+    vanity: # @schema description: Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)
+      enabled: false # @schema description: Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
+      hostname: "" # @schema description: Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs
+      clusterIssuer: letsencrypt-prod-eg # @schema description: cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
     annotations: # @schema description: Annotations to add to HTTPRoute resources
       external-dns.alpha.kubernetes.io/ttl: "60"
-  
+
   nodeSelector:
     kubernetes.io/arch: arm64 # @schema description: Node selector for architecture
 


### PR DESCRIPTION
## Why

Today a public/vanity domain (`tools.czi.team`, `*.rnaquarium.org`, …) needs a **platform PR to argus-infra-stacks** to get an HTTPS listener + cert on the shared Envoy Gateway (the `additionalListeners` path in #485). Regular `*.<cluster>.<env>.czi.team` domains are self-serve from the app's own stack chart; vanity domains are not. This closes that gap using GA Gateway API **`ListenerSet`** (Envoy Gateway v1.8) + the cert-manager **gateway-shim** (cert-manager v1.20).

## What this does

**`envoy-gateway-resources` (platform):** adds value-gated **`allowedListeners`** to the shared Gateway so tenant `ListenerSet`s may attach. Defaults: `listenerSets.enabled: true`, `from: All` (any namespace may attach — set `from: Selector` + `namespaceSelector` to restrict). No-op on Envoy Gateway < v1.8 (the field is ignored), so safe ahead of the upgrade.

**`stack` (tenant):** a new `gateway.vanity` block. When enabled it renders, in the app's own namespace:
- a **`ListenerSet`** (`gateway.networking.k8s.io/v1`) → `parentRef` the shared Gateway, one HTTPS listener (SNI = the vanity host, its own cert), annotated `cert-manager.io/cluster-issuer` so the shim auto-issues the cert;
- the service's **`HTTPRoute`** with `parentRef` pointed at the `ListenerSet` (same namespace → no `ReferenceGrant`).

Net: a vanity domain becomes as self-serve as a regular one — listener + cert + route all live in the app's stack chart, zero per-domain platform change.

## How to configure a vanity host

**Regular host (unchanged, no vanity block)** — any name under the cluster's own zone uses the shared wildcard listener + wildcard cert:
```yaml
services:
  my-app:
    gateway:
      enabled: true
      host: my-app.<cluster>.<env>.czi.team
      paths:
        - { path: /, pathType: Prefix }
```

**Vanity host (foreign parent)** — add the `gateway.vanity` block; it gets its own listener + cert:
```yaml
services:
  my-app:
    gateway:
      enabled: true
      host: tools.czi.team            # the vanity hostname (HTTPRoute + listener SNI)
      vanity:
        enabled: true                 # render a tenant ListenerSet + shim-issued cert
        clusterIssuer: letsencrypt-prod-eg   # default; cert-manager ClusterIssuer used by the shim
        # hostname: "*.rnaquarium.org"        # optional; defaults to gateway.host.
        #                                       a *. wildcard requires a dns01-capable issuer
        #                                       (http01 can't issue wildcard certs)
      paths:
        - { path: /, pathType: Prefix }
```
Renders `ListenerSet/my-app-vanity` (HTTPS `tools.czi.team`, secret `my-app-vanity-tls`, shim annotation) + an `HTTPRoute` parented to it. The `-vanity` name is centralized in the `service.vanityListenerSetName` helper (used by both the ListenerSet and the HTTPRoute parentRef).

## Cluster prerequisites
- Envoy Gateway **>= v1.8** (GA `ListenerSet`).
- cert-manager **>= v1.20** with the `ListenerSets` feature gate + `enableGatewayAPIListenerSet`.
- `allowedListeners` on the shared Gateway (this chart, default-on).

All live on **nonprod** as of argus-infra-stacks #2599.

## How to test

**Unit:** `helm unittest stack envoy-gateway-resources` (covers allowedListeners default-on / Selector / off, and the `gateway.vanity` ListenerSet + cert-ref + annotation + HTTPRoute-parentRef-to-ListenerSet).

**Live end-to-end (verified on dev-core-platform):** deploy a stack with `gateway.vanity.enabled: true` for an exact host, then:
```bash
kubectl -n <ns> get listenerset   # ACCEPTED=True, PROGRAMMED=True
kubectl -n <ns> get certificate   # READY=True  (shim auto-created it; issued via http01)
# pin to the Envoy NLB to test SNI/TLS independent of DNS:
IP=$(dig +short access-gw.<cluster>.<env>.czi.team @8.8.8.8 | grep '^[0-9]' | head -1)
curl -sS --resolve <vanity-host>:443:$IP -o /dev/null \
  -w 'HTTP %{http_code} tls_verify=%{ssl_verify_result}\n' https://<vanity-host>/
echo | openssl s_client -connect $IP:443 -servername <vanity-host> 2>/dev/null \
  | openssl x509 -noout -subject -issuer
```
Expect `HTTP 200`, `tls_verify=0` (publicly-trusted), and the cert subject = the vanity host (per-SNI selection), while a regular host on the same Gateway shows the shared `*.<cluster>…` wildcard cert.

**Verification run (2 regular + 2 vanity simultaneously, dev-core-platform):** all four returned HTTP 200 over trusted TLS; regular hosts served the `*.dev-core-platform.dev.czi.team` wildcard cert, vanity hosts (`eg-vanity-1.dev.czi.team`, `eg-vanity-2.dev.platform.si.czi.technology`) each served their own LE cert issued by the shim — confirming SNI cert selection, TLS termination, and routing all work at once.

## Known limitation
- **Wildcard parents need dns01.** http01 can't issue wildcard certs, so `*.parent` requires a dns01-capable `clusterIssuer`; exact hosts issue via http01.
- **DNS for ListenerSet routes is not auto-created reliably.** external-dns's `gateway-httproute` source flaps on HTTPRoutes parented to a `ListenerSet` (creates then deletes under `--policy=sync`), so vanity DNS currently needs separate/manual handling. The listener + cert half is fully self-serve; DNS automation is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)