### PR TITLE
feat: first-class gateway values for nginx-annotation parity

### DIFF
--- a/envoy-gateway-resources/Chart.yaml
+++ b/envoy-gateway-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: envoy-gateway-resources
 description: GatewayClass, Gateway, and ClusterIssuer for Envoy Gateway (per-cluster hostname and DNS)
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1"

--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -19,6 +19,7 @@
 | - [listenerSets](#listenerSets )     | No      | object | No         | -          | -                 |
 | - [proxyProtocol](#proxyProtocol )   | No      | object | No         | -          | -                 |
 | - [serviceAccount](#serviceAccount ) | No      | object | No         | -          | -                 |
+| - [tlsPassthrough](#tlsPassthrough ) | No      | object | No         | -          | -                 |
 
 ## <a name="alternateNames"></a>1. Property `envoy-gateway-resources > alternateNames`
 
@@ -211,5 +212,40 @@
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
+
+## <a name="tlsPassthrough"></a>10. Property `envoy-gateway-resources > tlsPassthrough`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                  | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ----------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [enabled](#tlsPassthrough_enabled )     | No      | boolean | No         | -          | -                 |
+| - [hostnames](#tlsPassthrough_hostnames ) | No      | array   | No         | -          | -                 |
+
+### <a name="tlsPassthrough_enabled"></a>10.1. Property `envoy-gateway-resources > tlsPassthrough > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+### <a name="tlsPassthrough_hostnames"></a>10.2. Property `envoy-gateway-resources > tlsPassthrough > hostnames`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
 
 ----------------------------------------------------------------------------------------------------------------------------

--- a/envoy-gateway-resources/templates/gateway.yaml
+++ b/envoy-gateway-resources/templates/gateway.yaml
@@ -48,6 +48,21 @@ spec:
           - group: ''
             kind: Secret
             name: {{ .Values.gatewayName }}-tls
+    {{- if .Values.tlsPassthrough.enabled }}
+    {{- range $i, $h := .Values.tlsPassthrough.hostnames }}
+    - name: tls-passthrough-{{ $i }}
+      protocol: TLS
+      port: 443
+      hostname: {{ $h | quote }}
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: TLSRoute
+    {{- end }}
+    {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/envoy-gateway-resources/tests/tls_passthrough_test.yaml
+++ b/envoy-gateway-resources/tests/tls_passthrough_test.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test TLS passthrough listeners on the shared Gateway
+templates:
+  - gateway.yaml
+tests:
+  - it: should not add passthrough listeners when disabled
+    set:
+      baseDomain: example.dev.czi.team
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Gateway
+      - documentIndex: 1
+        lengthEqual:
+          path: spec.listeners
+          count: 2
+
+  - it: should add one Passthrough listener per hostname when enabled
+    set:
+      baseDomain: example.dev.czi.team
+      tlsPassthrough:
+        enabled: true
+        hostnames:
+          - secure.example.com
+          - tools.czi.team
+    asserts:
+      - documentIndex: 1
+        lengthEqual:
+          path: spec.listeners
+          count: 4
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].name
+          value: tls-passthrough-0
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].protocol
+          value: TLS
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].tls.mode
+          value: Passthrough
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].hostname
+          value: secure.example.com
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[2].allowedRoutes.kinds[0].kind
+          value: TLSRoute
+      - documentIndex: 1
+        equal:
+          path: spec.listeners[3].hostname
+          value: tools.czi.team

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -73,6 +73,17 @@
           "type": "string"
         }
       }
+    },
+    "tlsPassthrough": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "hostnames": {
+          "type": "array"
+        }
+      }
     }
   }
 }

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -8,6 +8,14 @@ listenerSets:
   from: All
   namespaceSelector: {}
 
+# TLS passthrough listeners on the shared Gateway (mode: Passthrough). Off by default.
+# When enabled, one TLS listener is rendered per hostname; tenant TLSRoutes attach by
+# hostname. Hostnames must be specific (not the cluster wildcard) to avoid SNI conflict
+# with the Terminate HTTPS listener.
+tlsPassthrough:
+  enabled: false
+  hostnames: []
+
 serviceAccount:
   name: envoy-gateway-proxy
   annotations: {}

