### PR TITLE
feat: opt-in 2xx access-log filter (envoy-gateway-resources)

### DIFF
--- a/envoy-gateway-resources/README.md
+++ b/envoy-gateway-resources/README.md
@@ -10,6 +10,7 @@
 
 | Property                             | Pattern | Type   | Deprecated | Definition | Title/Description |
 | ------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [accessLog](#accessLog )           | No      | object | No         | -          | -                 |
 | - [alternateNames](#alternateNames ) | No      | array  | No         | -          | -                 |
 | - [autoscaling](#autoscaling )       | No      | object | No         | -          | -                 |
 | - [awsRegion](#awsRegion )           | No      | string | No         | -          | -                 |
@@ -23,7 +24,26 @@
 | - [serviceAccount](#serviceAccount ) | No      | object | No         | -          | -                 |
 | - [tlsPassthrough](#tlsPassthrough ) | No      | object | No         | -          | -                 |
 
-## <a name="alternateNames"></a>1. Property `envoy-gateway-resources > alternateNames`
+## <a name="accessLog"></a>1. Property `envoy-gateway-resources > accessLog`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                       | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ---------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [omitSuccessful](#accessLog_omitSuccessful ) | No      | boolean | No         | -          | -                 |
+
+### <a name="accessLog_omitSuccessful"></a>1.1. Property `envoy-gateway-resources > accessLog > omitSuccessful`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+## <a name="alternateNames"></a>2. Property `envoy-gateway-resources > alternateNames`
 
 |              |         |
 | ------------ | ------- |
@@ -38,7 +58,7 @@
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-## <a name="autoscaling"></a>2. Property `envoy-gateway-resources > autoscaling`
+## <a name="autoscaling"></a>3. Property `envoy-gateway-resources > autoscaling`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -53,49 +73,49 @@
 | - [minReplicas](#autoscaling_minReplicas )                                       | No      | integer | No         | -          | -                 |
 | - [targetCPUUtilizationPercentage](#autoscaling_targetCPUUtilizationPercentage ) | No      | integer | No         | -          | -                 |
 
-### <a name="autoscaling_enabled"></a>2.1. Property `envoy-gateway-resources > autoscaling > enabled`
+### <a name="autoscaling_enabled"></a>3.1. Property `envoy-gateway-resources > autoscaling > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-### <a name="autoscaling_maxReplicas"></a>2.2. Property `envoy-gateway-resources > autoscaling > maxReplicas`
+### <a name="autoscaling_maxReplicas"></a>3.2. Property `envoy-gateway-resources > autoscaling > maxReplicas`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `integer` |
 | **Required** | No        |
 
-### <a name="autoscaling_minReplicas"></a>2.3. Property `envoy-gateway-resources > autoscaling > minReplicas`
+### <a name="autoscaling_minReplicas"></a>3.3. Property `envoy-gateway-resources > autoscaling > minReplicas`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `integer` |
 | **Required** | No        |
 
-### <a name="autoscaling_targetCPUUtilizationPercentage"></a>2.4. Property `envoy-gateway-resources > autoscaling > targetCPUUtilizationPercentage`
+### <a name="autoscaling_targetCPUUtilizationPercentage"></a>3.4. Property `envoy-gateway-resources > autoscaling > targetCPUUtilizationPercentage`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `integer` |
 | **Required** | No        |
 
-## <a name="awsRegion"></a>3. Property `envoy-gateway-resources > awsRegion`
+## <a name="awsRegion"></a>4. Property `envoy-gateway-resources > awsRegion`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="baseDomain"></a>4. Property `envoy-gateway-resources > baseDomain`
+## <a name="baseDomain"></a>5. Property `envoy-gateway-resources > baseDomain`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="envoyService"></a>5. Property `envoy-gateway-resources > envoyService`
+## <a name="envoyService"></a>6. Property `envoy-gateway-resources > envoyService`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -107,21 +127,21 @@
 | ----------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [type](#envoyService_type ) | No      | string | No         | -          | -                 |
 
-### <a name="envoyService_type"></a>5.1. Property `envoy-gateway-resources > envoyService > type`
+### <a name="envoyService_type"></a>6.1. Property `envoy-gateway-resources > envoyService > type`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="gatewayName"></a>6. Property `envoy-gateway-resources > gatewayName`
+## <a name="gatewayName"></a>7. Property `envoy-gateway-resources > gatewayName`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="geoip"></a>7. Property `envoy-gateway-resources > geoip`
+## <a name="geoip"></a>8. Property `envoy-gateway-resources > geoip`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -134,7 +154,7 @@
 | - [blockedCountries](#geoip_blockedCountries ) | No      | array of string | No         | -          | -                 |
 | - [enabled](#geoip_enabled )                   | No      | boolean         | No         | -          | -                 |
 
-### <a name="geoip_blockedCountries"></a>7.1. Property `envoy-gateway-resources > geoip > blockedCountries`
+### <a name="geoip_blockedCountries"></a>8.1. Property `envoy-gateway-resources > geoip > blockedCountries`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -153,21 +173,21 @@
 | ------------------------------------------------------- | ----------- |
 | [blockedCountries items](#geoip_blockedCountries_items) | -           |
 
-#### <a name="geoip_blockedCountries_items"></a>7.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
+#### <a name="geoip_blockedCountries_items"></a>8.1.1. envoy-gateway-resources > geoip > blockedCountries > blockedCountries items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="geoip_enabled"></a>7.2. Property `envoy-gateway-resources > geoip > enabled`
+### <a name="geoip_enabled"></a>8.2. Property `envoy-gateway-resources > geoip > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="listenerSets"></a>8. Property `envoy-gateway-resources > listenerSets`
+## <a name="listenerSets"></a>9. Property `envoy-gateway-resources > listenerSets`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -181,21 +201,21 @@
 | - [from](#listenerSets_from )                           | No      | string  | No         | -          | -                 |
 | - [namespaceSelector](#listenerSets_namespaceSelector ) | No      | object  | No         | -          | -                 |
 
-### <a name="listenerSets_enabled"></a>8.1. Property `envoy-gateway-resources > listenerSets > enabled`
+### <a name="listenerSets_enabled"></a>9.1. Property `envoy-gateway-resources > listenerSets > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-### <a name="listenerSets_from"></a>8.2. Property `envoy-gateway-resources > listenerSets > from`
+### <a name="listenerSets_from"></a>9.2. Property `envoy-gateway-resources > listenerSets > from`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="listenerSets_namespaceSelector"></a>8.3. Property `envoy-gateway-resources > listenerSets > namespaceSelector`
+### <a name="listenerSets_namespaceSelector"></a>9.3. Property `envoy-gateway-resources > listenerSets > namespaceSelector`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -203,7 +223,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-## <a name="proxyProtocol"></a>9. Property `envoy-gateway-resources > proxyProtocol`
+## <a name="proxyProtocol"></a>10. Property `envoy-gateway-resources > proxyProtocol`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -216,21 +236,21 @@
 | - [enabled](#proxyProtocol_enabled )   | No      | boolean | No         | -          | -                 |
 | - [optional](#proxyProtocol_optional ) | No      | boolean | No         | -          | -                 |
 
-### <a name="proxyProtocol_enabled"></a>9.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
+### <a name="proxyProtocol_enabled"></a>10.1. Property `envoy-gateway-resources > proxyProtocol > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-### <a name="proxyProtocol_optional"></a>9.2. Property `envoy-gateway-resources > proxyProtocol > optional`
+### <a name="proxyProtocol_optional"></a>10.2. Property `envoy-gateway-resources > proxyProtocol > optional`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-## <a name="resources"></a>10. Property `envoy-gateway-resources > resources`
+## <a name="resources"></a>11. Property `envoy-gateway-resources > resources`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -243,7 +263,7 @@
 | - [limits](#resources_limits )     | No      | object | No         | -          | -                 |
 | - [requests](#resources_requests ) | No      | object | No         | -          | -                 |
 
-### <a name="resources_limits"></a>10.1. Property `envoy-gateway-resources > resources > limits`
+### <a name="resources_limits"></a>11.1. Property `envoy-gateway-resources > resources > limits`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -255,14 +275,14 @@
 | ------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [memory](#resources_limits_memory ) | No      | string | No         | -          | -                 |
 
-#### <a name="resources_limits_memory"></a>10.1.1. Property `envoy-gateway-resources > resources > limits > memory`
+#### <a name="resources_limits_memory"></a>11.1.1. Property `envoy-gateway-resources > resources > limits > memory`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="resources_requests"></a>10.2. Property `envoy-gateway-resources > resources > requests`
+### <a name="resources_requests"></a>11.2. Property `envoy-gateway-resources > resources > requests`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -275,21 +295,21 @@
 | - [cpu](#resources_requests_cpu )       | No      | string | No         | -          | -                 |
 | - [memory](#resources_requests_memory ) | No      | string | No         | -          | -                 |
 
-#### <a name="resources_requests_cpu"></a>10.2.1. Property `envoy-gateway-resources > resources > requests > cpu`
+#### <a name="resources_requests_cpu"></a>11.2.1. Property `envoy-gateway-resources > resources > requests > cpu`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="resources_requests_memory"></a>10.2.2. Property `envoy-gateway-resources > resources > requests > memory`
+#### <a name="resources_requests_memory"></a>11.2.2. Property `envoy-gateway-resources > resources > requests > memory`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="serviceAccount"></a>11. Property `envoy-gateway-resources > serviceAccount`
+## <a name="serviceAccount"></a>12. Property `envoy-gateway-resources > serviceAccount`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -302,7 +322,7 @@
 | - [annotations](#serviceAccount_annotations ) | No      | object | No         | -          | -                 |
 | - [name](#serviceAccount_name )               | No      | string | No         | -          | -                 |
 
-### <a name="serviceAccount_annotations"></a>11.1. Property `envoy-gateway-resources > serviceAccount > annotations`
+### <a name="serviceAccount_annotations"></a>12.1. Property `envoy-gateway-resources > serviceAccount > annotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -310,14 +330,14 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-### <a name="serviceAccount_name"></a>11.2. Property `envoy-gateway-resources > serviceAccount > name`
+### <a name="serviceAccount_name"></a>12.2. Property `envoy-gateway-resources > serviceAccount > name`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="tlsPassthrough"></a>12. Property `envoy-gateway-resources > tlsPassthrough`
+## <a name="tlsPassthrough"></a>13. Property `envoy-gateway-resources > tlsPassthrough`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -330,14 +350,14 @@
 | - [enabled](#tlsPassthrough_enabled )     | No      | boolean | No         | -          | -                 |
 | - [hostnames](#tlsPassthrough_hostnames ) | No      | array   | No         | -          | -                 |
 
-### <a name="tlsPassthrough_enabled"></a>12.1. Property `envoy-gateway-resources > tlsPassthrough > enabled`
+### <a name="tlsPassthrough_enabled"></a>13.1. Property `envoy-gateway-resources > tlsPassthrough > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-### <a name="tlsPassthrough_hostnames"></a>12.2. Property `envoy-gateway-resources > tlsPassthrough > hostnames`
+### <a name="tlsPassthrough_hostnames"></a>13.2. Property `envoy-gateway-resources > tlsPassthrough > hostnames`
 
 |              |         |
 | ------------ | ------- |

--- a/envoy-gateway-resources/templates/envoyproxy.yaml
+++ b/envoy-gateway-resources/templates/envoyproxy.yaml
@@ -73,3 +73,14 @@ spec:
                 type: Utilization
                 averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
       {{- end }}
+  {{- if .Values.accessLog.omitSuccessful }}
+  telemetry:
+    accessLog:
+      settings:
+        - matches:
+            - "!(response.code >= 200 && response.code < 300)"
+          sinks:
+            - type: File
+              file:
+                path: /dev/stdout
+  {{- end }}

--- a/envoy-gateway-resources/values.schema.json
+++ b/envoy-gateway-resources/values.schema.json
@@ -4,6 +4,14 @@
   "title": "envoy-gateway-resources",
   "type": "object",
   "properties": {
+    "accessLog": {
+      "type": "object",
+      "properties": {
+        "omitSuccessful": {
+          "type": "boolean"
+        }
+      }
+    },
     "alternateNames": {
       "type": "array"
     },

--- a/envoy-gateway-resources/values.yaml
+++ b/envoy-gateway-resources/values.yaml
@@ -69,3 +69,9 @@ geoip:
 proxyProtocol:
   enabled: true
   optional: false
+
+# When true, drop access logs for successful (2xx) responses; errors, redirects,
+# and reset connections are still logged. For high-traffic clusters where 2xx
+# access-log volume is significant self-ingest.
+accessLog:
+  omitSuccessful: false


### PR DESCRIPTION
## Summary

Adds an opt-in `accessLog.omitSuccessful` value to the envoy-gateway-resources chart. When a cluster enables it, the EnvoyProxy renders a `telemetry.accessLog` setting with a CEL match — `!(response.code >= 200 && response.code < 300)` — so successful requests stop emitting access logs while errors, redirects, and reset connections (code 0) still log. Sink and format stay at Envoy Gateway defaults, so surviving log lines keep their current JSON shape.

- Motivation: on prod-central-o11y, the fleet's heaviest gateway (central Loki ingest, ~950 rps steady / 1.3k rps peak), 2xx access logs run ~220 lines/s ≈ 19 GB/day — all self-ingested into the same Loki the gateway fronts. Rates, error classes, and latency remain covered by the envoy Prometheus metrics the envoy-gateway dashboard uses.
- Default `false` renders no `telemetry` block at all — zero behavior change for existing clusters. The prod-central-o11y opt-in lands via the argus-infra-stacks per-cluster overlay (companion PR).

## Test plan

- `helm lint` clean; default render verified to contain no `telemetry` block.
- Enabled render validated against the live EnvoyProxy CRD on prod-central-o11y (Envoy Gateway v1.8.1) via `kubectl apply --dry-run=server`.
- Post-merge, once the companion override lands: access-log line rate from `envoy-gateway-controller` on prod-central-o11y drops to error-only volume; 4xx/5xx lines keep flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)