### PR TITLE
feat: ip target-type, deletion protection, and hardened NLB annotations

### DIFF
--- a/envoy-gateway-nlb/Chart.yaml
+++ b/envoy-gateway-nlb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: envoy-gateway-nlb
 description: NLB LoadBalancer Services fronting the Envoy Gateway proxy (external + optional internal)
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1"

--- a/envoy-gateway-nlb/README.md
+++ b/envoy-gateway-nlb/README.md
@@ -12,6 +12,7 @@
 | ---------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
 | - [additionalInternalNLBs](#additionalInternalNLBs ) | No      | array   | No         | -          | -                 |
 | - [baseDomain](#baseDomain )                         | No      | string  | No         | -          | -                 |
+| - [deletionProtection](#deletionProtection )         | No      | boolean | No         | -          | -                 |
 | - [externalHostnamePrefix](#externalHostnamePrefix ) | No      | string  | No         | -          | -                 |
 | - [gatewayName](#gatewayName )                       | No      | string  | No         | -          | -                 |
 | - [gatewayNamespace](#gatewayNamespace )             | No      | string  | No         | -          | -                 |
@@ -43,28 +44,35 @@
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="externalHostnamePrefix"></a>3. Property `envoy-gateway-nlb > externalHostnamePrefix`
+## <a name="deletionProtection"></a>3. Property `envoy-gateway-nlb > deletionProtection`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+## <a name="externalHostnamePrefix"></a>4. Property `envoy-gateway-nlb > externalHostnamePrefix`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayName"></a>4. Property `envoy-gateway-nlb > gatewayName`
+## <a name="gatewayName"></a>5. Property `envoy-gateway-nlb > gatewayName`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayNamespace"></a>5. Property `envoy-gateway-nlb > gatewayNamespace`
+## <a name="gatewayNamespace"></a>6. Property `envoy-gateway-nlb > gatewayNamespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="internal"></a>6. Property `envoy-gateway-nlb > internal`
+## <a name="internal"></a>7. Property `envoy-gateway-nlb > internal`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -76,35 +84,35 @@
 | ------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
 | - [enabled](#internal_enabled ) | No      | boolean | No         | -          | -                 |
 
-### <a name="internal_enabled"></a>6.1. Property `envoy-gateway-nlb > internal > enabled`
+### <a name="internal_enabled"></a>7.1. Property `envoy-gateway-nlb > internal > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="internalHostnamePrefix"></a>7. Property `envoy-gateway-nlb > internalHostnamePrefix`
+## <a name="internalHostnamePrefix"></a>8. Property `envoy-gateway-nlb > internalHostnamePrefix`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="proxyNamespace"></a>8. Property `envoy-gateway-nlb > proxyNamespace`
+## <a name="proxyNamespace"></a>9. Property `envoy-gateway-nlb > proxyNamespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="proxyProtocolV2"></a>9. Property `envoy-gateway-nlb > proxyProtocolV2`
+## <a name="proxyProtocolV2"></a>10. Property `envoy-gateway-nlb > proxyProtocolV2`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="tags"></a>10. Property `envoy-gateway-nlb > tags`
+## <a name="tags"></a>11. Property `envoy-gateway-nlb > tags`
 
 |                           |                  |
 | ------------------------- | ---------------- |

--- a/envoy-gateway-nlb/README.md
+++ b/envoy-gateway-nlb/README.md
@@ -8,19 +8,22 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                             | Pattern | Type    | Deprecated | Definition | Title/Description |
-| ---------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
-| - [additionalInternalNLBs](#additionalInternalNLBs ) | No      | array   | No         | -          | -                 |
-| - [baseDomain](#baseDomain )                         | No      | string  | No         | -          | -                 |
-| - [deletionProtection](#deletionProtection )         | No      | boolean | No         | -          | -                 |
-| - [externalHostnamePrefix](#externalHostnamePrefix ) | No      | string  | No         | -          | -                 |
-| - [gatewayName](#gatewayName )                       | No      | string  | No         | -          | -                 |
-| - [gatewayNamespace](#gatewayNamespace )             | No      | string  | No         | -          | -                 |
-| - [internal](#internal )                             | No      | object  | No         | -          | -                 |
-| - [internalHostnamePrefix](#internalHostnamePrefix ) | No      | string  | No         | -          | -                 |
-| - [proxyNamespace](#proxyNamespace )                 | No      | string  | No         | -          | -                 |
-| - [proxyProtocolV2](#proxyProtocolV2 )               | No      | boolean | No         | -          | -                 |
-| - [tags](#tags )                                     | No      | object  | No         | -          | -                 |
+| Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                                          |
+| ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| - [additionalInternalNLBs](#additionalInternalNLBs ) | No      | array            | No         | -          | -                                                                                                                                                                                          |
+| - [baseDomain](#baseDomain )                         | No      | string           | No         | -          | -                                                                                                                                                                                          |
+| - [crossZone](#crossZone )                           | No      | boolean          | No         | -          | -                                                                                                                                                                                          |
+| - [deletionProtection](#deletionProtection )         | No      | boolean          | No         | -          | Enable NLB deletion protection. While enabled, deleting or recreating the Service strands the NLB in Terminating, so set this false and let it sync before any Service delete or recreate. |
+| - [externalHostnamePrefix](#externalHostnamePrefix ) | No      | string           | No         | -          | -                                                                                                                                                                                          |
+| - [externalTargetType](#externalTargetType )         | No      | enum (of string) | No         | -          | -                                                                                                                                                                                          |
+| - [gatewayName](#gatewayName )                       | No      | string           | No         | -          | -                                                                                                                                                                                          |
+| - [gatewayNamespace](#gatewayNamespace )             | No      | string           | No         | -          | -                                                                                                                                                                                          |
+| - [internal](#internal )                             | No      | object           | No         | -          | -                                                                                                                                                                                          |
+| - [internalHostnamePrefix](#internalHostnamePrefix ) | No      | string           | No         | -          | -                                                                                                                                                                                          |
+| - [proxyNamespace](#proxyNamespace )                 | No      | string           | No         | -          | -                                                                                                                                                                                          |
+| - [proxyProtocolV2](#proxyProtocolV2 )               | No      | boolean          | No         | -          | -                                                                                                                                                                                          |
+| - [tags](#tags )                                     | No      | object           | No         | -          | -                                                                                                                                                                                          |
+| - [targetGroup](#targetGroup )                       | No      | object           | No         | -          | -                                                                                                                                                                                          |
 
 ## <a name="additionalInternalNLBs"></a>1. Property `envoy-gateway-nlb > additionalInternalNLBs`
 
@@ -44,35 +47,55 @@
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="deletionProtection"></a>3. Property `envoy-gateway-nlb > deletionProtection`
+## <a name="crossZone"></a>3. Property `envoy-gateway-nlb > crossZone`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="externalHostnamePrefix"></a>4. Property `envoy-gateway-nlb > externalHostnamePrefix`
+## <a name="deletionProtection"></a>4. Property `envoy-gateway-nlb > deletionProtection`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable NLB deletion protection. While enabled, deleting or recreating the Service strands the NLB in Terminating, so set this false and let it sync before any Service delete or recreate.
+
+## <a name="externalHostnamePrefix"></a>5. Property `envoy-gateway-nlb > externalHostnamePrefix`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayName"></a>5. Property `envoy-gateway-nlb > gatewayName`
+## <a name="externalTargetType"></a>6. Property `envoy-gateway-nlb > externalTargetType`
+
+|              |                    |
+| ------------ | ------------------ |
+| **Type**     | `enum (of string)` |
+| **Required** | No                 |
+
+Must be one of:
+* "instance"
+* "ip"
+
+## <a name="gatewayName"></a>7. Property `envoy-gateway-nlb > gatewayName`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayNamespace"></a>6. Property `envoy-gateway-nlb > gatewayNamespace`
+## <a name="gatewayNamespace"></a>8. Property `envoy-gateway-nlb > gatewayNamespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="internal"></a>7. Property `envoy-gateway-nlb > internal`
+## <a name="internal"></a>9. Property `envoy-gateway-nlb > internal`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -84,40 +107,67 @@
 | ------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
 | - [enabled](#internal_enabled ) | No      | boolean | No         | -          | -                 |
 
-### <a name="internal_enabled"></a>7.1. Property `envoy-gateway-nlb > internal > enabled`
+### <a name="internal_enabled"></a>9.1. Property `envoy-gateway-nlb > internal > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="internalHostnamePrefix"></a>8. Property `envoy-gateway-nlb > internalHostnamePrefix`
+## <a name="internalHostnamePrefix"></a>10. Property `envoy-gateway-nlb > internalHostnamePrefix`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="proxyNamespace"></a>9. Property `envoy-gateway-nlb > proxyNamespace`
+## <a name="proxyNamespace"></a>11. Property `envoy-gateway-nlb > proxyNamespace`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="proxyProtocolV2"></a>10. Property `envoy-gateway-nlb > proxyProtocolV2`
+## <a name="proxyProtocolV2"></a>12. Property `envoy-gateway-nlb > proxyProtocolV2`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="tags"></a>11. Property `envoy-gateway-nlb > tags`
+## <a name="tags"></a>13. Property `envoy-gateway-nlb > tags`
 
 |                           |                  |
 | ------------------------- | ---------------- |
 | **Type**                  | `object`         |
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
+
+## <a name="targetGroup"></a>14. Property `envoy-gateway-nlb > targetGroup`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                                             | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [unhealthyConnectionTermination](#targetGroup_unhealthyConnectionTermination )     | No      | boolean | No         | -          | -                 |
+| - [unhealthyDrainingIntervalSeconds](#targetGroup_unhealthyDrainingIntervalSeconds ) | No      | integer | No         | -          | -                 |
+
+### <a name="targetGroup_unhealthyConnectionTermination"></a>14.1. Property `envoy-gateway-nlb > targetGroup > unhealthyConnectionTermination`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+### <a name="targetGroup_unhealthyDrainingIntervalSeconds"></a>14.2. Property `envoy-gateway-nlb > targetGroup > unhealthyDrainingIntervalSeconds`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
 
 ----------------------------------------------------------------------------------------------------------------------------

--- a/envoy-gateway-nlb/templates/_helpers.tpl
+++ b/envoy-gateway-nlb/templates/_helpers.tpl
@@ -22,3 +22,27 @@ gateway.envoyproxy.io/owning-gateway-namespace: {{ .Values.gatewayNamespace }}
 {{- end -}}
 {{- join "," $pairs -}}
 {{- end }}
+
+{{- define "envoy-gateway-nlb.lbAttributes" -}}
+{{- $pairs := list -}}
+{{- if .Values.deletionProtection -}}
+{{- $pairs = append $pairs "deletion_protection.enabled=true" -}}
+{{- end -}}
+{{- if .Values.crossZone -}}
+{{- $pairs = append $pairs "load_balancing.cross_zone.enabled=true" -}}
+{{- end -}}
+{{- join "," $pairs -}}
+{{- end }}
+
+{{- define "envoy-gateway-nlb.targetGroupAttributes" -}}
+{{- $tg := .Values.targetGroup | default dict -}}
+{{- $pairs := list "preserve_client_ip.enabled=true" -}}
+{{- if .Values.proxyProtocolV2 -}}
+{{- $pairs = append $pairs "proxy_protocol_v2.enabled=true" -}}
+{{- end -}}
+{{- if not $tg.unhealthyConnectionTermination -}}
+{{- $pairs = append $pairs "target_health_state.unhealthy.connection_termination.enabled=false" -}}
+{{- $pairs = append $pairs (printf "target_health_state.unhealthy.draining_interval_seconds=%d" (int $tg.unhealthyDrainingIntervalSeconds)) -}}
+{{- end -}}
+{{- join "," $pairs -}}
+{{- end }}

--- a/envoy-gateway-nlb/templates/nlb-service.yaml
+++ b/envoy-gateway-nlb/templates/nlb-service.yaml
@@ -7,6 +7,9 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: external
+    {{- if .Values.deletionProtection }}
+    service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+    {{- end }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.externalHostnamePrefix }}.{{ .Values.baseDomain }}
     {{- if .Values.proxyProtocolV2 }}
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
@@ -35,6 +38,9 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
+    {{- if .Values.deletionProtection }}
+    service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+    {{- end }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.internalHostnamePrefix }}.{{ .Values.baseDomain }}
     {{- if .Values.tags }}
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" . | quote }}
@@ -61,6 +67,9 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
+    {{- if $.Values.deletionProtection }}
+    service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+    {{- end }}
     external-dns.alpha.kubernetes.io/hostname: {{ .hostname }}
     {{- if $.Values.tags }}
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" $ | quote }}

--- a/envoy-gateway-nlb/templates/nlb-service.yaml
+++ b/envoy-gateway-nlb/templates/nlb-service.yaml
@@ -4,16 +4,14 @@ metadata:
   name: nlb-envoy
   namespace: {{ .Values.proxyNamespace }}
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: {{ .Values.externalTargetType }}
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: external
-    {{- if .Values.deletionProtection }}
-    service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+    {{- with (include "envoy-gateway-nlb.lbAttributes" .) }}
+    service.beta.kubernetes.io/aws-load-balancer-attributes: {{ . | quote }}
     {{- end }}
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: {{ include "envoy-gateway-nlb.targetGroupAttributes" . | quote }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.externalHostnamePrefix }}.{{ .Values.baseDomain }}
-    {{- if .Values.proxyProtocolV2 }}
-    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
-    {{- end }}
     {{- if .Values.tags }}
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" . | quote }}
     {{- end }}
@@ -37,10 +35,10 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internal
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
-    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
-    {{- if .Values.deletionProtection }}
-    service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+    {{- with (include "envoy-gateway-nlb.lbAttributes" .) }}
+    service.beta.kubernetes.io/aws-load-balancer-attributes: {{ . | quote }}
     {{- end }}
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: {{ include "envoy-gateway-nlb.targetGroupAttributes" . | quote }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.internalHostnamePrefix }}.{{ .Values.baseDomain }}
     {{- if .Values.tags }}
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" . | quote }}
@@ -66,10 +64,10 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internal
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
-    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
-    {{- if $.Values.deletionProtection }}
-    service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+    {{- with (include "envoy-gateway-nlb.lbAttributes" $) }}
+    service.beta.kubernetes.io/aws-load-balancer-attributes: {{ . | quote }}
     {{- end }}
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: {{ include "envoy-gateway-nlb.targetGroupAttributes" $ | quote }}
     external-dns.alpha.kubernetes.io/hostname: {{ .hostname }}
     {{- if $.Values.tags }}
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "envoy-gateway-nlb.tags" $ | quote }}

--- a/envoy-gateway-nlb/tests/nlb-service_test.yaml
+++ b/envoy-gateway-nlb/tests/nlb-service_test.yaml
@@ -36,31 +36,67 @@ tests:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
           value: external
 
-  - it: should enable proxy protocol v2 by default
+  - it: should switch the external target type to ip when set
+    set:
+      externalTargetType: ip
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"]
+          value: ip
+
+  - it: should assemble target group attributes with proxy protocol and unhealthy draining by default
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
+          value: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true,target_health_state.unhealthy.connection_termination.enabled=false,target_health_state.unhealthy.draining_interval_seconds=300
+
+  - it: should keep target group attributes without proxy_protocol_v2 when proxy protocol is disabled
+    set:
+      proxyProtocolV2: false
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
+          value: preserve_client_ip.enabled=true,target_health_state.unhealthy.connection_termination.enabled=false,target_health_state.unhealthy.draining_interval_seconds=300
+
+  - it: should omit the unhealthy draining keys when connection termination is enabled
+    set:
+      targetGroup:
+        unhealthyConnectionTermination: true
     asserts:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
           value: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true
 
-  - it: should omit target group attributes when proxy protocol is disabled
-    set:
-      proxyProtocolV2: false
+  - it: should enable deletion protection and cross-zone by default
     asserts:
-      - notExists:
-          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]
+          value: deletion_protection.enabled=true,load_balancing.cross_zone.enabled=true
 
-  - it: should enable NLB deletion protection by default
+  - it: should emit only deletion protection when cross-zone is disabled
+    set:
+      crossZone: false
     asserts:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]
           value: deletion_protection.enabled=true
 
-  - it: should omit the attributes annotation when deletion protection is disabled
+  - it: should omit the attributes annotation when deletion protection and cross-zone are both disabled
     set:
       deletionProtection: false
+      crossZone: false
     asserts:
       - notExists:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]
+
+  - it: should not render any health check annotations (TCP on traffic port)
+    asserts:
+      - notExists:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol"]
+      - notExists:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-port"]
+      - notExists:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-path"]
 
   - it: should select the envoy proxy pods for the cluster-wide Gateway
     asserts:
@@ -125,7 +161,7 @@ tests:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"]
           value: env=dev,managedBy=argocd,owner=infra-eng
 
-  - it: should render the internal Service when enabled
+  - it: should render the internal Service with hardened attributes and keep the legacy type
     set:
       baseDomain: test-cluster.dev.czi.team
       internal:
@@ -153,11 +189,19 @@ tests:
           value: nlb-ip
         documentIndex: 1
       - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]
+          value: deletion_protection.enabled=true,load_balancing.cross_zone.enabled=true
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
+          value: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true,target_health_state.unhealthy.connection_termination.enabled=false,target_health_state.unhealthy.draining_interval_seconds=300
+        documentIndex: 1
+      - equal:
           path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
           value: access-gw-internal.test-cluster.dev.czi.team
         documentIndex: 1
 
-  - it: should render additional internal NLBs with their own hostnames
+  - it: should render additional internal NLBs with their own hostnames and hardened attributes
     set:
       additionalInternalNLBs:
         - name: loki
@@ -172,6 +216,14 @@ tests:
       - equal:
           path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
           value: loki.test-cluster.dev.czi.team
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]
+          value: deletion_protection.enabled=true,load_balancing.cross_zone.enabled=true
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
+          value: preserve_client_ip.enabled=true,proxy_protocol_v2.enabled=true,target_health_state.unhealthy.connection_termination.enabled=false,target_health_state.unhealthy.draining_interval_seconds=300
         documentIndex: 1
       - equal:
           path: spec.selector["gateway.envoyproxy.io/owning-gateway-name"]

--- a/envoy-gateway-nlb/tests/nlb-service_test.yaml
+++ b/envoy-gateway-nlb/tests/nlb-service_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"]
-          value: instance
+          value: ip
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]
           value: internet-facing
@@ -36,13 +36,13 @@ tests:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
           value: external
 
-  - it: should switch the external target type to ip when set
+  - it: should switch the external target type to instance when set
     set:
-      externalTargetType: ip
+      externalTargetType: instance
     asserts:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"]
-          value: ip
+          value: instance
 
   - it: should assemble target group attributes with proxy protocol and unhealthy draining by default
     asserts:

--- a/envoy-gateway-nlb/tests/nlb-service_test.yaml
+++ b/envoy-gateway-nlb/tests/nlb-service_test.yaml
@@ -49,6 +49,19 @@ tests:
       - notExists:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"]
 
+  - it: should enable NLB deletion protection by default
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]
+          value: deletion_protection.enabled=true
+
+  - it: should omit the attributes annotation when deletion protection is disabled
+    set:
+      deletionProtection: false
+    asserts:
+      - notExists:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]
+
   - it: should select the envoy proxy pods for the cluster-wide Gateway
     asserts:
       - equal:

--- a/envoy-gateway-nlb/values.schema.json
+++ b/envoy-gateway-nlb/values.schema.json
@@ -10,11 +10,22 @@
     "baseDomain": {
       "type": "string"
     },
+    "crossZone": {
+      "type": "boolean"
+    },
     "deletionProtection": {
+      "description": "Enable NLB deletion protection. While enabled, deleting or recreating the Service strands the NLB in Terminating, so set this false and let it sync before any Service delete or recreate.",
       "type": "boolean"
     },
     "externalHostnamePrefix": {
       "type": "string"
+    },
+    "externalTargetType": {
+      "type": "string",
+      "enum": [
+        "instance",
+        "ip"
+      ]
     },
     "gatewayName": {
       "type": "string"
@@ -41,6 +52,17 @@
     },
     "tags": {
       "type": "object"
+    },
+    "targetGroup": {
+      "type": "object",
+      "properties": {
+        "unhealthyConnectionTermination": {
+          "type": "boolean"
+        },
+        "unhealthyDrainingIntervalSeconds": {
+          "type": "integer"
+        }
+      }
     }
   }
 }

--- a/envoy-gateway-nlb/values.schema.json
+++ b/envoy-gateway-nlb/values.schema.json
@@ -10,6 +10,9 @@
     "baseDomain": {
       "type": "string"
     },
+    "deletionProtection": {
+      "type": "boolean"
+    },
     "externalHostnamePrefix": {
       "type": "string"
     },

--- a/envoy-gateway-nlb/values.yaml
+++ b/envoy-gateway-nlb/values.yaml
@@ -14,7 +14,7 @@ deletionProtection: true # @schema description: Enable NLB deletion protection. 
 
 crossZone: true
 
-externalTargetType: instance # @schema enum: [instance, ip]
+externalTargetType: ip # @schema enum: [instance, ip]
 
 targetGroup:
   unhealthyConnectionTermination: false

--- a/envoy-gateway-nlb/values.yaml
+++ b/envoy-gateway-nlb/values.yaml
@@ -10,7 +10,15 @@ internalHostnamePrefix: "access-gw-internal"
 
 proxyProtocolV2: true
 
-deletionProtection: true
+deletionProtection: true # @schema description: Enable NLB deletion protection. While enabled, deleting or recreating the Service strands the NLB in Terminating, so set this false and let it sync before any Service delete or recreate.
+
+crossZone: true
+
+externalTargetType: instance # @schema enum: [instance, ip]
+
+targetGroup:
+  unhealthyConnectionTermination: false
+  unhealthyDrainingIntervalSeconds: 300
 
 internal:
   enabled: false

--- a/envoy-gateway-nlb/values.yaml
+++ b/envoy-gateway-nlb/values.yaml
@@ -10,6 +10,8 @@ internalHostnamePrefix: "access-gw-internal"
 
 proxyProtocolV2: true
 
+deletionProtection: true
+
 internal:
   enabled: false
 


### PR DESCRIPTION
## Summary

Hardens the NLB Services fronting Envoy Gateway (~46–52 clusters), folding the 2026-06-25 deletion-protection SEV-2 fix together with the move to ip-target NLBs:

- **`ip` target type (default)** — the NLB registers pod IPs directly instead of NodePorts, enabling readiness-gated zero-drop proxy rolls; the switch preserves the LB ARN/DNS (target-group replacement only).
- **Deletion protection** on by default — the SEV-2 remediation; an in-place attribute change.
- **Cross-zone on by default** — a correctness requirement in ip mode, since the 4-AZ NLBs aren't guaranteed a pod in every AZ (an empty AZ would drop from DNS); its cost is negligible.
- **Graceful draining** of long-lived L4 connections through a transient unhealthy blip (`target_health_state.unhealthy.*`) rather than an immediate RST.
- **TCP health check on the traffic port** — an HTTP `/ready` check can't work while proxy-protocol-v2 is on the target group (the PROXY header is prepended to health checks on any port), which under strict PROXY is outage-class.
- Attribute annotations are assembled by helpers so each is a single comma-joined key; internal NLBs keep their legacy type and simply gain the hardened attributes.

## Live-tested on nonprod ✅

Validated end-to-end on the 3 clusters the nonprod ArgoCD manages (dev-cilium-test, dev-core-platform, core-platform-nonprod-eks) by pointing the nonprod appset at this branch (argus-infra-stacks#2705, merged):

- All three reconciled Synced/Healthy; both target groups swapped `instance`→`ip` with **all targets Healthy** on 10080/10443, LB ARN/DNS **unchanged**, and Envoy pods **did not restart** (TG-only swap).
- New ip target group carries `proxy_protocol_v2` + `preserve_client_ip` (the outage-class check under strict PROXY) — confirmed via `describe-target-group-attributes`.
- **Cluster healthchecks return 200** on all three (`healthcheck.<cluster>.dev.czi.team`).
- Every route class on dev-core-platform serves correctly through the ip data path: plain, vanity hostnames, CORS, rate-limit, mTLS all 200; the auth-gated route correctly returns 401 (SecurityPolicy enforced, not a failure).
- The one transient blip (a brief connection timeout on dev-cilium-test during its re-registration window) self-recovered — the expected TG-swap window, not a regression.

## Rollout (⚠️ read before merging)

The chart is synced from `HEAD`, so with `ip` as the default, **merging replaces the external target group on every non-overriding cluster on the next sync** — brief, per-gateway, fleet-wide. Prod clusters live under the prod ArgoCD (still on `main` = `instance` today). Stage prod by holding clusters on per-cluster `externalTargetType: instance` overrides removed wave by wave, and land the readiness-gate label before ip is live. Rollback of a completed swap is another swap, so prefer forward-fix.

## Test plan

- `helm lint` clean; `helm unittest` 18/18 — ip default, instance override, comma/empty attribute guards, proxy-protocol-off path, unhealthy-draining gating, and a lock that no health-check annotation renders.
- Full render (external + internal + additional) is valid YAML with one attributes / target-group-attributes key per Service.
- Nonprod live validation above (target health, healthchecks, per-route-class 200s, no pod churn) — clean go signal for prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)