### PR TITLE
feat: geo-block the HTTPS :443 listener (envoy-gateway-resources)

### DIFF
--- a/envoy-gateway-resources/Chart.yaml
+++ b/envoy-gateway-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: envoy-gateway-resources
 description: GatewayClass, Gateway, and ClusterIssuer for Envoy Gateway (per-cluster hostname and DNS)
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "1"

--- a/envoy-gateway-resources/templates/geoip-policy.yaml
+++ b/envoy-gateway-resources/templates/geoip-policy.yaml
@@ -1,3 +1,18 @@
+{{- define "envoy-gateway-resources.geoipFilter" -}}
+name: envoy.filters.http.geoip
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.geoip.v3.Geoip
+  provider:
+    name: envoy.geoip_providers.maxmind
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.geoip_providers.maxmind.v3.MaxMindConfig
+      common_provider_config:
+        geo_headers_to_add:
+          country: "x-envoy-geoip-country-code"
+          city: "x-envoy-geoip-city"
+          region: "x-envoy-geoip-region"
+      city_db_path: /etc/envoy/geoip/GeoLite2-Country.mmdb
+{{- end }}
 {{- if .Values.geoip.enabled }}
 ---
 # EnvoyPatchPolicy to inject native Envoy GeoIP filter
@@ -14,25 +29,20 @@ spec:
   type: JSONPatch
   jsonPatches:
   - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
-    # Patch the HTTP connection manager to add GeoIP filter
     name: envoy-gateway/{{ .Values.gatewayName }}/http
     operation:
       op: add
       path: "/default_filter_chain/filters/0/typed_config/http_filters/0"
       value:
-        name: envoy.filters.http.geoip
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.http.geoip.v3.Geoip
-          provider:
-            name: envoy.geoip_providers.maxmind
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.geoip_providers.maxmind.v3.MaxMindConfig
-              common_provider_config:
-                geo_headers_to_add:
-                  country: "x-envoy-geoip-country-code"
-                  city: "x-envoy-geoip-city"
-                  region: "x-envoy-geoip-region"
-              city_db_path: /etc/envoy/geoip/GeoLite2-Country.mmdb
+        {{- include "envoy-gateway-resources.geoipFilter" . | nindent 8 }}
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: envoy-gateway/{{ .Values.gatewayName }}/https
+    operation:
+      op: add
+      jsonPath: '$.filter_chains[*].filters[?@.name=="envoy.filters.network.http_connection_manager"].typed_config'
+      path: "/http_filters/0"
+      value:
+        {{- include "envoy-gateway-resources.geoipFilter" . | nindent 8 }}
 ---
 # EnvoyExtensionPolicy for Lua country blocking filter
 apiVersion: gateway.envoyproxy.io/v1alpha1


### PR DESCRIPTION
## Summary

Country geo-blocking was inert for real traffic: the GeoIP `EnvoyPatchPolicy` patched only the HTTP `:80` listener's single `default_filter_chain`, so the native `geoip` filter never reached **HTTPS `:443`** — the listener that actually serves requests.

- Adds a second JSONPatch targeting the HTTPS listener. HTTPS has **one filter chain per SNI/hostname** (cluster wildcard + each vanity ListenerSet) and the count is dynamic, so a fixed `filter_chains/0` index can't work — it uses a `jsonPath` selector matching the `http_connection_manager` `typed_config` across all chains.
- Factors the filter config into a shared helper so `:80` and `:443` stay in sync.
- Chart `0.3.0 → 0.4.0`. Deploys via ArgoCD tracking git `HEAD`, so it rolls out fleet-wide on merge.

Rebased onto main and **scoped down to this fix**: the branch's original data-plane autoscaling half is dropped (superseded by #493, which already shipped `EnvoyProxy` resources + `envoyHpa` min 3 / max 20) — that was the source of the merge conflict.

## Test plan

- `helm lint` passes; `helm template --show-only templates/geoip-policy.yaml` renders patches for **both** `.../http` and `.../https` listeners.
- Validated on dev-core-platform: geoip present on all HTTPS filter chains; request from a **Ukraine** node → **451**, from the **US** → **200**.
- Post-merge: re-verify geofencing over HTTPS on a representative cluster once the rollout lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)