--- a/stack/Chart.yaml
+++ b/stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.42.0
+version: 2.43.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stack/Chart.yaml
+++ b/stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.41.0
+version: 2.42.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stack/README.md
+++ b/stack/README.md
@@ -706,6 +706,7 @@ Must be one of:
 | - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
 | - [sessionAffinity](#cronJobs_pattern1_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
 | - [timeouts](#cronJobs_pattern1_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
+| - [tlsPassthrough](#cronJobs_pattern1_gateway_tlsPassthrough )     | No      | object          | No         | -          | TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway                                                                                     |
 | - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>2.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
@@ -1413,7 +1414,40 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>2.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>2.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway
+
+| Property                                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                   |
+| ----------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
+| - [sectionName](#cronJobs_pattern1_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
+
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>2.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
+
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>2.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>2.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1429,7 +1463,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>2.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>2.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -1438,7 +1472,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>2.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>2.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1447,7 +1481,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>2.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>2.1.16.22.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -4692,6 +4726,7 @@ Must be one of:
 | - [sectionName](#global_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
 | - [sessionAffinity](#global_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
 | - [timeouts](#global_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
+| - [tlsPassthrough](#global_gateway_tlsPassthrough )     | No      | object          | No         | -          | TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway                                                                                     |
 | - [vanity](#global_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 #### <a name="global_gateway_annotations"></a>3.16.1. Property `stack > global > gateway > annotations`
@@ -5399,7 +5434,40 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-#### <a name="global_gateway_vanity"></a>3.16.21. Property `stack > global > gateway > vanity`
+#### <a name="global_gateway_tlsPassthrough"></a>3.16.21. Property `stack > global > gateway > tlsPassthrough`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway
+
+| Property                                                     | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                   |
+| ------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#global_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
+| - [sectionName](#global_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
+
+##### <a name="global_gateway_tlsPassthrough_enabled"></a>3.16.21.1. Property `stack > global > gateway > tlsPassthrough > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
+
+##### <a name="global_gateway_tlsPassthrough_sectionName"></a>3.16.21.2. Property `stack > global > gateway > tlsPassthrough > sectionName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
+
+#### <a name="global_gateway_vanity"></a>3.16.22. Property `stack > global > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5415,7 +5483,7 @@ Must be one of:
 | - [enabled](#global_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#global_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-##### <a name="global_gateway_vanity_clusterIssuer"></a>3.16.21.1. Property `stack > global > gateway > vanity > clusterIssuer`
+##### <a name="global_gateway_vanity_clusterIssuer"></a>3.16.22.1. Property `stack > global > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -5424,7 +5492,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-##### <a name="global_gateway_vanity_enabled"></a>3.16.21.2. Property `stack > global > gateway > vanity > enabled`
+##### <a name="global_gateway_vanity_enabled"></a>3.16.22.2. Property `stack > global > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -5433,7 +5501,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-##### <a name="global_gateway_vanity_hostname"></a>3.16.21.3. Property `stack > global > gateway > vanity > hostname`
+##### <a name="global_gateway_vanity_hostname"></a>3.16.22.3. Property `stack > global > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -8696,6 +8764,7 @@ Must be one of:
 | - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
 | - [sessionAffinity](#cronJobs_pattern1_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
 | - [timeouts](#cronJobs_pattern1_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
+| - [tlsPassthrough](#cronJobs_pattern1_gateway_tlsPassthrough )     | No      | object          | No         | -          | TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway                                                                                     |
 | - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>4.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
@@ -9403,7 +9472,40 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>4.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>4.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway
+
+| Property                                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                   |
+| ----------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
+| - [sectionName](#cronJobs_pattern1_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
+
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>4.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
+
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>4.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>4.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9419,7 +9521,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>4.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>4.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -9428,7 +9530,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>4.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>4.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -9437,7 +9539,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>4.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>4.1.16.22.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -13164,6 +13266,7 @@ Must be one of:
 | - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
 | - [sessionAffinity](#cronJobs_pattern1_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
 | - [timeouts](#cronJobs_pattern1_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
+| - [tlsPassthrough](#cronJobs_pattern1_gateway_tlsPassthrough )     | No      | object          | No         | -          | TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway                                                                                     |
 | - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>7.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
@@ -13871,7 +13974,40 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>7.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>7.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway
+
+| Property                                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                   |
+| ----------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
+| - [sectionName](#cronJobs_pattern1_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
+
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>7.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
+
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>7.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>7.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -13887,7 +14023,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>7.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>7.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -13896,7 +14032,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>7.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>7.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -13905,7 +14041,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>7.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>7.1.16.22.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/README.md
+++ b/stack/README.md
@@ -687,14 +687,25 @@ Must be one of:
 | Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                   |
 | ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                                                                                                                                           |
+| - [backendTLS](#cronJobs_pattern1_gateway_backendTLS )             | No      | object          | No         | -          | TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)                                                                                                                                                                                   |
+| - [basicAuth](#cronJobs_pattern1_gateway_basicAuth )               | No      | object          | No         | -          | HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected                                                                                                                                                                                 |
+| - [cors](#cronJobs_pattern1_gateway_cors )                         | No      | object          | No         | -          | CORS via a SecurityPolicy                                                                                                                                                                                                                                           |
 | - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                                                                                                                                               |
 | - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                                                                                                                                           |
 | - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                                                                                                                                                   |
 | - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                              |
+| - [hostRewrite](#cronJobs_pattern1_gateway_hostRewrite )           | No      | string          | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                         |
+| - [ipAllowList](#cronJobs_pattern1_gateway_ipAllowList )           | No      | array           | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                               |
 | - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                                                                                                                                                   |
 | - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                             |
+| - [rateLimit](#cronJobs_pattern1_gateway_rateLimit )               | No      | object          | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                            |
+| - [redirect](#cronJobs_pattern1_gateway_redirect )                 | No      | object          | No         | -          | Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host                                                                                                                                                                 |
+| - [requestHeaders](#cronJobs_pattern1_gateway_requestHeaders )     | No      | object          | No         | -          | Request header modifications (HTTPRoute RequestHeaderModifier filter)                                                                                                                                                                                               |
+| - [responseHeaders](#cronJobs_pattern1_gateway_responseHeaders )   | No      | object          | No         | -          | Response header modifications (HTTPRoute ResponseHeaderModifier filter)                                                                                                                                                                                             |
 | - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts. Each entry takes host, optional paths, and an optional vanity block (enabled, hostname, clusterIssuer) that renders a per-host ListenerSet so the extra host can be a vanity domain, mirroring gateway.vanity |
 | - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
+| - [sessionAffinity](#cronJobs_pattern1_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
+| - [timeouts](#cronJobs_pattern1_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
 | - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>2.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
@@ -718,7 +729,216 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_gateway_enabled"></a>2.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > enabled`
+##### <a name="cronJobs_pattern1_gateway_backendTLS"></a>2.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > backendTLS`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)
+
+| Property                                                                                    | Pattern | Type    | Deprecated | Definition | Title/Description                                                                |
+| ------------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| - [caCertificateRefs](#cronJobs_pattern1_gateway_backendTLS_caCertificateRefs )             | No      | array   | No         | -          | ConfigMap refs holding the CA bundle for self-signed/internal upstreams          |
+| - [enabled](#cronJobs_pattern1_gateway_backendTLS_enabled )                                 | No      | boolean | No         | -          | Enable upstream TLS                                                              |
+| - [hostname](#cronJobs_pattern1_gateway_backendTLS_hostname )                               | No      | string  | No         | -          | SNI/validation hostname presented by the upstream (required when enabled)        |
+| - [wellKnownCACertificates](#cronJobs_pattern1_gateway_backendTLS_wellKnownCACertificates ) | No      | string  | No         | -          | Use the System trust store, or set "" and use caCertificateRefs for a private CA |
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_caCertificateRefs"></a>2.1.16.2.1. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > caCertificateRefs`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** ConfigMap refs holding the CA bundle for self-signed/internal upstreams
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_enabled"></a>2.1.16.2.2. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable upstream TLS
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_hostname"></a>2.1.16.2.3. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** SNI/validation hostname presented by the upstream (required when enabled)
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_wellKnownCACertificates"></a>2.1.16.2.4. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > wellKnownCACertificates`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Use the System trust store, or set "" and use caCertificateRefs for a private CA
+
+##### <a name="cronJobs_pattern1_gateway_basicAuth"></a>2.1.16.3. Property `stack > cronJobs > ^.*$ > gateway > basicAuth`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected
+
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                             |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_basicAuth_enabled )       | No      | boolean | No         | -          | Enable basic auth                             |
+| - [secretName](#cronJobs_pattern1_gateway_basicAuth_secretName ) | No      | string  | No         | -          | Name of an Opaque Secret with a .htpasswd key |
+
+###### <a name="cronJobs_pattern1_gateway_basicAuth_enabled"></a>2.1.16.3.1. Property `stack > cronJobs > ^.*$ > gateway > basicAuth > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable basic auth
+
+###### <a name="cronJobs_pattern1_gateway_basicAuth_secretName"></a>2.1.16.3.2. Property `stack > cronJobs > ^.*$ > gateway > basicAuth > secretName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of an Opaque Secret with a .htpasswd key
+
+##### <a name="cronJobs_pattern1_gateway_cors"></a>2.1.16.4. Property `stack > cronJobs > ^.*$ > gateway > cors`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** CORS via a SecurityPolicy
+
+| Property                                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                    |
+| ----------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------- |
+| - [allowCredentials](#cronJobs_pattern1_gateway_cors_allowCredentials ) | No      | boolean | No         | -          | Allow credentials                                    |
+| - [allowHeaders](#cronJobs_pattern1_gateway_cors_allowHeaders )         | No      | array   | No         | -          | Allowed request headers                              |
+| - [allowMethods](#cronJobs_pattern1_gateway_cors_allowMethods )         | No      | array   | No         | -          | Allowed methods                                      |
+| - [allowOrigins](#cronJobs_pattern1_gateway_cors_allowOrigins )         | No      | array   | No         | -          | Allowed origins (string patterns)                    |
+| - [enabled](#cronJobs_pattern1_gateway_cors_enabled )                   | No      | boolean | No         | -          | Enable CORS                                          |
+| - [exposeHeaders](#cronJobs_pattern1_gateway_cors_exposeHeaders )       | No      | array   | No         | -          | Response headers exposed to the browser              |
+| - [maxAge](#cronJobs_pattern1_gateway_cors_maxAge )                     | No      | string  | No         | -          | Preflight cache duration (e.g. "1h"), empty omits it |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowCredentials"></a>2.1.16.4.1. Property `stack > cronJobs > ^.*$ > gateway > cors > allowCredentials`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Allow credentials
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowHeaders"></a>2.1.16.4.2. Property `stack > cronJobs > ^.*$ > gateway > cors > allowHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed request headers
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowMethods"></a>2.1.16.4.3. Property `stack > cronJobs > ^.*$ > gateway > cors > allowMethods`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed methods
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowOrigins"></a>2.1.16.4.4. Property `stack > cronJobs > ^.*$ > gateway > cors > allowOrigins`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed origins (string patterns)
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_enabled"></a>2.1.16.4.5. Property `stack > cronJobs > ^.*$ > gateway > cors > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable CORS
+
+###### <a name="cronJobs_pattern1_gateway_cors_exposeHeaders"></a>2.1.16.4.6. Property `stack > cronJobs > ^.*$ > gateway > cors > exposeHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Response headers exposed to the browser
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_maxAge"></a>2.1.16.4.7. Property `stack > cronJobs > ^.*$ > gateway > cors > maxAge`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Preflight cache duration (e.g. "1h"), empty omits it
+
+##### <a name="cronJobs_pattern1_gateway_enabled"></a>2.1.16.5. Property `stack > cronJobs > ^.*$ > gateway > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -727,7 +947,7 @@ Must be one of:
 
 **Description:** Enable Gateway API HTTPRoute (alternative to Ingress)
 
-##### <a name="cronJobs_pattern1_gateway_gatewayName"></a>2.1.16.3. Property `stack > cronJobs > ^.*$ > gateway > gatewayName`
+##### <a name="cronJobs_pattern1_gateway_gatewayName"></a>2.1.16.6. Property `stack > cronJobs > ^.*$ > gateway > gatewayName`
 
 |              |          |
 | ------------ | -------- |
@@ -736,7 +956,7 @@ Must be one of:
 
 **Description:** Name of the Gateway resource to attach to
 
-##### <a name="cronJobs_pattern1_gateway_gatewayNamespace"></a>2.1.16.4. Property `stack > cronJobs > ^.*$ > gateway > gatewayNamespace`
+##### <a name="cronJobs_pattern1_gateway_gatewayNamespace"></a>2.1.16.7. Property `stack > cronJobs > ^.*$ > gateway > gatewayNamespace`
 
 |              |          |
 | ------------ | -------- |
@@ -745,7 +965,7 @@ Must be one of:
 
 **Description:** Namespace of the Gateway resource
 
-##### <a name="cronJobs_pattern1_gateway_host"></a>2.1.16.5. Property `stack > cronJobs > ^.*$ > gateway > host`
+##### <a name="cronJobs_pattern1_gateway_host"></a>2.1.16.8. Property `stack > cronJobs > ^.*$ > gateway > host`
 
 |              |          |
 | ------------ | -------- |
@@ -754,7 +974,33 @@ Must be one of:
 
 **Description:** Hostname for HTTPRoute
 
-##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>2.1.16.6. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
+##### <a name="cronJobs_pattern1_gateway_hostRewrite"></a>2.1.16.9. Property `stack > cronJobs > ^.*$ > gateway > hostRewrite`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it
+
+##### <a name="cronJobs_pattern1_gateway_ipAllowList"></a>2.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > ipAllowList`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>2.1.16.11. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -763,7 +1009,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)
 
-##### <a name="cronJobs_pattern1_gateway_paths"></a>2.1.16.7. Property `stack > cronJobs > ^.*$ > gateway > paths`
+##### <a name="cronJobs_pattern1_gateway_paths"></a>2.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -784,7 +1030,7 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [paths items](#cronJobs_pattern1_gateway_paths_items) | -           |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items"></a>2.1.16.7.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
+###### <a name="cronJobs_pattern1_gateway_paths_items"></a>2.1.16.12.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -797,7 +1043,7 @@ Must be one of:
 | - [path](#cronJobs_pattern1_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#cronJobs_pattern1_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>2.1.16.7.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
+###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>2.1.16.12.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -806,7 +1052,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>2.1.16.7.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
+###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>2.1.16.12.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -815,7 +1061,247 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-##### <a name="cronJobs_pattern1_gateway_rules"></a>2.1.16.8. Property `stack > cronJobs > ^.*$ > gateway > rules`
+##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>2.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)
+
+| Property                                                     | Pattern | Type    | Deprecated | Definition | Title/Description                           |
+| ------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_rateLimit_enabled )   | No      | boolean | No         | -          | Enable local rate limiting                  |
+| - [requests](#cronJobs_pattern1_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
+| - [unit](#cronJobs_pattern1_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>2.1.16.13.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable local rate limiting
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>2.1.16.13.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Allowed requests per unit
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>2.1.16.13.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rate limit unit (Second, Minute, Hour, Day)
+
+##### <a name="cronJobs_pattern1_gateway_redirect"></a>2.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > redirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host
+
+| Property                                                        | Pattern | Type    | Deprecated | Definition | Title/Description                                               |
+| --------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_redirect_enabled )       | No      | boolean | No         | -          | Enable a redirect-only route                                    |
+| - [hostname](#cronJobs_pattern1_gateway_redirect_hostname )     | No      | string  | No         | -          | Target hostname, empty keeps the request host                   |
+| - [path](#cronJobs_pattern1_gateway_redirect_path )             | No      | string  | No         | -          | Replacement full path via ReplaceFullPath, empty keeps the path |
+| - [scheme](#cronJobs_pattern1_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
+| - [statusCode](#cronJobs_pattern1_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
+
+###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>2.1.16.14.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable a redirect-only route
+
+###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>2.1.16.14.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target hostname, empty keeps the request host
+
+###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>2.1.16.14.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Replacement full path via ReplaceFullPath, empty keeps the path
+
+###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>2.1.16.14.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target scheme, e.g. https
+
+###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>2.1.16.14.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Redirect status code (301 or 302)
+
+##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>2.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Request header modifications (HTTPRoute RequestHeaderModifier filter)
+
+| Property                                                      | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| ------------------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#cronJobs_pattern1_gateway_requestHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#cronJobs_pattern1_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#cronJobs_pattern1_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>2.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>2.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>2.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>2.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Response header modifications (HTTPRoute ResponseHeaderModifier filter)
+
+| Property                                                       | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| -------------------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#cronJobs_pattern1_gateway_responseHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#cronJobs_pattern1_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#cronJobs_pattern1_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>2.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>2.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>2.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_rules"></a>2.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -832,7 +1318,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_sectionName"></a>2.1.16.9. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
+##### <a name="cronJobs_pattern1_gateway_sectionName"></a>2.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -841,7 +1327,93 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>2.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>2.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)
+
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                              |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------- |
+| - [cookieName](#cronJobs_pattern1_gateway_sessionAffinity_cookieName ) | No      | string  | No         | -          | Affinity cookie name                           |
+| - [enabled](#cronJobs_pattern1_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
+| - [ttl](#cronJobs_pattern1_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>2.1.16.19.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie name
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>2.1.16.19.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable consistent-hash cookie session affinity
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>2.1.16.19.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie TTL
+
+##### <a name="cronJobs_pattern1_gateway_timeouts"></a>2.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy
+
+| Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                             |
+| ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| - [backendRequest](#cronJobs_pattern1_gateway_timeouts_backendRequest ) | No      | string | No         | -          | Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request                               |
+| - [connect](#cronJobs_pattern1_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
+| - [request](#cronJobs_pattern1_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>2.1.16.20.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>2.1.16.20.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>2.1.16.20.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>2.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -857,7 +1429,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>2.1.16.10.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>2.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -866,7 +1438,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>2.1.16.10.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>2.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -875,7 +1447,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>2.1.16.10.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>2.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -4101,14 +4673,25 @@ Must be one of:
 | Property                                                | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                   |
 | ------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | - [annotations](#global_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                                                                                                                                           |
+| - [backendTLS](#global_gateway_backendTLS )             | No      | object          | No         | -          | TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)                                                                                                                                                                                   |
+| - [basicAuth](#global_gateway_basicAuth )               | No      | object          | No         | -          | HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected                                                                                                                                                                                 |
+| - [cors](#global_gateway_cors )                         | No      | object          | No         | -          | CORS via a SecurityPolicy                                                                                                                                                                                                                                           |
 | - [enabled](#global_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                                                                                                                                               |
 | - [gatewayName](#global_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                                                                                                                                           |
 | - [gatewayNamespace](#global_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                                                                                                                                                   |
 | - [host](#global_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                              |
+| - [hostRewrite](#global_gateway_hostRewrite )           | No      | string          | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                         |
+| - [ipAllowList](#global_gateway_ipAllowList )           | No      | array           | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                               |
 | - [oidcProtected](#global_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                                                                                                                                                   |
 | - [paths](#global_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                             |
+| - [rateLimit](#global_gateway_rateLimit )               | No      | object          | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                            |
+| - [redirect](#global_gateway_redirect )                 | No      | object          | No         | -          | Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host                                                                                                                                                                 |
+| - [requestHeaders](#global_gateway_requestHeaders )     | No      | object          | No         | -          | Request header modifications (HTTPRoute RequestHeaderModifier filter)                                                                                                                                                                                               |
+| - [responseHeaders](#global_gateway_responseHeaders )   | No      | object          | No         | -          | Response header modifications (HTTPRoute ResponseHeaderModifier filter)                                                                                                                                                                                             |
 | - [rules](#global_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts. Each entry takes host, optional paths, and an optional vanity block (enabled, hostname, clusterIssuer) that renders a per-host ListenerSet so the extra host can be a vanity domain, mirroring gateway.vanity |
 | - [sectionName](#global_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
+| - [sessionAffinity](#global_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
+| - [timeouts](#global_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
 | - [vanity](#global_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 #### <a name="global_gateway_annotations"></a>3.16.1. Property `stack > global > gateway > annotations`
@@ -4132,7 +4715,216 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="global_gateway_enabled"></a>3.16.2. Property `stack > global > gateway > enabled`
+#### <a name="global_gateway_backendTLS"></a>3.16.2. Property `stack > global > gateway > backendTLS`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)
+
+| Property                                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                |
+| -------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| - [caCertificateRefs](#global_gateway_backendTLS_caCertificateRefs )             | No      | array   | No         | -          | ConfigMap refs holding the CA bundle for self-signed/internal upstreams          |
+| - [enabled](#global_gateway_backendTLS_enabled )                                 | No      | boolean | No         | -          | Enable upstream TLS                                                              |
+| - [hostname](#global_gateway_backendTLS_hostname )                               | No      | string  | No         | -          | SNI/validation hostname presented by the upstream (required when enabled)        |
+| - [wellKnownCACertificates](#global_gateway_backendTLS_wellKnownCACertificates ) | No      | string  | No         | -          | Use the System trust store, or set "" and use caCertificateRefs for a private CA |
+
+##### <a name="global_gateway_backendTLS_caCertificateRefs"></a>3.16.2.1. Property `stack > global > gateway > backendTLS > caCertificateRefs`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** ConfigMap refs holding the CA bundle for self-signed/internal upstreams
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_backendTLS_enabled"></a>3.16.2.2. Property `stack > global > gateway > backendTLS > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable upstream TLS
+
+##### <a name="global_gateway_backendTLS_hostname"></a>3.16.2.3. Property `stack > global > gateway > backendTLS > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** SNI/validation hostname presented by the upstream (required when enabled)
+
+##### <a name="global_gateway_backendTLS_wellKnownCACertificates"></a>3.16.2.4. Property `stack > global > gateway > backendTLS > wellKnownCACertificates`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Use the System trust store, or set "" and use caCertificateRefs for a private CA
+
+#### <a name="global_gateway_basicAuth"></a>3.16.3. Property `stack > global > gateway > basicAuth`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected
+
+| Property                                              | Pattern | Type    | Deprecated | Definition | Title/Description                             |
+| ----------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------- |
+| - [enabled](#global_gateway_basicAuth_enabled )       | No      | boolean | No         | -          | Enable basic auth                             |
+| - [secretName](#global_gateway_basicAuth_secretName ) | No      | string  | No         | -          | Name of an Opaque Secret with a .htpasswd key |
+
+##### <a name="global_gateway_basicAuth_enabled"></a>3.16.3.1. Property `stack > global > gateway > basicAuth > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable basic auth
+
+##### <a name="global_gateway_basicAuth_secretName"></a>3.16.3.2. Property `stack > global > gateway > basicAuth > secretName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of an Opaque Secret with a .htpasswd key
+
+#### <a name="global_gateway_cors"></a>3.16.4. Property `stack > global > gateway > cors`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** CORS via a SecurityPolicy
+
+| Property                                                     | Pattern | Type    | Deprecated | Definition | Title/Description                                    |
+| ------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ---------------------------------------------------- |
+| - [allowCredentials](#global_gateway_cors_allowCredentials ) | No      | boolean | No         | -          | Allow credentials                                    |
+| - [allowHeaders](#global_gateway_cors_allowHeaders )         | No      | array   | No         | -          | Allowed request headers                              |
+| - [allowMethods](#global_gateway_cors_allowMethods )         | No      | array   | No         | -          | Allowed methods                                      |
+| - [allowOrigins](#global_gateway_cors_allowOrigins )         | No      | array   | No         | -          | Allowed origins (string patterns)                    |
+| - [enabled](#global_gateway_cors_enabled )                   | No      | boolean | No         | -          | Enable CORS                                          |
+| - [exposeHeaders](#global_gateway_cors_exposeHeaders )       | No      | array   | No         | -          | Response headers exposed to the browser              |
+| - [maxAge](#global_gateway_cors_maxAge )                     | No      | string  | No         | -          | Preflight cache duration (e.g. "1h"), empty omits it |
+
+##### <a name="global_gateway_cors_allowCredentials"></a>3.16.4.1. Property `stack > global > gateway > cors > allowCredentials`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Allow credentials
+
+##### <a name="global_gateway_cors_allowHeaders"></a>3.16.4.2. Property `stack > global > gateway > cors > allowHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed request headers
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_cors_allowMethods"></a>3.16.4.3. Property `stack > global > gateway > cors > allowMethods`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed methods
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_cors_allowOrigins"></a>3.16.4.4. Property `stack > global > gateway > cors > allowOrigins`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed origins (string patterns)
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_cors_enabled"></a>3.16.4.5. Property `stack > global > gateway > cors > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable CORS
+
+##### <a name="global_gateway_cors_exposeHeaders"></a>3.16.4.6. Property `stack > global > gateway > cors > exposeHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Response headers exposed to the browser
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_cors_maxAge"></a>3.16.4.7. Property `stack > global > gateway > cors > maxAge`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Preflight cache duration (e.g. "1h"), empty omits it
+
+#### <a name="global_gateway_enabled"></a>3.16.5. Property `stack > global > gateway > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -4141,7 +4933,7 @@ Must be one of:
 
 **Description:** Enable Gateway API HTTPRoute (alternative to Ingress)
 
-#### <a name="global_gateway_gatewayName"></a>3.16.3. Property `stack > global > gateway > gatewayName`
+#### <a name="global_gateway_gatewayName"></a>3.16.6. Property `stack > global > gateway > gatewayName`
 
 |              |          |
 | ------------ | -------- |
@@ -4150,7 +4942,7 @@ Must be one of:
 
 **Description:** Name of the Gateway resource to attach to
 
-#### <a name="global_gateway_gatewayNamespace"></a>3.16.4. Property `stack > global > gateway > gatewayNamespace`
+#### <a name="global_gateway_gatewayNamespace"></a>3.16.7. Property `stack > global > gateway > gatewayNamespace`
 
 |              |          |
 | ------------ | -------- |
@@ -4159,7 +4951,7 @@ Must be one of:
 
 **Description:** Namespace of the Gateway resource
 
-#### <a name="global_gateway_host"></a>3.16.5. Property `stack > global > gateway > host`
+#### <a name="global_gateway_host"></a>3.16.8. Property `stack > global > gateway > host`
 
 |              |          |
 | ------------ | -------- |
@@ -4168,7 +4960,33 @@ Must be one of:
 
 **Description:** Hostname for HTTPRoute
 
-#### <a name="global_gateway_oidcProtected"></a>3.16.6. Property `stack > global > gateway > oidcProtected`
+#### <a name="global_gateway_hostRewrite"></a>3.16.9. Property `stack > global > gateway > hostRewrite`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it
+
+#### <a name="global_gateway_ipAllowList"></a>3.16.10. Property `stack > global > gateway > ipAllowList`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+#### <a name="global_gateway_oidcProtected"></a>3.16.11. Property `stack > global > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -4177,7 +4995,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)
 
-#### <a name="global_gateway_paths"></a>3.16.7. Property `stack > global > gateway > paths`
+#### <a name="global_gateway_paths"></a>3.16.12. Property `stack > global > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -4198,7 +5016,7 @@ Must be one of:
 | ------------------------------------------ | ----------- |
 | [paths items](#global_gateway_paths_items) | -           |
 
-##### <a name="global_gateway_paths_items"></a>3.16.7.1. stack > global > gateway > paths > paths items
+##### <a name="global_gateway_paths_items"></a>3.16.12.1. stack > global > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -4211,7 +5029,7 @@ Must be one of:
 | - [path](#global_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#global_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="global_gateway_paths_items_path"></a>3.16.7.1.1. Property `stack > global > gateway > paths > paths items > path`
+###### <a name="global_gateway_paths_items_path"></a>3.16.12.1.1. Property `stack > global > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -4220,7 +5038,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="global_gateway_paths_items_pathType"></a>3.16.7.1.2. Property `stack > global > gateway > paths > paths items > pathType`
+###### <a name="global_gateway_paths_items_pathType"></a>3.16.12.1.2. Property `stack > global > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -4229,7 +5047,247 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-#### <a name="global_gateway_rules"></a>3.16.8. Property `stack > global > gateway > rules`
+#### <a name="global_gateway_rateLimit"></a>3.16.13. Property `stack > global > gateway > rateLimit`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)
+
+| Property                                          | Pattern | Type    | Deprecated | Definition | Title/Description                           |
+| ------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------- |
+| - [enabled](#global_gateway_rateLimit_enabled )   | No      | boolean | No         | -          | Enable local rate limiting                  |
+| - [requests](#global_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
+| - [unit](#global_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
+
+##### <a name="global_gateway_rateLimit_enabled"></a>3.16.13.1. Property `stack > global > gateway > rateLimit > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable local rate limiting
+
+##### <a name="global_gateway_rateLimit_requests"></a>3.16.13.2. Property `stack > global > gateway > rateLimit > requests`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Allowed requests per unit
+
+##### <a name="global_gateway_rateLimit_unit"></a>3.16.13.3. Property `stack > global > gateway > rateLimit > unit`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rate limit unit (Second, Minute, Hour, Day)
+
+#### <a name="global_gateway_redirect"></a>3.16.14. Property `stack > global > gateway > redirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host
+
+| Property                                             | Pattern | Type    | Deprecated | Definition | Title/Description                                               |
+| ---------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------- |
+| - [enabled](#global_gateway_redirect_enabled )       | No      | boolean | No         | -          | Enable a redirect-only route                                    |
+| - [hostname](#global_gateway_redirect_hostname )     | No      | string  | No         | -          | Target hostname, empty keeps the request host                   |
+| - [path](#global_gateway_redirect_path )             | No      | string  | No         | -          | Replacement full path via ReplaceFullPath, empty keeps the path |
+| - [scheme](#global_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
+| - [statusCode](#global_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
+
+##### <a name="global_gateway_redirect_enabled"></a>3.16.14.1. Property `stack > global > gateway > redirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable a redirect-only route
+
+##### <a name="global_gateway_redirect_hostname"></a>3.16.14.2. Property `stack > global > gateway > redirect > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target hostname, empty keeps the request host
+
+##### <a name="global_gateway_redirect_path"></a>3.16.14.3. Property `stack > global > gateway > redirect > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Replacement full path via ReplaceFullPath, empty keeps the path
+
+##### <a name="global_gateway_redirect_scheme"></a>3.16.14.4. Property `stack > global > gateway > redirect > scheme`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target scheme, e.g. https
+
+##### <a name="global_gateway_redirect_statusCode"></a>3.16.14.5. Property `stack > global > gateway > redirect > statusCode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Redirect status code (301 or 302)
+
+#### <a name="global_gateway_requestHeaders"></a>3.16.15. Property `stack > global > gateway > requestHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Request header modifications (HTTPRoute RequestHeaderModifier filter)
+
+| Property                                           | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| -------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#global_gateway_requestHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#global_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#global_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+##### <a name="global_gateway_requestHeaders_add"></a>3.16.15.1. Property `stack > global > gateway > requestHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_requestHeaders_remove"></a>3.16.15.2. Property `stack > global > gateway > requestHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_requestHeaders_set"></a>3.16.15.3. Property `stack > global > gateway > requestHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+#### <a name="global_gateway_responseHeaders"></a>3.16.16. Property `stack > global > gateway > responseHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Response header modifications (HTTPRoute ResponseHeaderModifier filter)
+
+| Property                                            | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| --------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#global_gateway_responseHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#global_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#global_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+##### <a name="global_gateway_responseHeaders_add"></a>3.16.16.1. Property `stack > global > gateway > responseHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_responseHeaders_remove"></a>3.16.16.2. Property `stack > global > gateway > responseHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_responseHeaders_set"></a>3.16.16.3. Property `stack > global > gateway > responseHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+#### <a name="global_gateway_rules"></a>3.16.17. Property `stack > global > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -4246,7 +5304,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="global_gateway_sectionName"></a>3.16.9. Property `stack > global > gateway > sectionName`
+#### <a name="global_gateway_sectionName"></a>3.16.18. Property `stack > global > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -4255,7 +5313,93 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-#### <a name="global_gateway_vanity"></a>3.16.10. Property `stack > global > gateway > vanity`
+#### <a name="global_gateway_sessionAffinity"></a>3.16.19. Property `stack > global > gateway > sessionAffinity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)
+
+| Property                                                    | Pattern | Type    | Deprecated | Definition | Title/Description                              |
+| ----------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------- |
+| - [cookieName](#global_gateway_sessionAffinity_cookieName ) | No      | string  | No         | -          | Affinity cookie name                           |
+| - [enabled](#global_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
+| - [ttl](#global_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
+
+##### <a name="global_gateway_sessionAffinity_cookieName"></a>3.16.19.1. Property `stack > global > gateway > sessionAffinity > cookieName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie name
+
+##### <a name="global_gateway_sessionAffinity_enabled"></a>3.16.19.2. Property `stack > global > gateway > sessionAffinity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable consistent-hash cookie session affinity
+
+##### <a name="global_gateway_sessionAffinity_ttl"></a>3.16.19.3. Property `stack > global > gateway > sessionAffinity > ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie TTL
+
+#### <a name="global_gateway_timeouts"></a>3.16.20. Property `stack > global > gateway > timeouts`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy
+
+| Property                                                     | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                             |
+| ------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| - [backendRequest](#global_gateway_timeouts_backendRequest ) | No      | string | No         | -          | Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request                               |
+| - [connect](#global_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
+| - [request](#global_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
+
+##### <a name="global_gateway_timeouts_backendRequest"></a>3.16.20.1. Property `stack > global > gateway > timeouts > backendRequest`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
+
+##### <a name="global_gateway_timeouts_connect"></a>3.16.20.2. Property `stack > global > gateway > timeouts > connect`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
+
+##### <a name="global_gateway_timeouts_request"></a>3.16.20.3. Property `stack > global > gateway > timeouts > request`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
+
+#### <a name="global_gateway_vanity"></a>3.16.21. Property `stack > global > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -4271,7 +5415,7 @@ Must be one of:
 | - [enabled](#global_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#global_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-##### <a name="global_gateway_vanity_clusterIssuer"></a>3.16.10.1. Property `stack > global > gateway > vanity > clusterIssuer`
+##### <a name="global_gateway_vanity_clusterIssuer"></a>3.16.21.1. Property `stack > global > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -4280,7 +5424,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-##### <a name="global_gateway_vanity_enabled"></a>3.16.10.2. Property `stack > global > gateway > vanity > enabled`
+##### <a name="global_gateway_vanity_enabled"></a>3.16.21.2. Property `stack > global > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -4289,7 +5433,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-##### <a name="global_gateway_vanity_hostname"></a>3.16.10.3. Property `stack > global > gateway > vanity > hostname`
+##### <a name="global_gateway_vanity_hostname"></a>3.16.21.3. Property `stack > global > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -7533,14 +8677,25 @@ Must be one of:
 | Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                   |
 | ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                                                                                                                                           |
+| - [backendTLS](#cronJobs_pattern1_gateway_backendTLS )             | No      | object          | No         | -          | TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)                                                                                                                                                                                   |
+| - [basicAuth](#cronJobs_pattern1_gateway_basicAuth )               | No      | object          | No         | -          | HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected                                                                                                                                                                                 |
+| - [cors](#cronJobs_pattern1_gateway_cors )                         | No      | object          | No         | -          | CORS via a SecurityPolicy                                                                                                                                                                                                                                           |
 | - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                                                                                                                                               |
 | - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                                                                                                                                           |
 | - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                                                                                                                                                   |
 | - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                              |
+| - [hostRewrite](#cronJobs_pattern1_gateway_hostRewrite )           | No      | string          | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                         |
+| - [ipAllowList](#cronJobs_pattern1_gateway_ipAllowList )           | No      | array           | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                               |
 | - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                                                                                                                                                   |
 | - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                             |
+| - [rateLimit](#cronJobs_pattern1_gateway_rateLimit )               | No      | object          | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                            |
+| - [redirect](#cronJobs_pattern1_gateway_redirect )                 | No      | object          | No         | -          | Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host                                                                                                                                                                 |
+| - [requestHeaders](#cronJobs_pattern1_gateway_requestHeaders )     | No      | object          | No         | -          | Request header modifications (HTTPRoute RequestHeaderModifier filter)                                                                                                                                                                                               |
+| - [responseHeaders](#cronJobs_pattern1_gateway_responseHeaders )   | No      | object          | No         | -          | Response header modifications (HTTPRoute ResponseHeaderModifier filter)                                                                                                                                                                                             |
 | - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts. Each entry takes host, optional paths, and an optional vanity block (enabled, hostname, clusterIssuer) that renders a per-host ListenerSet so the extra host can be a vanity domain, mirroring gateway.vanity |
 | - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
+| - [sessionAffinity](#cronJobs_pattern1_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
+| - [timeouts](#cronJobs_pattern1_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
 | - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>4.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
@@ -7564,7 +8719,216 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_gateway_enabled"></a>4.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > enabled`
+##### <a name="cronJobs_pattern1_gateway_backendTLS"></a>4.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > backendTLS`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)
+
+| Property                                                                                    | Pattern | Type    | Deprecated | Definition | Title/Description                                                                |
+| ------------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| - [caCertificateRefs](#cronJobs_pattern1_gateway_backendTLS_caCertificateRefs )             | No      | array   | No         | -          | ConfigMap refs holding the CA bundle for self-signed/internal upstreams          |
+| - [enabled](#cronJobs_pattern1_gateway_backendTLS_enabled )                                 | No      | boolean | No         | -          | Enable upstream TLS                                                              |
+| - [hostname](#cronJobs_pattern1_gateway_backendTLS_hostname )                               | No      | string  | No         | -          | SNI/validation hostname presented by the upstream (required when enabled)        |
+| - [wellKnownCACertificates](#cronJobs_pattern1_gateway_backendTLS_wellKnownCACertificates ) | No      | string  | No         | -          | Use the System trust store, or set "" and use caCertificateRefs for a private CA |
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_caCertificateRefs"></a>4.1.16.2.1. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > caCertificateRefs`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** ConfigMap refs holding the CA bundle for self-signed/internal upstreams
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_enabled"></a>4.1.16.2.2. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable upstream TLS
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_hostname"></a>4.1.16.2.3. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** SNI/validation hostname presented by the upstream (required when enabled)
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_wellKnownCACertificates"></a>4.1.16.2.4. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > wellKnownCACertificates`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Use the System trust store, or set "" and use caCertificateRefs for a private CA
+
+##### <a name="cronJobs_pattern1_gateway_basicAuth"></a>4.1.16.3. Property `stack > cronJobs > ^.*$ > gateway > basicAuth`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected
+
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                             |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_basicAuth_enabled )       | No      | boolean | No         | -          | Enable basic auth                             |
+| - [secretName](#cronJobs_pattern1_gateway_basicAuth_secretName ) | No      | string  | No         | -          | Name of an Opaque Secret with a .htpasswd key |
+
+###### <a name="cronJobs_pattern1_gateway_basicAuth_enabled"></a>4.1.16.3.1. Property `stack > cronJobs > ^.*$ > gateway > basicAuth > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable basic auth
+
+###### <a name="cronJobs_pattern1_gateway_basicAuth_secretName"></a>4.1.16.3.2. Property `stack > cronJobs > ^.*$ > gateway > basicAuth > secretName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of an Opaque Secret with a .htpasswd key
+
+##### <a name="cronJobs_pattern1_gateway_cors"></a>4.1.16.4. Property `stack > cronJobs > ^.*$ > gateway > cors`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** CORS via a SecurityPolicy
+
+| Property                                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                    |
+| ----------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------- |
+| - [allowCredentials](#cronJobs_pattern1_gateway_cors_allowCredentials ) | No      | boolean | No         | -          | Allow credentials                                    |
+| - [allowHeaders](#cronJobs_pattern1_gateway_cors_allowHeaders )         | No      | array   | No         | -          | Allowed request headers                              |
+| - [allowMethods](#cronJobs_pattern1_gateway_cors_allowMethods )         | No      | array   | No         | -          | Allowed methods                                      |
+| - [allowOrigins](#cronJobs_pattern1_gateway_cors_allowOrigins )         | No      | array   | No         | -          | Allowed origins (string patterns)                    |
+| - [enabled](#cronJobs_pattern1_gateway_cors_enabled )                   | No      | boolean | No         | -          | Enable CORS                                          |
+| - [exposeHeaders](#cronJobs_pattern1_gateway_cors_exposeHeaders )       | No      | array   | No         | -          | Response headers exposed to the browser              |
+| - [maxAge](#cronJobs_pattern1_gateway_cors_maxAge )                     | No      | string  | No         | -          | Preflight cache duration (e.g. "1h"), empty omits it |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowCredentials"></a>4.1.16.4.1. Property `stack > cronJobs > ^.*$ > gateway > cors > allowCredentials`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Allow credentials
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowHeaders"></a>4.1.16.4.2. Property `stack > cronJobs > ^.*$ > gateway > cors > allowHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed request headers
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowMethods"></a>4.1.16.4.3. Property `stack > cronJobs > ^.*$ > gateway > cors > allowMethods`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed methods
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowOrigins"></a>4.1.16.4.4. Property `stack > cronJobs > ^.*$ > gateway > cors > allowOrigins`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed origins (string patterns)
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_enabled"></a>4.1.16.4.5. Property `stack > cronJobs > ^.*$ > gateway > cors > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable CORS
+
+###### <a name="cronJobs_pattern1_gateway_cors_exposeHeaders"></a>4.1.16.4.6. Property `stack > cronJobs > ^.*$ > gateway > cors > exposeHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Response headers exposed to the browser
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_maxAge"></a>4.1.16.4.7. Property `stack > cronJobs > ^.*$ > gateway > cors > maxAge`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Preflight cache duration (e.g. "1h"), empty omits it
+
+##### <a name="cronJobs_pattern1_gateway_enabled"></a>4.1.16.5. Property `stack > cronJobs > ^.*$ > gateway > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -7573,7 +8937,7 @@ Must be one of:
 
 **Description:** Enable Gateway API HTTPRoute (alternative to Ingress)
 
-##### <a name="cronJobs_pattern1_gateway_gatewayName"></a>4.1.16.3. Property `stack > cronJobs > ^.*$ > gateway > gatewayName`
+##### <a name="cronJobs_pattern1_gateway_gatewayName"></a>4.1.16.6. Property `stack > cronJobs > ^.*$ > gateway > gatewayName`
 
 |              |          |
 | ------------ | -------- |
@@ -7582,7 +8946,7 @@ Must be one of:
 
 **Description:** Name of the Gateway resource to attach to
 
-##### <a name="cronJobs_pattern1_gateway_gatewayNamespace"></a>4.1.16.4. Property `stack > cronJobs > ^.*$ > gateway > gatewayNamespace`
+##### <a name="cronJobs_pattern1_gateway_gatewayNamespace"></a>4.1.16.7. Property `stack > cronJobs > ^.*$ > gateway > gatewayNamespace`
 
 |              |          |
 | ------------ | -------- |
@@ -7591,7 +8955,7 @@ Must be one of:
 
 **Description:** Namespace of the Gateway resource
 
-##### <a name="cronJobs_pattern1_gateway_host"></a>4.1.16.5. Property `stack > cronJobs > ^.*$ > gateway > host`
+##### <a name="cronJobs_pattern1_gateway_host"></a>4.1.16.8. Property `stack > cronJobs > ^.*$ > gateway > host`
 
 |              |          |
 | ------------ | -------- |
@@ -7600,7 +8964,33 @@ Must be one of:
 
 **Description:** Hostname for HTTPRoute
 
-##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>4.1.16.6. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
+##### <a name="cronJobs_pattern1_gateway_hostRewrite"></a>4.1.16.9. Property `stack > cronJobs > ^.*$ > gateway > hostRewrite`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it
+
+##### <a name="cronJobs_pattern1_gateway_ipAllowList"></a>4.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > ipAllowList`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>4.1.16.11. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -7609,7 +8999,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)
 
-##### <a name="cronJobs_pattern1_gateway_paths"></a>4.1.16.7. Property `stack > cronJobs > ^.*$ > gateway > paths`
+##### <a name="cronJobs_pattern1_gateway_paths"></a>4.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -7630,7 +9020,7 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [paths items](#cronJobs_pattern1_gateway_paths_items) | -           |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items"></a>4.1.16.7.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
+###### <a name="cronJobs_pattern1_gateway_paths_items"></a>4.1.16.12.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -7643,7 +9033,7 @@ Must be one of:
 | - [path](#cronJobs_pattern1_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#cronJobs_pattern1_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>4.1.16.7.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
+###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>4.1.16.12.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -7652,7 +9042,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>4.1.16.7.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
+###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>4.1.16.12.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -7661,7 +9051,247 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-##### <a name="cronJobs_pattern1_gateway_rules"></a>4.1.16.8. Property `stack > cronJobs > ^.*$ > gateway > rules`
+##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>4.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)
+
+| Property                                                     | Pattern | Type    | Deprecated | Definition | Title/Description                           |
+| ------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_rateLimit_enabled )   | No      | boolean | No         | -          | Enable local rate limiting                  |
+| - [requests](#cronJobs_pattern1_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
+| - [unit](#cronJobs_pattern1_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>4.1.16.13.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable local rate limiting
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>4.1.16.13.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Allowed requests per unit
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>4.1.16.13.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rate limit unit (Second, Minute, Hour, Day)
+
+##### <a name="cronJobs_pattern1_gateway_redirect"></a>4.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > redirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host
+
+| Property                                                        | Pattern | Type    | Deprecated | Definition | Title/Description                                               |
+| --------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_redirect_enabled )       | No      | boolean | No         | -          | Enable a redirect-only route                                    |
+| - [hostname](#cronJobs_pattern1_gateway_redirect_hostname )     | No      | string  | No         | -          | Target hostname, empty keeps the request host                   |
+| - [path](#cronJobs_pattern1_gateway_redirect_path )             | No      | string  | No         | -          | Replacement full path via ReplaceFullPath, empty keeps the path |
+| - [scheme](#cronJobs_pattern1_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
+| - [statusCode](#cronJobs_pattern1_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
+
+###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>4.1.16.14.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable a redirect-only route
+
+###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>4.1.16.14.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target hostname, empty keeps the request host
+
+###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>4.1.16.14.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Replacement full path via ReplaceFullPath, empty keeps the path
+
+###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>4.1.16.14.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target scheme, e.g. https
+
+###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>4.1.16.14.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Redirect status code (301 or 302)
+
+##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>4.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Request header modifications (HTTPRoute RequestHeaderModifier filter)
+
+| Property                                                      | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| ------------------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#cronJobs_pattern1_gateway_requestHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#cronJobs_pattern1_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#cronJobs_pattern1_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>4.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>4.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>4.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>4.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Response header modifications (HTTPRoute ResponseHeaderModifier filter)
+
+| Property                                                       | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| -------------------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#cronJobs_pattern1_gateway_responseHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#cronJobs_pattern1_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#cronJobs_pattern1_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>4.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>4.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>4.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_rules"></a>4.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -7678,7 +9308,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_sectionName"></a>4.1.16.9. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
+##### <a name="cronJobs_pattern1_gateway_sectionName"></a>4.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -7687,7 +9317,93 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>4.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>4.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)
+
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                              |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------- |
+| - [cookieName](#cronJobs_pattern1_gateway_sessionAffinity_cookieName ) | No      | string  | No         | -          | Affinity cookie name                           |
+| - [enabled](#cronJobs_pattern1_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
+| - [ttl](#cronJobs_pattern1_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>4.1.16.19.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie name
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>4.1.16.19.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable consistent-hash cookie session affinity
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>4.1.16.19.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie TTL
+
+##### <a name="cronJobs_pattern1_gateway_timeouts"></a>4.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy
+
+| Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                             |
+| ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| - [backendRequest](#cronJobs_pattern1_gateway_timeouts_backendRequest ) | No      | string | No         | -          | Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request                               |
+| - [connect](#cronJobs_pattern1_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
+| - [request](#cronJobs_pattern1_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>4.1.16.20.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>4.1.16.20.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>4.1.16.20.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>4.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -7703,7 +9419,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>4.1.16.10.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>4.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -7712,7 +9428,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>4.1.16.10.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>4.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -7721,7 +9437,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>4.1.16.10.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>4.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -11429,14 +13145,25 @@ Must be one of:
 | Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                   |
 | ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | - [annotations](#cronJobs_pattern1_gateway_annotations )           | No      | object          | No         | -          | Annotations to add to HTTPRoute resources                                                                                                                                                                                                                           |
+| - [backendTLS](#cronJobs_pattern1_gateway_backendTLS )             | No      | object          | No         | -          | TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)                                                                                                                                                                                   |
+| - [basicAuth](#cronJobs_pattern1_gateway_basicAuth )               | No      | object          | No         | -          | HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected                                                                                                                                                                                 |
+| - [cors](#cronJobs_pattern1_gateway_cors )                         | No      | object          | No         | -          | CORS via a SecurityPolicy                                                                                                                                                                                                                                           |
 | - [enabled](#cronJobs_pattern1_gateway_enabled )                   | No      | boolean         | No         | -          | Enable Gateway API HTTPRoute (alternative to Ingress)                                                                                                                                                                                                               |
 | - [gatewayName](#cronJobs_pattern1_gateway_gatewayName )           | No      | string          | No         | -          | Name of the Gateway resource to attach to                                                                                                                                                                                                                           |
 | - [gatewayNamespace](#cronJobs_pattern1_gateway_gatewayNamespace ) | No      | string          | No         | -          | Namespace of the Gateway resource                                                                                                                                                                                                                                   |
 | - [host](#cronJobs_pattern1_gateway_host )                         | No      | string          | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                              |
+| - [hostRewrite](#cronJobs_pattern1_gateway_hostRewrite )           | No      | string          | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                         |
+| - [ipAllowList](#cronJobs_pattern1_gateway_ipAllowList )           | No      | array           | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                               |
 | - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean         | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)                                                                                                                                                                   |
 | - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                             |
+| - [rateLimit](#cronJobs_pattern1_gateway_rateLimit )               | No      | object          | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                            |
+| - [redirect](#cronJobs_pattern1_gateway_redirect )                 | No      | object          | No         | -          | Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host                                                                                                                                                                 |
+| - [requestHeaders](#cronJobs_pattern1_gateway_requestHeaders )     | No      | object          | No         | -          | Request header modifications (HTTPRoute RequestHeaderModifier filter)                                                                                                                                                                                               |
+| - [responseHeaders](#cronJobs_pattern1_gateway_responseHeaders )   | No      | object          | No         | -          | Response header modifications (HTTPRoute ResponseHeaderModifier filter)                                                                                                                                                                                             |
 | - [rules](#cronJobs_pattern1_gateway_rules )                       | No      | array           | No         | -          | List of additional HTTPRoute rules with custom hosts. Each entry takes host, optional paths, and an optional vanity block (enabled, hostname, clusterIssuer) that renders a per-host ListenerSet so the extra host can be a vanity domain, mirroring gateway.vanity |
 | - [sectionName](#cronJobs_pattern1_gateway_sectionName )           | No      | string          | No         | -          | Optional section name (listener name) on the Gateway                                                                                                                                                                                                                |
+| - [sessionAffinity](#cronJobs_pattern1_gateway_sessionAffinity )   | No      | object          | No         | -          | Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)                                                                                                                         |
+| - [timeouts](#cronJobs_pattern1_gateway_timeouts )                 | No      | object          | No         | -          | HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy                                                                                                                                            |
 | - [vanity](#cronJobs_pattern1_gateway_vanity )                     | No      | object          | No         | -          | Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway >= v1.8 and cert-manager >= v1.20)                                                                                                                           |
 
 ##### <a name="cronJobs_pattern1_gateway_annotations"></a>7.1.16.1. Property `stack > cronJobs > ^.*$ > gateway > annotations`
@@ -11460,7 +13187,216 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_gateway_enabled"></a>7.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > enabled`
+##### <a name="cronJobs_pattern1_gateway_backendTLS"></a>7.1.16.2. Property `stack > cronJobs > ^.*$ > gateway > backendTLS`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)
+
+| Property                                                                                    | Pattern | Type    | Deprecated | Definition | Title/Description                                                                |
+| ------------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| - [caCertificateRefs](#cronJobs_pattern1_gateway_backendTLS_caCertificateRefs )             | No      | array   | No         | -          | ConfigMap refs holding the CA bundle for self-signed/internal upstreams          |
+| - [enabled](#cronJobs_pattern1_gateway_backendTLS_enabled )                                 | No      | boolean | No         | -          | Enable upstream TLS                                                              |
+| - [hostname](#cronJobs_pattern1_gateway_backendTLS_hostname )                               | No      | string  | No         | -          | SNI/validation hostname presented by the upstream (required when enabled)        |
+| - [wellKnownCACertificates](#cronJobs_pattern1_gateway_backendTLS_wellKnownCACertificates ) | No      | string  | No         | -          | Use the System trust store, or set "" and use caCertificateRefs for a private CA |
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_caCertificateRefs"></a>7.1.16.2.1. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > caCertificateRefs`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** ConfigMap refs holding the CA bundle for self-signed/internal upstreams
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_enabled"></a>7.1.16.2.2. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable upstream TLS
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_hostname"></a>7.1.16.2.3. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** SNI/validation hostname presented by the upstream (required when enabled)
+
+###### <a name="cronJobs_pattern1_gateway_backendTLS_wellKnownCACertificates"></a>7.1.16.2.4. Property `stack > cronJobs > ^.*$ > gateway > backendTLS > wellKnownCACertificates`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Use the System trust store, or set "" and use caCertificateRefs for a private CA
+
+##### <a name="cronJobs_pattern1_gateway_basicAuth"></a>7.1.16.3. Property `stack > cronJobs > ^.*$ > gateway > basicAuth`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected
+
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                             |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_basicAuth_enabled )       | No      | boolean | No         | -          | Enable basic auth                             |
+| - [secretName](#cronJobs_pattern1_gateway_basicAuth_secretName ) | No      | string  | No         | -          | Name of an Opaque Secret with a .htpasswd key |
+
+###### <a name="cronJobs_pattern1_gateway_basicAuth_enabled"></a>7.1.16.3.1. Property `stack > cronJobs > ^.*$ > gateway > basicAuth > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable basic auth
+
+###### <a name="cronJobs_pattern1_gateway_basicAuth_secretName"></a>7.1.16.3.2. Property `stack > cronJobs > ^.*$ > gateway > basicAuth > secretName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Name of an Opaque Secret with a .htpasswd key
+
+##### <a name="cronJobs_pattern1_gateway_cors"></a>7.1.16.4. Property `stack > cronJobs > ^.*$ > gateway > cors`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** CORS via a SecurityPolicy
+
+| Property                                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                    |
+| ----------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------- |
+| - [allowCredentials](#cronJobs_pattern1_gateway_cors_allowCredentials ) | No      | boolean | No         | -          | Allow credentials                                    |
+| - [allowHeaders](#cronJobs_pattern1_gateway_cors_allowHeaders )         | No      | array   | No         | -          | Allowed request headers                              |
+| - [allowMethods](#cronJobs_pattern1_gateway_cors_allowMethods )         | No      | array   | No         | -          | Allowed methods                                      |
+| - [allowOrigins](#cronJobs_pattern1_gateway_cors_allowOrigins )         | No      | array   | No         | -          | Allowed origins (string patterns)                    |
+| - [enabled](#cronJobs_pattern1_gateway_cors_enabled )                   | No      | boolean | No         | -          | Enable CORS                                          |
+| - [exposeHeaders](#cronJobs_pattern1_gateway_cors_exposeHeaders )       | No      | array   | No         | -          | Response headers exposed to the browser              |
+| - [maxAge](#cronJobs_pattern1_gateway_cors_maxAge )                     | No      | string  | No         | -          | Preflight cache duration (e.g. "1h"), empty omits it |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowCredentials"></a>7.1.16.4.1. Property `stack > cronJobs > ^.*$ > gateway > cors > allowCredentials`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Allow credentials
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowHeaders"></a>7.1.16.4.2. Property `stack > cronJobs > ^.*$ > gateway > cors > allowHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed request headers
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowMethods"></a>7.1.16.4.3. Property `stack > cronJobs > ^.*$ > gateway > cors > allowMethods`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed methods
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_allowOrigins"></a>7.1.16.4.4. Property `stack > cronJobs > ^.*$ > gateway > cors > allowOrigins`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Allowed origins (string patterns)
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_enabled"></a>7.1.16.4.5. Property `stack > cronJobs > ^.*$ > gateway > cors > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable CORS
+
+###### <a name="cronJobs_pattern1_gateway_cors_exposeHeaders"></a>7.1.16.4.6. Property `stack > cronJobs > ^.*$ > gateway > cors > exposeHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Response headers exposed to the browser
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_cors_maxAge"></a>7.1.16.4.7. Property `stack > cronJobs > ^.*$ > gateway > cors > maxAge`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Preflight cache duration (e.g. "1h"), empty omits it
+
+##### <a name="cronJobs_pattern1_gateway_enabled"></a>7.1.16.5. Property `stack > cronJobs > ^.*$ > gateway > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -11469,7 +13405,7 @@ Must be one of:
 
 **Description:** Enable Gateway API HTTPRoute (alternative to Ingress)
 
-##### <a name="cronJobs_pattern1_gateway_gatewayName"></a>7.1.16.3. Property `stack > cronJobs > ^.*$ > gateway > gatewayName`
+##### <a name="cronJobs_pattern1_gateway_gatewayName"></a>7.1.16.6. Property `stack > cronJobs > ^.*$ > gateway > gatewayName`
 
 |              |          |
 | ------------ | -------- |
@@ -11478,7 +13414,7 @@ Must be one of:
 
 **Description:** Name of the Gateway resource to attach to
 
-##### <a name="cronJobs_pattern1_gateway_gatewayNamespace"></a>7.1.16.4. Property `stack > cronJobs > ^.*$ > gateway > gatewayNamespace`
+##### <a name="cronJobs_pattern1_gateway_gatewayNamespace"></a>7.1.16.7. Property `stack > cronJobs > ^.*$ > gateway > gatewayNamespace`
 
 |              |          |
 | ------------ | -------- |
@@ -11487,7 +13423,7 @@ Must be one of:
 
 **Description:** Namespace of the Gateway resource
 
-##### <a name="cronJobs_pattern1_gateway_host"></a>7.1.16.5. Property `stack > cronJobs > ^.*$ > gateway > host`
+##### <a name="cronJobs_pattern1_gateway_host"></a>7.1.16.8. Property `stack > cronJobs > ^.*$ > gateway > host`
 
 |              |          |
 | ------------ | -------- |
@@ -11496,7 +13432,33 @@ Must be one of:
 
 **Description:** Hostname for HTTPRoute
 
-##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>7.1.16.6. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
+##### <a name="cronJobs_pattern1_gateway_hostRewrite"></a>7.1.16.9. Property `stack > cronJobs > ^.*$ > gateway > hostRewrite`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it
+
+##### <a name="cronJobs_pattern1_gateway_ipAllowList"></a>7.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > ipAllowList`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>7.1.16.11. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -11505,7 +13467,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)
 
-##### <a name="cronJobs_pattern1_gateway_paths"></a>7.1.16.7. Property `stack > cronJobs > ^.*$ > gateway > paths`
+##### <a name="cronJobs_pattern1_gateway_paths"></a>7.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -11526,7 +13488,7 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [paths items](#cronJobs_pattern1_gateway_paths_items) | -           |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items"></a>7.1.16.7.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
+###### <a name="cronJobs_pattern1_gateway_paths_items"></a>7.1.16.12.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -11539,7 +13501,7 @@ Must be one of:
 | - [path](#cronJobs_pattern1_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#cronJobs_pattern1_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>7.1.16.7.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
+###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>7.1.16.12.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -11548,7 +13510,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>7.1.16.7.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
+###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>7.1.16.12.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -11557,7 +13519,247 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-##### <a name="cronJobs_pattern1_gateway_rules"></a>7.1.16.8. Property `stack > cronJobs > ^.*$ > gateway > rules`
+##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>7.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)
+
+| Property                                                     | Pattern | Type    | Deprecated | Definition | Title/Description                           |
+| ------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_rateLimit_enabled )   | No      | boolean | No         | -          | Enable local rate limiting                  |
+| - [requests](#cronJobs_pattern1_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
+| - [unit](#cronJobs_pattern1_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>7.1.16.13.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable local rate limiting
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>7.1.16.13.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Allowed requests per unit
+
+###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>7.1.16.13.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Rate limit unit (Second, Minute, Hour, Day)
+
+##### <a name="cronJobs_pattern1_gateway_redirect"></a>7.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > redirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host
+
+| Property                                                        | Pattern | Type    | Deprecated | Definition | Title/Description                                               |
+| --------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_redirect_enabled )       | No      | boolean | No         | -          | Enable a redirect-only route                                    |
+| - [hostname](#cronJobs_pattern1_gateway_redirect_hostname )     | No      | string  | No         | -          | Target hostname, empty keeps the request host                   |
+| - [path](#cronJobs_pattern1_gateway_redirect_path )             | No      | string  | No         | -          | Replacement full path via ReplaceFullPath, empty keeps the path |
+| - [scheme](#cronJobs_pattern1_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
+| - [statusCode](#cronJobs_pattern1_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
+
+###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>7.1.16.14.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable a redirect-only route
+
+###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>7.1.16.14.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target hostname, empty keeps the request host
+
+###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>7.1.16.14.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Replacement full path via ReplaceFullPath, empty keeps the path
+
+###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>7.1.16.14.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Target scheme, e.g. https
+
+###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>7.1.16.14.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Redirect status code (301 or 302)
+
+##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>7.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Request header modifications (HTTPRoute RequestHeaderModifier filter)
+
+| Property                                                      | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| ------------------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#cronJobs_pattern1_gateway_requestHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#cronJobs_pattern1_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#cronJobs_pattern1_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>7.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>7.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>7.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>7.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Response header modifications (HTTPRoute ResponseHeaderModifier filter)
+
+| Property                                                       | Pattern | Type  | Deprecated | Definition | Title/Description                    |
+| -------------------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------ |
+| - [add](#cronJobs_pattern1_gateway_responseHeaders_add )       | No      | array | No         | -          | Headers to add, list of {name,value} |
+| - [remove](#cronJobs_pattern1_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
+| - [set](#cronJobs_pattern1_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>7.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to add, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>7.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Header names to remove
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>7.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Headers to set, list of {name,value}
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_rules"></a>7.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -11574,7 +13776,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_sectionName"></a>7.1.16.9. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
+##### <a name="cronJobs_pattern1_gateway_sectionName"></a>7.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -11583,7 +13785,93 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>7.1.16.10. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>7.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)
+
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                              |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------- |
+| - [cookieName](#cronJobs_pattern1_gateway_sessionAffinity_cookieName ) | No      | string  | No         | -          | Affinity cookie name                           |
+| - [enabled](#cronJobs_pattern1_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
+| - [ttl](#cronJobs_pattern1_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>7.1.16.19.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie name
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>7.1.16.19.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable consistent-hash cookie session affinity
+
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>7.1.16.19.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Affinity cookie TTL
+
+##### <a name="cronJobs_pattern1_gateway_timeouts"></a>7.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy
+
+| Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                             |
+| ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| - [backendRequest](#cronJobs_pattern1_gateway_timeouts_backendRequest ) | No      | string | No         | -          | Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request                               |
+| - [connect](#cronJobs_pattern1_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
+| - [request](#cronJobs_pattern1_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>7.1.16.20.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>7.1.16.20.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
+
+###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>7.1.16.20.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
+
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>7.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -11599,7 +13887,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>7.1.16.10.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>7.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -11608,7 +13896,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>7.1.16.10.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>7.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -11617,7 +13905,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>7.1.16.10.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>7.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -304,6 +304,195 @@ https://{{ .Values.gateway.host }}/oauth2/callback
 {{- end -}}
 
 {{/*
+Validate that OIDC and basic auth are not both enabled on a gateway service.
+A route can carry only one SecurityPolicy, and oidc + basicAuth are independent
+auth mechanisms; combining them is unsupported.
+*/}}
+{{- define "validate.gatewaySecurityExclusive" -}}
+{{- if and .Values.gateway.oidcProtected .Values.gateway.basicAuth.enabled -}}
+  {{- fail "gateway.oidcProtected and gateway.basicAuth.enabled cannot both be true on the same service. Pick one auth method." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the service needs a SecurityPolicy (any of oidc, basicAuth, cors, ipAllowList).
+Returns "true"/"" .
+*/}}
+{{- define "gateway.hasSecurityPolicy" -}}
+{{- $g := .Values.gateway -}}
+{{- if or $g.oidcProtected $g.basicAuth.enabled $g.cors.enabled (gt (len $g.ipAllowList) 0) -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+SecurityPolicy name suffix: keep "-oidc" when OIDC is on (name continuity with the
+pre-consolidation policy, avoids delete/recreate), else "-security".
+*/}}
+{{- define "gateway.securityPolicy.suffix" -}}
+{{- if .Values.gateway.oidcProtected -}}oidc{{- else -}}security{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the service needs a BackendTrafficPolicy (sessionAffinity, rateLimit, or connect timeout).
+*/}}
+{{- define "gateway.hasBackendTrafficPolicy" -}}
+{{- $g := .Values.gateway -}}
+{{- if or $g.sessionAffinity.enabled $g.rateLimit.enabled $g.timeouts.connect -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+HTTPRoute per-rule timeouts block body (no "timeouts:" key). Caller indents under a rule.
+*/}}
+{{- define "gateway.ruleTimeoutsInner" -}}
+{{- $t := .Values.gateway.timeouts -}}
+{{- if $t.request }}
+request: {{ $t.request | quote }}
+{{- end }}
+{{- if $t.backendRequest }}
+backendRequest: {{ $t.backendRequest | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+HTTPRoute per-rule filters list (no "filters:" key). Caller indents under a rule.
+Covers hostRewrite (URLRewrite) and request/response header modifiers. Redirect is
+handled separately as a whole-route rule.
+*/}}
+{{- define "gateway.ruleFiltersInner" -}}
+{{- $g := .Values.gateway -}}
+{{- if $g.hostRewrite }}
+- type: URLRewrite
+  urlRewrite:
+    hostname: {{ $g.hostRewrite | quote }}
+{{- end }}
+{{- $rh := $g.requestHeaders -}}
+{{- if and $rh (or $rh.set $rh.add $rh.remove) }}
+- type: RequestHeaderModifier
+  requestHeaderModifier:
+    {{- if $rh.set }}
+    set:
+      {{- toYaml $rh.set | nindent 6 }}
+    {{- end }}
+    {{- if $rh.add }}
+    add:
+      {{- toYaml $rh.add | nindent 6 }}
+    {{- end }}
+    {{- if $rh.remove }}
+    remove:
+      {{- toYaml $rh.remove | nindent 6 }}
+    {{- end }}
+{{- end }}
+{{- $sh := $g.responseHeaders -}}
+{{- if and $sh (or $sh.set $sh.add $sh.remove) }}
+- type: ResponseHeaderModifier
+  responseHeaderModifier:
+    {{- if $sh.set }}
+    set:
+      {{- toYaml $sh.set | nindent 6 }}
+    {{- end }}
+    {{- if $sh.add }}
+    add:
+      {{- toYaml $sh.add | nindent 6 }}
+    {{- end }}
+    {{- if $sh.remove }}
+    remove:
+      {{- toYaml $sh.remove | nindent 6 }}
+    {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+SecurityPolicy spec body (no "targetRefs"). Input dict: "ctx" (service), "host", "public" (bool).
+Public routes (skipAuth) carry only cors/authorization, never oidc/basicAuth.
+*/}}
+{{- define "gateway.securityPolicy.body" -}}
+{{- $ := .ctx -}}
+{{- $g := $.Values.gateway -}}
+{{- if and (not .public) $g.oidcProtected }}
+oidc:
+  provider:
+    issuer: {{ include "oidcProxyGateway.issuer" $ | quote }}
+    {{- if $.Values.oidcProxyGateway.provider.authorizationEndpoint }}
+    authorizationEndpoint: {{ $.Values.oidcProxyGateway.provider.authorizationEndpoint | quote }}
+    {{- end }}
+    {{- if $.Values.oidcProxyGateway.provider.tokenEndpoint }}
+    tokenEndpoint: {{ $.Values.oidcProxyGateway.provider.tokenEndpoint | quote }}
+    {{- end }}
+  clientID: {{ include "oidcProxyGateway.clientID" $ | quote }}
+  clientSecret:
+    name: {{ include "service.fullname" $ }}-oidc-client-secret
+  redirectURL: https://{{ .host }}/oauth2/callback
+  {{- if $.Values.oidcProxyGateway.logoutPath }}
+  logoutPath: {{ $.Values.oidcProxyGateway.logoutPath | quote }}
+  {{- end }}
+  {{- if $.Values.oidcProxyGateway.forwardAccessToken }}
+  forwardAccessToken: {{ $.Values.oidcProxyGateway.forwardAccessToken }}
+  {{- end }}
+  {{- if $.Values.oidcProxyGateway.refreshToken }}
+  refreshToken: {{ $.Values.oidcProxyGateway.refreshToken }}
+  {{- end }}
+  {{- if $.Values.oidcProxyGateway.cookieDomain }}
+  cookieDomain: {{ $.Values.oidcProxyGateway.cookieDomain | quote }}
+  {{- end }}
+  {{- if or $.Values.oidcProxyGateway.cookieNames.accessToken $.Values.oidcProxyGateway.cookieNames.idToken }}
+  cookieNames:
+    {{- if $.Values.oidcProxyGateway.cookieNames.accessToken }}
+    accessToken: {{ $.Values.oidcProxyGateway.cookieNames.accessToken | quote }}
+    {{- end }}
+    {{- if $.Values.oidcProxyGateway.cookieNames.idToken }}
+    idToken: {{ $.Values.oidcProxyGateway.cookieNames.idToken | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if $.Values.oidcProxyGateway.scopes }}
+  scopes:
+    {{- toYaml $.Values.oidcProxyGateway.scopes | nindent 4 }}
+  {{- end }}
+  {{- if $.Values.oidcProxyGateway.resources }}
+  resources:
+    {{- toYaml $.Values.oidcProxyGateway.resources | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if and (not .public) $g.basicAuth.enabled }}
+basicAuth:
+  users:
+    name: {{ required "gateway.basicAuth.secretName is required when gateway.basicAuth.enabled is true" $g.basicAuth.secretName }}
+{{- end }}
+{{- if $g.cors.enabled }}
+cors:
+  {{- if $g.cors.allowOrigins }}
+  allowOrigins:
+    {{- toYaml $g.cors.allowOrigins | nindent 4 }}
+  {{- end }}
+  {{- if $g.cors.allowMethods }}
+  allowMethods:
+    {{- toYaml $g.cors.allowMethods | nindent 4 }}
+  {{- end }}
+  {{- if $g.cors.allowHeaders }}
+  allowHeaders:
+    {{- toYaml $g.cors.allowHeaders | nindent 4 }}
+  {{- end }}
+  {{- if $g.cors.exposeHeaders }}
+  exposeHeaders:
+    {{- toYaml $g.cors.exposeHeaders | nindent 4 }}
+  {{- end }}
+  {{- if $g.cors.allowCredentials }}
+  allowCredentials: true
+  {{- end }}
+  {{- if $g.cors.maxAge }}
+  maxAge: {{ $g.cors.maxAge | quote }}
+  {{- end }}
+{{- end }}
+{{- if gt (len $g.ipAllowList) 0 }}
+authorization:
+  defaultAction: Deny
+  rules:
+    - action: Allow
+      principal:
+        clientCIDRs:
+          {{- toYaml $g.ipAllowList | nindent 10 }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Check if gateway config keys are provided (auto-enable detection)
 Returns: "true" if any gateway.* keys exist (excluding just "enabled")
 */}}

--- a/stack/templates/gateway-backendtlspolicy.yaml
+++ b/stack/templates/gateway-backendtlspolicy.yaml
@@ -1,0 +1,50 @@
+{{- $global := . -}}
+{{ range $serviceName, $serviceValues := .Values.services }}
+  {{- $globalValuesDict := $global.Values.global | toYaml -}}
+  {{- $values := fromYaml $globalValuesDict -}}
+  {{- $values = set $values "name" $serviceName -}}
+  {{- $values := mergeOverwrite $values $serviceValues -}}
+
+  {{/* Auto-enable gateway when config keys are provided (unless explicitly disabled) */}}
+  {{- if hasKey $serviceValues "gateway" -}}
+    {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
+    {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
+      {{- $_ := set $values.gateway "enabled" true -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* Auto-disable gateway when ingress is explicitly enabled at service level */}}
+  {{- if and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled -}}
+    {{- if not (and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled")) -}}
+      {{- $_ := set $values "gateway" (mergeOverwrite (default dict $values.gateway) (dict "enabled" false)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
+{{- with $service }}
+{{- if and .Values.gateway.enabled .Values.gateway.backendTLS.enabled -}}
+{{- $bt := .Values.gateway.backendTLS -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: {{ include "service.fullname" . }}-btls
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ include "service.fullname" . }}
+      sectionName: http
+  validation:
+    hostname: {{ required "gateway.backendTLS.hostname is required when gateway.backendTLS.enabled is true" $bt.hostname | quote }}
+    {{- if $bt.caCertificateRefs }}
+    caCertificateRefs:
+      {{- toYaml $bt.caCertificateRefs | nindent 6 }}
+    {{- else }}
+    wellKnownCACertificates: {{ $bt.wellKnownCACertificates | default "System" }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/stack/templates/gateway-backendtlspolicy.yaml
+++ b/stack/templates/gateway-backendtlspolicy.yaml
@@ -10,6 +10,9 @@
     {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
     {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
       {{- $_ := set $values.gateway "enabled" true -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 

--- a/stack/templates/gateway-backendtrafficpolicy.yaml
+++ b/stack/templates/gateway-backendtrafficpolicy.yaml
@@ -10,6 +10,9 @@
     {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
     {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
       {{- $_ := set $values.gateway "enabled" true -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 

--- a/stack/templates/gateway-backendtrafficpolicy.yaml
+++ b/stack/templates/gateway-backendtrafficpolicy.yaml
@@ -1,0 +1,87 @@
+{{- $global := . -}}
+{{ range $serviceName, $serviceValues := .Values.services }}
+  {{- $globalValuesDict := $global.Values.global | toYaml -}}
+  {{- $values := fromYaml $globalValuesDict -}}
+  {{- $values = set $values "name" $serviceName -}}
+  {{- $values := mergeOverwrite $values $serviceValues -}}
+
+  {{/* Auto-enable gateway when config keys are provided (unless explicitly disabled) */}}
+  {{- if hasKey $serviceValues "gateway" -}}
+    {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
+    {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
+      {{- $_ := set $values.gateway "enabled" true -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* Auto-disable ingress when gateway is explicitly enabled at service level */}}
+  {{- if and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled") $serviceValues.gateway.enabled -}}
+    {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled")) -}}
+      {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* Auto-disable gateway when ingress is explicitly enabled at service level */}}
+  {{- if and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled -}}
+    {{- if not (and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled")) -}}
+      {{- $_ := set $values "gateway" (mergeOverwrite (default dict $values.gateway) (dict "enabled" false)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
+{{- with $service }}
+{{- include "validate.gatewayIngressMutualExclusion" . -}}
+
+{{- if and .Values.gateway.enabled (eq (include "gateway.hasBackendTrafficPolicy" .) "true") -}}
+{{- $g := .Values.gateway -}}
+{{- $routes := list (include "service.fullname" .) -}}
+{{- range $i, $rule := .Values.gateway.rules -}}
+  {{- $routes = append $routes (printf "%s-rule-%d" (include "service.fullname" $service) $i) -}}
+{{- end -}}
+{{- range $routeName := $routes }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ $routeName }}-btp
+  labels:
+    {{- include "service.labels" $service | nindent 4 }}
+  annotations:
+    {{- with (mergeOverwrite
+                (dict)
+                ($service.Values.annotations)
+                ($service.Values.gateway.annotations)
+      ) }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ $routeName }}
+  {{- if $g.sessionAffinity.enabled }}
+  loadBalancer:
+    type: ConsistentHash
+    consistentHash:
+      type: Cookie
+      cookie:
+        name: {{ $g.sessionAffinity.cookieName | quote }}
+        ttl: {{ $g.sessionAffinity.ttl | quote }}
+  {{- end }}
+  {{- if $g.rateLimit.enabled }}
+  rateLimit:
+    type: Local
+    local:
+      rules:
+        - limit:
+            requests: {{ $g.rateLimit.requests | int }}
+            unit: {{ $g.rateLimit.unit }}
+  {{- end }}
+  {{- if $g.timeouts.connect }}
+  timeout:
+    tcp:
+      connectTimeout: {{ $g.timeouts.connect | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{ end }}
+{{- end }}

--- a/stack/templates/gateway-backendtrafficpolicy.yaml
+++ b/stack/templates/gateway-backendtrafficpolicy.yaml
@@ -31,7 +31,7 @@
 {{- with $service }}
 {{- include "validate.gatewayIngressMutualExclusion" . -}}
 
-{{- if and .Values.gateway.enabled (eq (include "gateway.hasBackendTrafficPolicy" .) "true") -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.tlsPassthrough.enabled) (eq (include "gateway.hasBackendTrafficPolicy" .) "true") -}}
 {{- $g := .Values.gateway -}}
 {{- $routes := list (include "service.fullname" .) -}}
 {{- range $i, $rule := .Values.gateway.rules -}}

--- a/stack/templates/gateway-oidc.yaml
+++ b/stack/templates/gateway-oidc.yaml
@@ -10,6 +10,9 @@
     {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
     {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
       {{- $_ := set $values.gateway "enabled" true -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 

--- a/stack/templates/gateway-oidc.yaml
+++ b/stack/templates/gateway-oidc.yaml
@@ -32,7 +32,7 @@
 {{- include "validate.gatewayIngressMutualExclusion" . -}}
 {{- include "validate.gatewayRuleHost" . -}}
 
-{{- if and .Values.gateway.enabled .Values.gateway.oidcProtected -}}
+{{- if and .Values.gateway.enabled .Values.gateway.oidcProtected (not .Values.gateway.tlsPassthrough.enabled) -}}
 {{- $filters := include "gateway.ruleFiltersInner" $service | trim -}}
 {{- $timeouts := include "gateway.ruleTimeoutsInner" $service | trim -}}
 {{- /* Create public HTTPRoute for skipAuth paths if configured */ -}}

--- a/stack/templates/gateway-oidc.yaml
+++ b/stack/templates/gateway-oidc.yaml
@@ -33,6 +33,8 @@
 {{- include "validate.gatewayRuleHost" . -}}
 
 {{- if and .Values.gateway.enabled .Values.gateway.oidcProtected -}}
+{{- $filters := include "gateway.ruleFiltersInner" $service | trim -}}
+{{- $timeouts := include "gateway.ruleTimeoutsInner" $service | trim -}}
 {{- /* Create public HTTPRoute for skipAuth paths if configured */ -}}
 {{- if gt (len .Values.oidcProxyGateway.skipAuth) 0 -}}
 ---
@@ -133,6 +135,14 @@ spec:
           {{- if .weight }}
           weight: {{ .weight }}
           {{- end }}
+      {{- if $filters }}
+      filters:
+        {{- $filters | nindent 8 }}
+      {{- end }}
+      {{- if $timeouts }}
+      timeouts:
+        {{- $timeouts | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- range $i, $rule := .Values.gateway.rules }}
 ---
@@ -199,134 +209,16 @@ spec:
           {{- if .weight }}
           weight: {{ .weight }}
           {{- end }}
+      {{- if $filters }}
+      filters:
+        {{- $filters | nindent 8 }}
+      {{- end }}
+      {{- if $timeouts }}
+      timeouts:
+        {{- $timeouts | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: SecurityPolicy
-metadata:
-  name: {{ include "service.fullname" . }}-oidc
-  labels:
-    {{- include "service.labels" . | nindent 4 }}
-  annotations:
-    {{- with (mergeOverwrite
-                (dict)
-                (.Values.annotations)
-                (.Values.oidcProxyGateway.annotations)
-      ) }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: {{ include "service.fullname" . }}
-  oidc:
-    provider:
-      issuer: {{ include "oidcProxyGateway.issuer" . | quote }}
-      {{- if .Values.oidcProxyGateway.provider.authorizationEndpoint }}
-      authorizationEndpoint: {{ .Values.oidcProxyGateway.provider.authorizationEndpoint | quote }}
-      {{- end }}
-      {{- if .Values.oidcProxyGateway.provider.tokenEndpoint }}
-      tokenEndpoint: {{ .Values.oidcProxyGateway.provider.tokenEndpoint | quote }}
-      {{- end }}
-    clientID: {{ include "oidcProxyGateway.clientID" . | quote }}
-    clientSecret:
-      name: {{ include "service.fullname" . }}-oidc-client-secret
-    redirectURL: https://{{ .Values.gateway.host }}/oauth2/callback
-    {{- if .Values.oidcProxyGateway.logoutPath }}
-    logoutPath: {{ .Values.oidcProxyGateway.logoutPath | quote }}
-    {{- end }}
-    {{- if .Values.oidcProxyGateway.forwardAccessToken }}
-    forwardAccessToken: {{ .Values.oidcProxyGateway.forwardAccessToken }}
-    {{- end }}
-    {{- if .Values.oidcProxyGateway.refreshToken }}
-    refreshToken: {{ .Values.oidcProxyGateway.refreshToken }}
-    {{- end }}
-    {{- if .Values.oidcProxyGateway.cookieDomain }}
-    cookieDomain: {{ .Values.oidcProxyGateway.cookieDomain | quote }}
-    {{- end }}
-    {{- if or .Values.oidcProxyGateway.cookieNames.accessToken .Values.oidcProxyGateway.cookieNames.idToken }}
-    cookieNames:
-      {{- if .Values.oidcProxyGateway.cookieNames.accessToken }}
-      accessToken: {{ .Values.oidcProxyGateway.cookieNames.accessToken | quote }}
-      {{- end }}
-      {{- if .Values.oidcProxyGateway.cookieNames.idToken }}
-      idToken: {{ .Values.oidcProxyGateway.cookieNames.idToken | quote }}
-      {{- end }}
-    {{- end }}
-    {{- if .Values.oidcProxyGateway.scopes }}
-    scopes:
-      {{- toYaml .Values.oidcProxyGateway.scopes | nindent 6 }}
-    {{- end }}
-    {{- if .Values.oidcProxyGateway.resources }}
-    resources:
-      {{- toYaml .Values.oidcProxyGateway.resources | nindent 6 }}
-    {{- end }}
-{{- range $i, $rule := .Values.gateway.rules }}
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: SecurityPolicy
-metadata:
-  name: {{ include "service.fullname" $service }}-rule-{{ $i }}-oidc
-  labels:
-    {{- include "service.labels" $service | nindent 4 }}
-  annotations:
-    {{- with (mergeOverwrite
-                (dict)
-                ($service.Values.annotations)
-                ($service.Values.oidcProxyGateway.annotations)
-      ) }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: {{ include "service.fullname" $service }}-rule-{{ $i }}
-  oidc:
-    provider:
-      issuer: {{ include "oidcProxyGateway.issuer" $service | quote }}
-      {{- if $service.Values.oidcProxyGateway.provider.authorizationEndpoint }}
-      authorizationEndpoint: {{ $service.Values.oidcProxyGateway.provider.authorizationEndpoint | quote }}
-      {{- end }}
-      {{- if $service.Values.oidcProxyGateway.provider.tokenEndpoint }}
-      tokenEndpoint: {{ $service.Values.oidcProxyGateway.provider.tokenEndpoint | quote }}
-      {{- end }}
-    clientID: {{ include "oidcProxyGateway.clientID" $service | quote }}
-    clientSecret:
-      name: {{ include "service.fullname" $service }}-oidc-client-secret
-    redirectURL: https://{{ $rule.host }}/oauth2/callback
-    {{- if $service.Values.oidcProxyGateway.logoutPath }}
-    logoutPath: {{ $service.Values.oidcProxyGateway.logoutPath | quote }}
-    {{- end }}
-    {{- if $service.Values.oidcProxyGateway.forwardAccessToken }}
-    forwardAccessToken: {{ $service.Values.oidcProxyGateway.forwardAccessToken }}
-    {{- end }}
-    {{- if $service.Values.oidcProxyGateway.refreshToken }}
-    refreshToken: {{ $service.Values.oidcProxyGateway.refreshToken }}
-    {{- end }}
-    {{- if $service.Values.oidcProxyGateway.cookieDomain }}
-    cookieDomain: {{ $service.Values.oidcProxyGateway.cookieDomain | quote }}
-    {{- end }}
-    {{- if or $service.Values.oidcProxyGateway.cookieNames.accessToken $service.Values.oidcProxyGateway.cookieNames.idToken }}
-    cookieNames:
-      {{- if $service.Values.oidcProxyGateway.cookieNames.accessToken }}
-      accessToken: {{ $service.Values.oidcProxyGateway.cookieNames.accessToken | quote }}
-      {{- end }}
-      {{- if $service.Values.oidcProxyGateway.cookieNames.idToken }}
-      idToken: {{ $service.Values.oidcProxyGateway.cookieNames.idToken | quote }}
-      {{- end }}
-    {{- end }}
-    {{- if $service.Values.oidcProxyGateway.scopes }}
-    scopes:
-      {{- toYaml $service.Values.oidcProxyGateway.scopes | nindent 6 }}
-    {{- end }}
-    {{- if $service.Values.oidcProxyGateway.resources }}
-    resources:
-      {{- toYaml $service.Values.oidcProxyGateway.resources | nindent 6 }}
-    {{- end }}
 {{- end }}
 {{ end }}
-{{- end }}
 {{- end }}

--- a/stack/templates/gateway-securitypolicy.yaml
+++ b/stack/templates/gateway-securitypolicy.yaml
@@ -10,6 +10,9 @@
     {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
     {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
       {{- $_ := set $values.gateway "enabled" true -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 

--- a/stack/templates/gateway-securitypolicy.yaml
+++ b/stack/templates/gateway-securitypolicy.yaml
@@ -1,0 +1,107 @@
+{{- $global := . -}}
+{{ range $serviceName, $serviceValues := .Values.services }}
+  {{- $globalValuesDict := $global.Values.global | toYaml -}}
+  {{- $values := fromYaml $globalValuesDict -}}
+  {{- $values = set $values "name" $serviceName -}}
+  {{- $values := mergeOverwrite $values $serviceValues -}}
+
+  {{/* Auto-enable gateway when config keys are provided (unless explicitly disabled) */}}
+  {{- if hasKey $serviceValues "gateway" -}}
+    {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
+    {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
+      {{- $_ := set $values.gateway "enabled" true -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* Auto-disable ingress when gateway is explicitly enabled at service level */}}
+  {{- if and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled") $serviceValues.gateway.enabled -}}
+    {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled")) -}}
+      {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* Auto-disable gateway when ingress is explicitly enabled at service level */}}
+  {{- if and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled -}}
+    {{- if not (and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled")) -}}
+      {{- $_ := set $values "gateway" (mergeOverwrite (default dict $values.gateway) (dict "enabled" false)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
+{{- with $service }}
+{{- include "validate.gatewayIngressMutualExclusion" . -}}
+{{- include "validate.gatewayRuleHost" . -}}
+{{- include "validate.gatewaySecurityExclusive" . -}}
+
+{{- if and .Values.gateway.enabled (eq (include "gateway.hasSecurityPolicy" .) "true") -}}
+{{- $suffix := include "gateway.securityPolicy.suffix" . -}}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "service.fullname" . }}-{{ $suffix }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+  annotations:
+    {{- with (mergeOverwrite
+                (dict)
+                (.Values.annotations)
+                (.Values.oidcProxyGateway.annotations)
+      ) }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "service.fullname" . }}
+  {{- include "gateway.securityPolicy.body" (dict "ctx" . "host" .Values.gateway.host "public" false) | nindent 2 }}
+{{- range $i, $rule := .Values.gateway.rules }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "service.fullname" $service }}-rule-{{ $i }}-{{ $suffix }}
+  labels:
+    {{- include "service.labels" $service | nindent 4 }}
+  annotations:
+    {{- with (mergeOverwrite
+                (dict)
+                ($service.Values.annotations)
+                ($service.Values.oidcProxyGateway.annotations)
+      ) }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "service.fullname" $service }}-rule-{{ $i }}
+  {{- include "gateway.securityPolicy.body" (dict "ctx" $service "host" $rule.host "public" false) | nindent 2 }}
+{{- end }}
+{{- if and .Values.gateway.oidcProtected (gt (len .Values.oidcProxyGateway.skipAuth) 0) (or .Values.gateway.cors.enabled (gt (len .Values.gateway.ipAllowList) 0)) }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "service.fullname" . }}-public-security
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+  annotations:
+    {{- with (mergeOverwrite
+                (dict)
+                (.Values.annotations)
+                (.Values.oidcProxyGateway.annotations)
+      ) }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "service.fullname" . }}-public
+  {{- include "gateway.securityPolicy.body" (dict "ctx" . "host" .Values.gateway.host "public" true) | nindent 2 }}
+{{- end }}
+{{- end }}
+{{ end }}
+{{- end }}

--- a/stack/templates/gateway-securitypolicy.yaml
+++ b/stack/templates/gateway-securitypolicy.yaml
@@ -33,7 +33,7 @@
 {{- include "validate.gatewayRuleHost" . -}}
 {{- include "validate.gatewaySecurityExclusive" . -}}
 
-{{- if and .Values.gateway.enabled (eq (include "gateway.hasSecurityPolicy" .) "true") -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.tlsPassthrough.enabled) (eq (include "gateway.hasSecurityPolicy" .) "true") -}}
 {{- $suffix := include "gateway.securityPolicy.suffix" . -}}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1

--- a/stack/templates/httproute.yaml
+++ b/stack/templates/httproute.yaml
@@ -33,6 +33,9 @@
 {{- include "validate.gatewayRuleHost" . -}}
 
 {{- if and .Values.gateway.enabled (not .Values.gateway.oidcProtected) -}}
+{{- $filters := include "gateway.ruleFiltersInner" $service | trim -}}
+{{- $timeouts := include "gateway.ruleTimeoutsInner" $service | trim -}}
+{{- $redirect := .Values.gateway.redirect -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -64,6 +67,27 @@ spec:
   hostnames:
     - {{ $service.Values.gateway.host }}
   rules:
+    {{- if $redirect.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            {{- if $redirect.scheme }}
+            scheme: {{ $redirect.scheme }}
+            {{- end }}
+            {{- if $redirect.hostname }}
+            hostname: {{ $redirect.hostname }}
+            {{- end }}
+            {{- if $redirect.path }}
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ $redirect.path }}
+            {{- end }}
+            statusCode: {{ $redirect.statusCode | int }}
+    {{- else }}
     {{- range $service.Values.gateway.paths }}
     - matches:
         - path:
@@ -79,6 +103,15 @@ spec:
           {{- if .weight }}
           weight: {{ .weight }}
           {{- end }}
+      {{- if $filters }}
+      filters:
+        {{- $filters | nindent 8 }}
+      {{- end }}
+      {{- if $timeouts }}
+      timeouts:
+        {{- $timeouts | nindent 8 }}
+      {{- end }}
+    {{- end }}
     {{- end }}
 {{- range $i, $rule := .Values.gateway.rules }}
 ---
@@ -112,6 +145,27 @@ spec:
   hostnames:
     - {{ $rule.host }}
   rules:
+    {{- if $redirect.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            {{- if $redirect.scheme }}
+            scheme: {{ $redirect.scheme }}
+            {{- end }}
+            {{- if $redirect.hostname }}
+            hostname: {{ $redirect.hostname }}
+            {{- end }}
+            {{- if $redirect.path }}
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ $redirect.path }}
+            {{- end }}
+            statusCode: {{ $redirect.statusCode | int }}
+    {{- else }}
     {{- $ruleValues := mergeOverwrite (dict "paths" $service.Values.gateway.paths) $rule -}}
     {{- range $ruleValues.paths }}
     - matches:
@@ -128,6 +182,15 @@ spec:
           {{- if .weight }}
           weight: {{ .weight }}
           {{- end }}
+      {{- if $filters }}
+      filters:
+        {{- $filters | nindent 8 }}
+      {{- end }}
+      {{- if $timeouts }}
+      timeouts:
+        {{- $timeouts | nindent 8 }}
+      {{- end }}
+    {{- end }}
     {{- end }}
 {{- end }}
 {{ end }}

--- a/stack/templates/httproute.yaml
+++ b/stack/templates/httproute.yaml
@@ -10,6 +10,9 @@
     {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
     {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
       {{- $_ := set $values.gateway "enabled" true -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 

--- a/stack/templates/httproute.yaml
+++ b/stack/templates/httproute.yaml
@@ -32,7 +32,7 @@
 {{- include "validate.gatewayIngressMutualExclusion" . -}}
 {{- include "validate.gatewayRuleHost" . -}}
 
-{{- if and .Values.gateway.enabled (not .Values.gateway.oidcProtected) -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.oidcProtected) (not .Values.gateway.tlsPassthrough.enabled) -}}
 {{- $filters := include "gateway.ruleFiltersInner" $service | trim -}}
 {{- $timeouts := include "gateway.ruleTimeoutsInner" $service | trim -}}
 {{- $redirect := .Values.gateway.redirect -}}

--- a/stack/templates/ingress.yaml
+++ b/stack/templates/ingress.yaml
@@ -12,6 +12,16 @@
     {{- end -}}
   {{- end -}}
 
+  {{/* Auto-disable ingress when gateway config keys auto-enable the gateway (mirrors the gateway templates) */}}
+  {{- if hasKey $serviceValues "gateway" -}}
+    {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
+    {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
   {{/* Auto-disable gateway when ingress is explicitly enabled at service level */}}
   {{- if and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled -}}
     {{- if not (and (hasKey $serviceValues "gateway") (hasKey $serviceValues.gateway "enabled")) -}}

--- a/stack/templates/listenerset.yaml
+++ b/stack/templates/listenerset.yaml
@@ -10,6 +10,9 @@
     {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
     {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
       {{- $_ := set $values.gateway "enabled" true -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 

--- a/stack/templates/listenerset.yaml
+++ b/stack/templates/listenerset.yaml
@@ -15,7 +15,7 @@
 
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}
-{{- if and .Values.gateway.enabled .Values.gateway.vanity.enabled -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.tlsPassthrough.enabled) .Values.gateway.vanity.enabled -}}
 {{- $hostname := .Values.gateway.vanity.hostname | default .Values.gateway.host -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -44,7 +44,7 @@ spec:
             kind: Secret
             name: {{ include "service.vanityListenerSetName" . }}-tls
 {{- end }}
-{{- if .Values.gateway.enabled }}
+{{- if and .Values.gateway.enabled (not .Values.gateway.tlsPassthrough.enabled) }}
 {{- range $i, $rule := .Values.gateway.rules }}
 {{- if and $rule.vanity $rule.vanity.enabled }}
 {{- $rname := printf "%s-rule-%d" (include "service.vanityListenerSetName" $service) $i }}

--- a/stack/templates/tlsroute.yaml
+++ b/stack/templates/tlsroute.yaml
@@ -10,6 +10,9 @@
     {{- $hasGatewayKeys := include "gateway.hasConfigKeys" (dict "Values" $values) -}}
     {{- if and $hasGatewayKeys (not (and (hasKey $serviceValues.gateway "enabled") (eq $serviceValues.gateway.enabled false))) -}}
       {{- $_ := set $values.gateway "enabled" true -}}
+      {{- if not (and (hasKey $serviceValues "ingress") (hasKey $serviceValues.ingress "enabled") $serviceValues.ingress.enabled) -}}
+        {{- $_ := set $values "ingress" (mergeOverwrite (default dict $values.ingress) (dict "enabled" false)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 

--- a/stack/templates/tlsroute.yaml
+++ b/stack/templates/tlsroute.yaml
@@ -22,29 +22,39 @@
 
   {{- $service := dict "Chart" $global.Chart "Release" $global.Release "Capabilities" $global.Capabilities "Values" $values -}}
 {{- with $service }}
-{{- if and .Values.gateway.enabled (not .Values.gateway.tlsPassthrough.enabled) .Values.gateway.backendTLS.enabled -}}
-{{- $bt := .Values.gateway.backendTLS -}}
+{{- include "validate.gatewayRuleHost" . -}}
+{{- if and .Values.gateway.enabled .Values.gateway.tlsPassthrough.enabled -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
-kind: BackendTLSPolicy
+kind: TLSRoute
 metadata:
-  name: {{ include "service.fullname" . }}-btls
+  name: {{ include "service.fullname" . }}
   labels:
     {{- include "service.labels" . | nindent 4 }}
+  annotations:
+    {{- with (mergeOverwrite
+                (dict)
+                (.Values.annotations)
+                (.Values.gateway.annotations)
+      ) }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  targetRefs:
-    - group: ""
-      kind: Service
-      name: {{ include "service.fullname" . }}
-      sectionName: http
-  validation:
-    hostname: {{ required "gateway.backendTLS.hostname is required when gateway.backendTLS.enabled is true" $bt.hostname | quote }}
-    {{- if $bt.caCertificateRefs }}
-    caCertificateRefs:
-      {{- toYaml $bt.caCertificateRefs | nindent 6 }}
-    {{- else }}
-    wellKnownCACertificates: {{ $bt.wellKnownCACertificates | default "System" }}
+  parentRefs:
+    - name: {{ .Values.gateway.gatewayName }}
+      namespace: {{ .Values.gateway.gatewayNamespace }}
+      {{- if .Values.gateway.tlsPassthrough.sectionName }}
+      sectionName: {{ .Values.gateway.tlsPassthrough.sectionName }}
+      {{- end }}
+  hostnames:
+    - {{ .Values.gateway.host }}
+    {{- range $i, $rule := .Values.gateway.rules }}
+    - {{ $rule.host }}
     {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "service.fullname" . }}
+          port: {{ .Values.service.port | int }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/stack/tests/gateway_backendtlspolicy_test.yaml
+++ b/stack/tests/gateway_backendtlspolicy_test.yaml
@@ -1,0 +1,108 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test gateway BackendTLSPolicy (upstream TLS)
+templates:
+  - gateway-backendtlspolicy.yaml
+tests:
+  - it: should create no BackendTLSPolicy when backendTLS is disabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a v1 BackendTLSPolicy targeting the Service port name
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          backendTLS:
+            enabled: true
+            hostname: upstream.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        isKind:
+          of: BackendTLSPolicy
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-btls
+      - documentIndex: 0
+        equal:
+          path: spec.targetRefs[0].kind
+          value: Service
+      - documentIndex: 0
+        equal:
+          path: spec.targetRefs[0].name
+          value: release-name-stack-service1
+      - documentIndex: 0
+        equal:
+          path: spec.targetRefs[0].sectionName
+          value: http
+      - documentIndex: 0
+        equal:
+          path: spec.validation.hostname
+          value: upstream.example.com
+      - documentIndex: 0
+        equal:
+          path: spec.validation.wellKnownCACertificates
+          value: System
+
+  - it: should use caCertificateRefs instead of System when provided
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          backendTLS:
+            enabled: true
+            hostname: upstream.example.com
+            caCertificateRefs:
+              - group: ""
+                kind: ConfigMap
+                name: upstream-ca
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.validation.caCertificateRefs[0].name
+          value: upstream-ca
+      - documentIndex: 0
+        notExists:
+          path: spec.validation.wellKnownCACertificates
+
+  - it: should fail when backendTLS is enabled without a hostname
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          backendTLS:
+            enabled: true
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.backendTLS.hostname is required when gateway.backendTLS.enabled is true"

--- a/stack/tests/gateway_backendtrafficpolicy_test.yaml
+++ b/stack/tests/gateway_backendtrafficpolicy_test.yaml
@@ -1,0 +1,123 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test gateway BackendTrafficPolicy (session affinity, rate limit, connect timeout)
+templates:
+  - gateway-backendtrafficpolicy.yaml
+tests:
+  - it: should create no BackendTrafficPolicy when no relevant features are set
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render consistent-hash cookie session affinity
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          sessionAffinity:
+            enabled: true
+            cookieName: argus_sticky_session
+            ttl: "600s"
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        isKind:
+          of: BackendTrafficPolicy
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-btp
+      - documentIndex: 0
+        equal:
+          path: spec.targetRefs[0].name
+          value: release-name-stack-service1
+      - documentIndex: 0
+        equal:
+          path: spec.loadBalancer.type
+          value: ConsistentHash
+      - documentIndex: 0
+        equal:
+          path: spec.loadBalancer.consistentHash.type
+          value: Cookie
+      - documentIndex: 0
+        equal:
+          path: spec.loadBalancer.consistentHash.cookie.name
+          value: argus_sticky_session
+
+  - it: should render a local rate limit and connect timeout
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          rateLimit:
+            enabled: true
+            requests: 10
+            unit: Second
+          timeouts:
+            connect: "5s"
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.rateLimit.type
+          value: Local
+      - documentIndex: 0
+        equal:
+          path: spec.rateLimit.local.rules[0].limit.requests
+          value: 10
+      - documentIndex: 0
+        equal:
+          path: spec.rateLimit.local.rules[0].limit.unit
+          value: Second
+      - documentIndex: 0
+        equal:
+          path: spec.timeout.tcp.connectTimeout
+          value: "5s"
+
+  - it: should create one BackendTrafficPolicy per route (primary + rules)
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          sessionAffinity:
+            enabled: true
+          rules:
+            - host: api2.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: spec.targetRefs[0].name
+          value: release-name-stack-service1
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-rule-0-btp
+      - documentIndex: 1
+        equal:
+          path: spec.targetRefs[0].name
+          value: release-name-stack-service1-rule-0

--- a/stack/tests/gateway_oidc_test.yaml
+++ b/stack/tests/gateway_oidc_test.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
-suite: test gateway OIDC HTTPRoute and SecurityPolicy
+suite: test gateway OIDC HTTPRoutes
 templates:
   - gateway-oidc.yaml
 tests:
@@ -31,7 +31,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should create HTTPRoute and SecurityPolicy for primary host
+  - it: should create the primary HTTPRoute (SecurityPolicy is in gateway-securitypolicy.yaml)
     set:
       global:
         ingress:
@@ -51,8 +51,7 @@ tests:
         service1: {}
     asserts:
       - hasDocuments:
-          count: 2
-      # HTTPRoute
+          count: 1
       - documentIndex: 0
         isKind:
           of: HTTPRoute
@@ -64,28 +63,8 @@ tests:
         equal:
           path: spec.hostnames[0]
           value: api.example.com
-      # SecurityPolicy
-      - documentIndex: 1
-        isKind:
-          of: SecurityPolicy
-      - documentIndex: 1
-        equal:
-          path: metadata.name
-          value: release-name-stack-service1-oidc
-      - documentIndex: 1
-        equal:
-          path: spec.targetRefs[0].kind
-          value: HTTPRoute
-      - documentIndex: 1
-        equal:
-          path: spec.targetRefs[0].name
-          value: release-name-stack-service1
-      - documentIndex: 1
-        equal:
-          path: spec.oidc.redirectURL
-          value: https://api.example.com/oauth2/callback
 
-  - it: should create separate HTTPRoute and SecurityPolicy per rule
+  - it: should create a separate HTTPRoute per rule
     set:
       global:
         fullnameOverride: myapp
@@ -109,23 +88,11 @@ tests:
         service1: {}
     asserts:
       - hasDocuments:
-          count: 6
-      # Primary HTTPRoute
-      - documentIndex: 0
-        isKind:
-          of: HTTPRoute
+          count: 3
       - documentIndex: 0
         equal:
           path: metadata.name
           value: myapp-service1
-      - documentIndex: 0
-        equal:
-          path: spec.hostnames[0]
-          value: api.example.com
-      # Rule 0 HTTPRoute
-      - documentIndex: 1
-        isKind:
-          of: HTTPRoute
       - documentIndex: 1
         equal:
           path: metadata.name
@@ -134,170 +101,10 @@ tests:
         equal:
           path: spec.hostnames[0]
           value: api2.example.com
-      # Rule 1 HTTPRoute
-      - documentIndex: 2
-        isKind:
-          of: HTTPRoute
       - documentIndex: 2
         equal:
           path: metadata.name
           value: myapp-service1-rule-1
-      - documentIndex: 2
-        equal:
-          path: spec.hostnames[0]
-          value: api3.example.com
-      # Primary SecurityPolicy
-      - documentIndex: 3
-        isKind:
-          of: SecurityPolicy
-      - documentIndex: 3
-        equal:
-          path: metadata.name
-          value: myapp-service1-oidc
-      - documentIndex: 3
-        equal:
-          path: spec.targetRefs[0].name
-          value: myapp-service1
-      - documentIndex: 3
-        lengthEqual:
-          path: spec.targetRefs
-          count: 1
-      - documentIndex: 3
-        equal:
-          path: spec.oidc.redirectURL
-          value: https://api.example.com/oauth2/callback
-      # Rule 0 SecurityPolicy
-      - documentIndex: 4
-        isKind:
-          of: SecurityPolicy
-      - documentIndex: 4
-        equal:
-          path: metadata.name
-          value: myapp-service1-rule-0-oidc
-      - documentIndex: 4
-        equal:
-          path: spec.targetRefs[0].name
-          value: myapp-service1-rule-0
-      - documentIndex: 4
-        lengthEqual:
-          path: spec.targetRefs
-          count: 1
-      - documentIndex: 4
-        equal:
-          path: spec.oidc.redirectURL
-          value: https://api2.example.com/oauth2/callback
-      # Rule 1 SecurityPolicy
-      - documentIndex: 5
-        isKind:
-          of: SecurityPolicy
-      - documentIndex: 5
-        equal:
-          path: metadata.name
-          value: myapp-service1-rule-1-oidc
-      - documentIndex: 5
-        equal:
-          path: spec.targetRefs[0].name
-          value: myapp-service1-rule-1
-      - documentIndex: 5
-        lengthEqual:
-          path: spec.targetRefs
-          count: 1
-      - documentIndex: 5
-        equal:
-          path: spec.oidc.redirectURL
-          value: https://api3.example.com/oauth2/callback
-
-  - it: should set OIDC configuration in all SecurityPolicies
-    set:
-      global:
-        ingress:
-          enabled: false
-        gateway:
-          enabled: true
-          host: api.example.com
-          oidcProtected: true
-          rules:
-            - host: api2.example.com
-        oidcProxyGateway:
-          clientID: my-client-id
-          provider:
-            issuer: https://auth.example.com
-            authorizationEndpoint: https://auth.example.com/authorize
-            tokenEndpoint: https://auth.example.com/token
-          logoutPath: /logout
-          forwardAccessToken: true
-          refreshToken: false
-          cookieDomain: example.com
-          cookieNames:
-            accessToken: my-access-token
-            idToken: my-id-token
-          scopes:
-            - openid
-            - profile
-            - email
-      services:
-        service1: {}
-    asserts:
-      - hasDocuments:
-          count: 4
-      # Primary SecurityPolicy (HTTPRoutes 0,1 then SecurityPolicies 2,3)
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.provider.issuer
-          value: https://auth.example.com
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.provider.authorizationEndpoint
-          value: https://auth.example.com/authorize
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.provider.tokenEndpoint
-          value: https://auth.example.com/token
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.clientID
-          value: my-client-id
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.clientSecret.name
-          value: release-name-stack-service1-oidc-client-secret
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.logoutPath
-          value: /logout
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.forwardAccessToken
-          value: true
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.cookieDomain
-          value: example.com
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.cookieNames.accessToken
-          value: my-access-token
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.cookieNames.idToken
-          value: my-id-token
-      - documentIndex: 2
-        contains:
-          path: spec.oidc.scopes
-          content: openid
-      # Rule SecurityPolicy has same OIDC config except redirectURL
-      - documentIndex: 3
-        equal:
-          path: spec.oidc.provider.issuer
-          value: https://auth.example.com
-      - documentIndex: 3
-        equal:
-          path: spec.oidc.clientID
-          value: my-client-id
-      - documentIndex: 3
-        equal:
-          path: spec.oidc.redirectURL
-          value: https://api2.example.com/oauth2/callback
 
   - it: should create public HTTPRoute for skipAuth paths with all hostnames
     set:
@@ -323,8 +130,7 @@ tests:
         service1: {}
     asserts:
       - hasDocuments:
-          count: 5
-      # Public HTTPRoute
+          count: 3
       - documentIndex: 0
         isKind:
           of: HTTPRoute
@@ -340,10 +146,6 @@ tests:
         contains:
           path: spec.hostnames
           content: api2.example.com
-      - documentIndex: 0
-        lengthEqual:
-          path: spec.hostnames
-          count: 2
       - documentIndex: 0
         lengthEqual:
           path: spec.rules
@@ -389,78 +191,7 @@ tests:
           path: spec.rules[0].matches[0].path.value
           value: /
 
-  - it: should include annotations on SecurityPolicies
-    set:
-      global:
-        ingress:
-          enabled: false
-        annotations:
-          global-annotation: "global-value"
-        gateway:
-          enabled: true
-          host: api.example.com
-          oidcProtected: true
-          rules:
-            - host: api2.example.com
-        oidcProxyGateway:
-          clientID: my-client-id
-          provider:
-            issuer: https://auth.example.com
-          annotations:
-            oidc-annotation: "oidc-value"
-      services:
-        service1: {}
-    asserts:
-      - hasDocuments:
-          count: 4
-      # Primary SecurityPolicy (HTTPRoutes at 0,1 then SecurityPolicies at 2,3)
-      - documentIndex: 2
-        equal:
-          path: metadata.annotations["global-annotation"]
-          value: "global-value"
-      - documentIndex: 2
-        equal:
-          path: metadata.annotations["oidc-annotation"]
-          value: "oidc-value"
-      # Rule SecurityPolicy
-      - documentIndex: 3
-        equal:
-          path: metadata.annotations["global-annotation"]
-          value: "global-value"
-      - documentIndex: 3
-        equal:
-          path: metadata.annotations["oidc-annotation"]
-          value: "oidc-value"
-
-  - it: should support OIDC resources parameter
-    set:
-      global:
-        ingress:
-          enabled: false
-        gateway:
-          enabled: true
-          host: api.example.com
-          oidcProtected: true
-        oidcProxyGateway:
-          clientID: my-client-id
-          provider:
-            issuer: https://auth.example.com
-          resources:
-            - resource1
-            - resource2
-      services:
-        service1: {}
-    asserts:
-      - documentIndex: 1
-        contains:
-          path: spec.oidc.resources
-          content: resource1
-      - documentIndex: 1
-        contains:
-          path: spec.oidc.resources
-          content: resource2
-
-  - it: should include service labels on all resources
+  - it: should include service labels on the HTTPRoutes
     set:
       global:
         ingress:
@@ -480,7 +211,6 @@ tests:
       services:
         service1: {}
     asserts:
-      # All HTTPRoutes
       - documentIndex: 0
         equal:
           path: metadata.labels["argus/env-name"]
@@ -489,42 +219,3 @@ tests:
         equal:
           path: metadata.labels["argus/env-name"]
           value: "production"
-      # All SecurityPolicies
-      - documentIndex: 2
-        equal:
-          path: metadata.labels["argus/env-name"]
-          value: "production"
-      - documentIndex: 3
-        equal:
-          path: metadata.labels["argus/env-name"]
-          value: "production"
-
-  - it: should reference same client secret for all SecurityPolicies
-    set:
-      global:
-        fullnameOverride: myapp
-        ingress:
-          enabled: false
-        gateway:
-          enabled: true
-          host: api.example.com
-          oidcProtected: true
-          rules:
-            - host: api2.example.com
-        oidcProxyGateway:
-          clientID: my-client-id
-          provider:
-            issuer: https://auth.example.com
-      services:
-        service1: {}
-    asserts:
-      # Primary SecurityPolicy
-      - documentIndex: 2
-        equal:
-          path: spec.oidc.clientSecret.name
-          value: myapp-service1-oidc-client-secret
-      # Rule SecurityPolicy
-      - documentIndex: 3
-        equal:
-          path: spec.oidc.clientSecret.name
-          value: myapp-service1-oidc-client-secret

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -1,0 +1,301 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test gateway SecurityPolicy (oidc, basicAuth, cors, ipAllowList)
+templates:
+  - gateway-securitypolicy.yaml
+tests:
+  - it: should create no SecurityPolicy when no security features are set
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a SecurityPolicy named -oidc for the primary host
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        isKind:
+          of: SecurityPolicy
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-oidc
+      - documentIndex: 0
+        equal:
+          path: spec.targetRefs[0].name
+          value: release-name-stack-service1
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.redirectURL
+          value: https://api.example.com/oauth2/callback
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.clientSecret.name
+          value: release-name-stack-service1-oidc-client-secret
+
+  - it: should create a SecurityPolicy per rule with full OIDC config
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          rules:
+            - host: api2.example.com
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+            authorizationEndpoint: https://auth.example.com/authorize
+            tokenEndpoint: https://auth.example.com/token
+          logoutPath: /logout
+          forwardAccessToken: true
+          cookieDomain: example.com
+          scopes:
+            - openid
+            - profile
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-oidc
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.provider.issuer
+          value: https://auth.example.com
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.provider.authorizationEndpoint
+          value: https://auth.example.com/authorize
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.clientID
+          value: my-client-id
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.logoutPath
+          value: /logout
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.cookieDomain
+          value: example.com
+      - documentIndex: 0
+        contains:
+          path: spec.oidc.scopes
+          content: openid
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-rule-0-oidc
+      - documentIndex: 1
+        equal:
+          path: spec.oidc.redirectURL
+          value: https://api2.example.com/oauth2/callback
+
+  - it: should include annotations on SecurityPolicies
+    set:
+      global:
+        ingress:
+          enabled: false
+        annotations:
+          global-annotation: "global-value"
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          annotations:
+            oidc-annotation: "oidc-value"
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["global-annotation"]
+          value: "global-value"
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["oidc-annotation"]
+          value: "oidc-value"
+
+  - it: should render basicAuth (named -security) when enabled without oidc
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          basicAuth:
+            enabled: true
+            secretName: my-htpasswd
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-security
+      - documentIndex: 0
+        equal:
+          path: spec.basicAuth.users.name
+          value: my-htpasswd
+      - documentIndex: 0
+        notExists:
+          path: spec.oidc
+
+  - it: should render cors when enabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          cors:
+            enabled: true
+            allowOrigins:
+              - https://app.example.com
+            allowMethods:
+              - GET
+              - POST
+            allowCredentials: true
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        contains:
+          path: spec.cors.allowOrigins
+          content: https://app.example.com
+      - documentIndex: 0
+        equal:
+          path: spec.cors.allowCredentials
+          value: true
+
+  - it: should render an IP allowlist authorization rule
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          ipAllowList:
+            - 192.112.170.192/26
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        equal:
+          path: spec.authorization.defaultAction
+          value: Deny
+      - documentIndex: 0
+        equal:
+          path: spec.authorization.rules[0].action
+          value: Allow
+      - documentIndex: 0
+        contains:
+          path: spec.authorization.rules[0].principal.clientCIDRs
+          content: 192.112.170.192/26
+
+  - it: should compose oidc with cors in a single SecurityPolicy
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          cors:
+            enabled: true
+            allowOrigins:
+              - https://app.example.com
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        exists:
+          path: spec.oidc
+      - documentIndex: 0
+        exists:
+          path: spec.cors
+
+  - it: should add a public SecurityPolicy for cors on the skipAuth route
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          cors:
+            enabled: true
+            allowOrigins:
+              - https://app.example.com
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          skipAuth:
+            - path: /healthz
+              method: GET
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-public-security
+      - documentIndex: 1
+        notExists:
+          path: spec.oidc
+      - documentIndex: 1
+        exists:
+          path: spec.cors

--- a/stack/tests/gateway_test.yaml
+++ b/stack/tests/gateway_test.yaml
@@ -424,3 +424,103 @@ tests:
           value: primary.dev.czi.team
         notExists:
           path: spec.parentRefs[0].kind
+
+  - it: should apply default 60s timeouts to gateway routes
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].timeouts.request
+          value: "60s"
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].timeouts.backendRequest
+          value: "60s"
+
+  - it: should add a URLRewrite filter for hostRewrite
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          hostRewrite: upstream.example.com
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].filters[0].type
+          value: URLRewrite
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].filters[0].urlRewrite.hostname
+          value: upstream.example.com
+
+  - it: should add a RequestHeaderModifier filter
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          requestHeaders:
+            set:
+              - name: X-Forwarded-Host
+                value: api.example.com
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].filters[0].requestHeaderModifier.set[0].name
+          value: X-Forwarded-Host
+
+  - it: should render a redirect-only rule when redirect is enabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          redirect:
+            enabled: true
+            scheme: https
+            statusCode: 301
+            hostname: new.example.com
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].filters[0].requestRedirect.hostname
+          value: new.example.com
+      - documentIndex: 0
+        notExists:
+          path: spec.rules[0].backendRefs

--- a/stack/tests/gateway_validation_test.yaml
+++ b/stack/tests/gateway_validation_test.yaml
@@ -3,6 +3,7 @@ suite: test gateway validation
 templates:
   - httproute.yaml
   - gateway-oidc.yaml
+  - gateway-securitypolicy.yaml
   - ingress.yaml
 tests:
   - it: should fail when gateway rule is missing host (non-OIDC)
@@ -64,7 +65,7 @@ tests:
           count: 3
 
   - it: should fail when oidcProxyGateway.clientID is missing
-    template: gateway-oidc.yaml
+    template: gateway-securitypolicy.yaml
     set:
       global:
         ingress:
@@ -83,7 +84,7 @@ tests:
           errorMessage: "oidcProxyGateway.clientID is required when gateway.oidcProtected is enabled. Set it explicitly in your values.yaml."
 
   - it: should fail when oidcProxyGateway.provider.issuer is missing
-    template: gateway-oidc.yaml
+    template: gateway-securitypolicy.yaml
     set:
       global:
         ingress:
@@ -191,6 +192,29 @@ tests:
       - template: ingress.yaml
         hasDocuments:
           count: 1
+
+  - it: should fail when both oidcProtected and basicAuth are enabled
+    template: gateway-securitypolicy.yaml
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          basicAuth:
+            enabled: true
+            secretName: my-htpasswd
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.oidcProtected and gateway.basicAuth.enabled cannot both be true on the same service. Pick one auth method."
 
   - it: should fail when service explicitly enables both gateway and ingress
     template: ingress.yaml

--- a/stack/tests/gateway_validation_test.yaml
+++ b/stack/tests/gateway_validation_test.yaml
@@ -193,6 +193,32 @@ tests:
         hasDocuments:
           count: 1
 
+  - it: should auto-disable ingress when a service sets only gateway config keys (no explicit enabled) with global ingress on
+    templates:
+      - httproute.yaml
+      - ingress.yaml
+    set:
+      global:
+        ingress:
+          enabled: true
+          host: default.example.com
+        gateway:
+          host: api.example.com
+      services:
+        svc:
+          gateway:
+            cors:
+              enabled: true
+              allowOrigins:
+                - https://app.example.com
+    asserts:
+      - template: httproute.yaml
+        hasDocuments:
+          count: 1
+      - template: ingress.yaml
+        hasDocuments:
+          count: 0
+
   - it: should fail when both oidcProtected and basicAuth are enabled
     template: gateway-securitypolicy.yaml
     set:

--- a/stack/tests/tlsroute_test.yaml
+++ b/stack/tests/tlsroute_test.yaml
@@ -1,0 +1,110 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test gateway TLSRoute (passthrough)
+templates:
+  - tlsroute.yaml
+  - httproute.yaml
+tests:
+  - it: should not create a TLSRoute when tlsPassthrough is disabled
+    template: tlsroute.yaml
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a v1 TLSRoute with all hostnames when enabled
+    template: tlsroute.yaml
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: passthrough.example.com
+          tlsPassthrough:
+            enabled: true
+          rules:
+            - host: passthrough2.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        isKind:
+          of: TLSRoute
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1
+      - documentIndex: 0
+        contains:
+          path: spec.hostnames
+          content: passthrough.example.com
+      - documentIndex: 0
+        contains:
+          path: spec.hostnames
+          content: passthrough2.example.com
+      - documentIndex: 0
+        equal:
+          path: spec.parentRefs[0].name
+          value: envoy-gateway
+      - documentIndex: 0
+        notExists:
+          path: spec.parentRefs[0].sectionName
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: release-name-stack-service1
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should pin sectionName when set
+    template: tlsroute.yaml
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: passthrough.example.com
+          tlsPassthrough:
+            enabled: true
+            sectionName: tls-passthrough-0
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.parentRefs[0].sectionName
+          value: tls-passthrough-0
+
+  - it: should suppress the L7 HTTPRoute when tlsPassthrough is enabled
+    template: httproute.yaml
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: passthrough.example.com
+          tlsPassthrough:
+            enabled: true
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -254,6 +254,76 @@
                 }
               }
             },
+            "backendTLS": {
+              "description": "TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)",
+              "type": "object",
+              "properties": {
+                "caCertificateRefs": {
+                  "description": "ConfigMap refs holding the CA bundle for self-signed/internal upstreams",
+                  "type": "array"
+                },
+                "enabled": {
+                  "description": "Enable upstream TLS",
+                  "type": "boolean"
+                },
+                "hostname": {
+                  "description": "SNI/validation hostname presented by the upstream (required when enabled)",
+                  "type": "string"
+                },
+                "wellKnownCACertificates": {
+                  "description": "Use the System trust store, or set \"\" and use caCertificateRefs for a private CA",
+                  "type": "string"
+                }
+              }
+            },
+            "basicAuth": {
+              "description": "HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Enable basic auth",
+                  "type": "boolean"
+                },
+                "secretName": {
+                  "description": "Name of an Opaque Secret with a .htpasswd key",
+                  "type": "string"
+                }
+              }
+            },
+            "cors": {
+              "description": "CORS via a SecurityPolicy",
+              "type": "object",
+              "properties": {
+                "allowCredentials": {
+                  "description": "Allow credentials",
+                  "type": "boolean"
+                },
+                "allowHeaders": {
+                  "description": "Allowed request headers",
+                  "type": "array"
+                },
+                "allowMethods": {
+                  "description": "Allowed methods",
+                  "type": "array"
+                },
+                "allowOrigins": {
+                  "description": "Allowed origins (string patterns)",
+                  "type": "array"
+                },
+                "enabled": {
+                  "description": "Enable CORS",
+                  "type": "boolean"
+                },
+                "exposeHeaders": {
+                  "description": "Response headers exposed to the browser",
+                  "type": "array"
+                },
+                "maxAge": {
+                  "description": "Preflight cache duration (e.g. \"1h\"), empty omits it",
+                  "type": "string"
+                }
+              }
+            },
             "enabled": {
               "description": "Enable Gateway API HTTPRoute (alternative to Ingress)",
               "type": "boolean"
@@ -269,6 +339,14 @@
             "host": {
               "description": "Hostname for HTTPRoute",
               "type": "string"
+            },
+            "hostRewrite": {
+              "description": "Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it",
+              "type": "string"
+            },
+            "ipAllowList": {
+              "description": "Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it",
+              "type": "array"
             },
             "oidcProtected": {
               "description": "Enable OIDC protection via Envoy Gateway SecurityPolicy (requires oidcProxyGateway configuration)",
@@ -291,6 +369,86 @@
                 }
               }
             },
+            "rateLimit": {
+              "description": "Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Enable local rate limiting",
+                  "type": "boolean"
+                },
+                "requests": {
+                  "description": "Allowed requests per unit",
+                  "type": "integer"
+                },
+                "unit": {
+                  "description": "Rate limit unit (Second, Minute, Hour, Day)",
+                  "type": "string"
+                }
+              }
+            },
+            "redirect": {
+              "description": "Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Enable a redirect-only route",
+                  "type": "boolean"
+                },
+                "hostname": {
+                  "description": "Target hostname, empty keeps the request host",
+                  "type": "string"
+                },
+                "path": {
+                  "description": "Replacement full path via ReplaceFullPath, empty keeps the path",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Target scheme, e.g. https",
+                  "type": "string"
+                },
+                "statusCode": {
+                  "description": "Redirect status code (301 or 302)",
+                  "type": "integer"
+                }
+              }
+            },
+            "requestHeaders": {
+              "description": "Request header modifications (HTTPRoute RequestHeaderModifier filter)",
+              "type": "object",
+              "properties": {
+                "add": {
+                  "description": "Headers to add, list of {name,value}",
+                  "type": "array"
+                },
+                "remove": {
+                  "description": "Header names to remove",
+                  "type": "array"
+                },
+                "set": {
+                  "description": "Headers to set, list of {name,value}",
+                  "type": "array"
+                }
+              }
+            },
+            "responseHeaders": {
+              "description": "Response header modifications (HTTPRoute ResponseHeaderModifier filter)",
+              "type": "object",
+              "properties": {
+                "add": {
+                  "description": "Headers to add, list of {name,value}",
+                  "type": "array"
+                },
+                "remove": {
+                  "description": "Header names to remove",
+                  "type": "array"
+                },
+                "set": {
+                  "description": "Headers to set, list of {name,value}",
+                  "type": "array"
+                }
+              }
+            },
             "rules": {
               "description": "List of additional HTTPRoute rules with custom hosts. Each entry takes host, optional paths, and an optional vanity block (enabled, hostname, clusterIssuer) that renders a per-host ListenerSet so the extra host can be a vanity domain, mirroring gateway.vanity",
               "type": "array"
@@ -298,6 +456,42 @@
             "sectionName": {
               "description": "Optional section name (listener name) on the Gateway",
               "type": "string"
+            },
+            "sessionAffinity": {
+              "description": "Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)",
+              "type": "object",
+              "properties": {
+                "cookieName": {
+                  "description": "Affinity cookie name",
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "Enable consistent-hash cookie session affinity",
+                  "type": "boolean"
+                },
+                "ttl": {
+                  "description": "Affinity cookie TTL",
+                  "type": "string"
+                }
+              }
+            },
+            "timeouts": {
+              "description": "HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy",
+              "type": "object",
+              "properties": {
+                "backendRequest": {
+                  "description": "Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be \u003c= request",
+                  "type": "string"
+                },
+                "connect": {
+                  "description": "Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default",
+                  "type": "string"
+                },
+                "request": {
+                  "description": "Overall request timeout (HTTPRoute rules[].timeouts.request). Set \"0s\" to disable, e.g. for streaming or websockets",
+                  "type": "string"
+                }
+              }
             },
             "vanity": {
               "description": "Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway \u003e= v1.8 and cert-manager \u003e= v1.20)",

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -493,6 +493,20 @@
                 }
               }
             },
+            "tlsPassthrough": {
+              "description": "TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service",
+                  "type": "boolean"
+                },
+                "sectionName": {
+                  "description": "Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case",
+                  "type": "string"
+                }
+              }
+            },
             "vanity": {
               "description": "Self-serve public/vanity-domain TLS via a tenant-owned Gateway API ListenerSet (requires Envoy Gateway \u003e= v1.8 and cert-manager \u003e= v1.20)",
               "type": "object",

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -275,6 +275,9 @@ global: # @schema description: Global configuration for the stack - this serves 
       statusCode: 301 # @schema description: Redirect status code (301 or 302)
       hostname: "" # @schema description: Target hostname, empty keeps the request host
       path: "" # @schema description: Replacement full path via ReplaceFullPath, empty keeps the path
+    tlsPassthrough: # @schema description: TLS passthrough via a TLSRoute (the Gateway does not terminate TLS). Mutually exclusive with the L7 gateway features, and requires a Passthrough listener on the shared Gateway
+      enabled: false # @schema description: Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
+      sectionName: "" # @schema description: Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
 
   nodeSelector:
     kubernetes.io/arch: arm64 # @schema description: Node selector for architecture

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -231,6 +231,50 @@ global: # @schema description: Global configuration for the stack - this serves 
       clusterIssuer: letsencrypt-prod-eg # @schema description: cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
     annotations: # @schema description: Annotations to add to HTTPRoute resources
       external-dns.alpha.kubernetes.io/ttl: "60"
+    timeouts: # @schema description: HTTPRoute timeouts. request maps to nginx proxy-read and send-timeout. connect (optional) renders a BackendTrafficPolicy
+      request: "60s" # @schema description: Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
+      backendRequest: "60s" # @schema description: Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
+      connect: "" # @schema description: Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
+    sessionAffinity: # @schema description: Cookie-based sticky sessions via a BackendTrafficPolicy. Off by default (the ingress cookie-affinity default is not carried to the gateway)
+      enabled: false # @schema description: Enable consistent-hash cookie session affinity
+      cookieName: argus_sticky_session # @schema description: Affinity cookie name
+      ttl: "600s" # @schema description: Affinity cookie TTL
+    rateLimit: # @schema description: Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)
+      enabled: false # @schema description: Enable local rate limiting
+      requests: 0 # @schema description: Allowed requests per unit
+      unit: Second # @schema description: Rate limit unit (Second, Minute, Hour, Day)
+    basicAuth: # @schema description: HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected
+      enabled: false # @schema description: Enable basic auth
+      secretName: "" # @schema description: Name of an Opaque Secret with a .htpasswd key
+    cors: # @schema description: CORS via a SecurityPolicy
+      enabled: false # @schema description: Enable CORS
+      allowOrigins: [] # @schema description: Allowed origins (string patterns)
+      allowMethods: [] # @schema description: Allowed methods
+      allowHeaders: [] # @schema description: Allowed request headers
+      exposeHeaders: [] # @schema description: Response headers exposed to the browser
+      allowCredentials: false # @schema description: Allow credentials
+      maxAge: "" # @schema description: Preflight cache duration (e.g. "1h"), empty omits it
+    ipAllowList: [] # @schema description: Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it
+    backendTLS: # @schema description: TLS to the upstream Service via a BackendTLSPolicy (gateway.networking.k8s.io/v1)
+      enabled: false # @schema description: Enable upstream TLS
+      hostname: "" # @schema description: SNI/validation hostname presented by the upstream (required when enabled)
+      wellKnownCACertificates: System # @schema description: Use the System trust store, or set "" and use caCertificateRefs for a private CA
+      caCertificateRefs: [] # @schema description: ConfigMap refs holding the CA bundle for self-signed/internal upstreams
+    hostRewrite: "" # @schema description: Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it
+    requestHeaders: # @schema description: Request header modifications (HTTPRoute RequestHeaderModifier filter)
+      set: [] # @schema description: Headers to set, list of {name,value}
+      add: [] # @schema description: Headers to add, list of {name,value}
+      remove: [] # @schema description: Header names to remove
+    responseHeaders: # @schema description: Response header modifications (HTTPRoute ResponseHeaderModifier filter)
+      set: [] # @schema description: Headers to set, list of {name,value}
+      add: [] # @schema description: Headers to add, list of {name,value}
+      remove: [] # @schema description: Header names to remove
+    redirect: # @schema description: Whole-route redirect via an HTTPRoute RequestRedirect filter, replaces backend routing for the host
+      enabled: false # @schema description: Enable a redirect-only route
+      scheme: "" # @schema description: Target scheme, e.g. https
+      statusCode: 301 # @schema description: Redirect status code (301 or 302)
+      hostname: "" # @schema description: Target hostname, empty keeps the request host
+      path: "" # @schema description: Replacement full path via ReplaceFullPath, empty keeps the path
 
   nodeSelector:
     kubernetes.io/arch: arm64 # @schema description: Node selector for architecture


### PR DESCRIPTION
## Motivation

The stack chart's nginx `ingress` path already supports a rich set of behaviors that app teams rely on today — timeouts, cookie session affinity, basic auth, CORS, IP allowlists, header rewrites, redirects, backend TLS, TLS passthrough — mostly via `nginx.ingress.kubernetes.io/*` annotations and chart defaults. The Envoy `gateway` path, by contrast, only did routing (`enabled`/`host`/`paths`/`rules`/`vanity`/`oidcProtected`), rendering an HTTPRoute with just `matches` + `backendRefs`.

That gap means a team migrating a service from ingress to gateway silently loses behavior, or has to hand-author raw `SecurityPolicy` / `BackendTrafficPolicy` / `BackendTLSPolicy` / `TLSRoute` objects via `extraObjects` — which stack owners don't do.

**This PR brings the gateway path to parity with what nginx ingress already supports**, exposing each capability as a first-class `gateway.*` value so an ingress→gateway migration is a faithful, self-serve values change.

## Parity mapping (nginx ingress -> gateway value -> rendered object)

| nginx ingress behavior | new `gateway.*` value | Renders |
| --- | --- | --- |
| `proxy-read/send-timeout` | `gateway.timeouts.request` / `backendRequest` (default `60s`) | HTTPRoute `rules[].timeouts` |
| `proxy-connect-timeout` | `gateway.timeouts.connect` | BackendTrafficPolicy `timeout.tcp.connectTimeout` |
| `affinity: cookie` + `session-cookie-*` | `gateway.sessionAffinity` | BackendTrafficPolicy consistent-hash cookie |
| `limit-rps` | `gateway.rateLimit` | BackendTrafficPolicy local rate limit |
| `auth-type: basic` | `gateway.basicAuth` | SecurityPolicy `basicAuth` |
| CORS snippet | `gateway.cors` | SecurityPolicy `cors` |
| `whitelist-source-range` | `gateway.ipAllowList` | SecurityPolicy `authorization` |
| `backend-protocol: HTTPS` + `proxy_ssl_*` | `gateway.backendTLS` | BackendTLSPolicy (`gateway.networking.k8s.io/v1`) |
| `upstream-vhost` | `gateway.hostRewrite` | HTTPRoute `URLRewrite` filter |
| header `proxy_set_header` snippets | `gateway.requestHeaders` / `responseHeaders` | HTTPRoute header-modifier filters |
| `ssl-redirect` / `rewrite ... redirect` | `gateway.redirect` | HTTPRoute `RequestRedirect` rule |
| `ssl-passthrough` | `gateway.tlsPassthrough` | TLSRoute (`gateway.networking.k8s.io/v1`) + a Passthrough listener on the shared Gateway |

(GeoIP and a hard request-body-size cap are intentionally out of scope — platform-level, or no faithful per-route EG 1.8 equivalent.)

## Design notes

- **One SecurityPolicy per route.** Envoy Gateway accepts only the oldest SecurityPolicy targeting a route and marks the rest `Conflicted`, so OIDC rendering moved out of `gateway-oidc.yaml` into the new consolidated `gateway-securitypolicy.yaml` (oidc + basicAuth + cors + authorization in one object). It keeps the `-oidc` object name when OIDC is on to avoid a delete/recreate on existing OIDC stacks.
- `oidcProtected` and `basicAuth.enabled` are mutually exclusive (validated); `cors`/`ipAllowList` compose with either.
- **Session affinity stays off by default** — the ingress cookie-affinity default is vestigial (a decommissioned-app remnant) and intentionally not carried to the gateway.
- **TLS passthrough.** `gateway.tlsPassthrough.enabled` renders a `TLSRoute` and suppresses all L7 objects for that service (no termination). It attaches to the shared Gateway by hostname. The shared Gateway gets the matching Passthrough listener from `envoy-gateway-resources` (`tlsPassthrough.{enabled,hostnames}`, **off by default**, one TLS listener per hostname). Passthrough hostnames must be specific (not the cluster wildcard) to avoid an SNI conflict with the Terminate listener.

## Validation

- Verified against Envoy Gateway v1.8 docs and the live fleet (BackendTLSPolicy / TLSRoute at `gateway.networking.k8s.io/v1`; the `gateway.envoyproxy.io/v1alpha1` policies; Services use a named `http` port for BackendTLSPolicy `sectionName`).
- `helm lint` clean. **`helm unittest`: stack 154/154, envoy-gateway-resources 82/82** — new suites for SecurityPolicy / BackendTrafficPolicy / BackendTLSPolicy / TLSRoute / passthrough-listener, plus timeouts/filters/redirect coverage; existing OIDC tests split into HTTPRoute (`gateway-oidc`) and SecurityPolicy (`gateway-securitypolicy`) suites.
- `values.schema.json` regenerated for both charts (all new keys present; required because `services` uses `unevaluatedProperties: false`). READMEs regenerated by the Charts Update CI.
- stack `2.41.0` -> `2.43.0`; envoy-gateway-resources `0.1.0` -> `0.2.0`.

## Follow-up

Once merged, the routing docs (Confluence migration page + `argus/.../envoy_routing.md`) get updated to show the `gateway.*` values instead of raw policy YAML. The shared-Gateway passthrough listener (`envoy-gateway-resources` `tlsPassthrough`) is opt-in per cluster and depends on EG v1.8 fleet-wide (`core-platform-prod-eks` upgrade tracked in CCIE-6822).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
