### PR TITLE
feat(grafana-alloy): add alloyConfig.extraConfig for appending custom River blocks

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,4 +16,4 @@ jobs:
   conventional_commit_title:
     runs-on: ARM64
     steps:
-      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.4.0
+      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v6.29.4

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,4 +16,4 @@ jobs:
   conventional_commit_title:
     runs-on: ARM64
     steps:
-      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v6.29.4
+      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v6

--- a/grafana-alloy/README.md
+++ b/grafana-alloy/README.md
@@ -708,14 +708,15 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                           | Pattern | Type   | Deprecated | Definition | Title/Description                                                                            |
-| ---------------------------------- | ------- | ------ | ---------- | ---------- | -------------------------------------------------------------------------------------------- |
-| - [beyla](#alloyConfig_beyla )     | No      | object | No         | -          | Enable Beyla integration for eBPF-based application instrumentation                          |
-| - [content](#alloyConfig_content ) | No      | string | No         | -          | Custom Alloy configuration content (River format). If empty, uses default collection config. |
-| - [events](#alloyConfig_events )   | No      | object | No         | -          | Enable Kubernetes events collection                                                          |
-| - [logging](#alloyConfig_logging ) | No      | object | No         | -          | Logging configuration for Alloy                                                              |
-| - [metrics](#alloyConfig_metrics ) | No      | object | No         | -          | Enable Prometheus metrics collection                                                         |
-| - [podLogs](#alloyConfig_podLogs ) | No      | object | No         | -          | Enable pod log collection                                                                    |
+| Property                                   | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                                                                                                 |
+| ------------------------------------------ | ------- | ------ | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [beyla](#alloyConfig_beyla )             | No      | object | No         | -          | Enable Beyla integration for eBPF-based application instrumentation                                                                                                                               |
+| - [content](#alloyConfig_content )         | No      | string | No         | -          | Custom Alloy configuration content (River format). If empty, uses default collection config.                                                                                                      |
+| - [events](#alloyConfig_events )           | No      | object | No         | -          | Enable Kubernetes events collection                                                                                                                                                               |
+| - [extraConfig](#alloyConfig_extraConfig ) | No      | string | No         | -          | Raw River config appended after the generated config. Ignored when alloyConfig.content is set. Use this to add custom blocks (e.g. OTLP receivers) without replacing the entire generated config. |
+| - [logging](#alloyConfig_logging )         | No      | object | No         | -          | Logging configuration for Alloy                                                                                                                                                                   |
+| - [metrics](#alloyConfig_metrics )         | No      | object | No         | -          | Enable Prometheus metrics collection                                                                                                                                                              |
+| - [podLogs](#alloyConfig_podLogs )         | No      | object | No         | -          | Enable pod log collection                                                                                                                                                                         |
 
 ### <a name="alloyConfig_beyla"></a>2.1. Property `grafana-alloy > alloyConfig > beyla`
 
@@ -782,7 +783,16 @@ Must be one of:
 
 **Description:** Enable collection of Kubernetes events
 
-### <a name="alloyConfig_logging"></a>2.4. Property `grafana-alloy > alloyConfig > logging`
+### <a name="alloyConfig_extraConfig"></a>2.4. Property `grafana-alloy > alloyConfig > extraConfig`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Raw River config appended after the generated config. Ignored when alloyConfig.content is set. Use this to add custom blocks (e.g. OTLP receivers) without replacing the entire generated config.
+
+### <a name="alloyConfig_logging"></a>2.5. Property `grafana-alloy > alloyConfig > logging`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -797,7 +807,7 @@ Must be one of:
 | - [format](#alloyConfig_logging_format ) | No      | enum (of string) | No         | -          | Log format for Alloy |
 | - [level](#alloyConfig_logging_level )   | No      | enum (of string) | No         | -          | Log level for Alloy  |
 
-#### <a name="alloyConfig_logging_format"></a>2.4.1. Property `grafana-alloy > alloyConfig > logging > format`
+#### <a name="alloyConfig_logging_format"></a>2.5.1. Property `grafana-alloy > alloyConfig > logging > format`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -810,7 +820,7 @@ Must be one of:
 * "logfmt"
 * "json"
 
-#### <a name="alloyConfig_logging_level"></a>2.4.2. Property `grafana-alloy > alloyConfig > logging > level`
+#### <a name="alloyConfig_logging_level"></a>2.5.2. Property `grafana-alloy > alloyConfig > logging > level`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -825,7 +835,7 @@ Must be one of:
 * "warn"
 * "error"
 
-### <a name="alloyConfig_metrics"></a>2.5. Property `grafana-alloy > alloyConfig > metrics`
+### <a name="alloyConfig_metrics"></a>2.6. Property `grafana-alloy > alloyConfig > metrics`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -839,7 +849,7 @@ Must be one of:
 | ------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------- |
 | - [enabled](#alloyConfig_metrics_enabled ) | No      | boolean | No         | -          | Enable scraping of Prometheus metrics from pods (requires prometheusRemoteWrite.enabled=true) |
 
-#### <a name="alloyConfig_metrics_enabled"></a>2.5.1. Property `grafana-alloy > alloyConfig > metrics > enabled`
+#### <a name="alloyConfig_metrics_enabled"></a>2.6.1. Property `grafana-alloy > alloyConfig > metrics > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -848,7 +858,7 @@ Must be one of:
 
 **Description:** Enable scraping of Prometheus metrics from pods (requires prometheusRemoteWrite.enabled=true)
 
-### <a name="alloyConfig_podLogs"></a>2.6. Property `grafana-alloy > alloyConfig > podLogs`
+### <a name="alloyConfig_podLogs"></a>2.7. Property `grafana-alloy > alloyConfig > podLogs`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -862,7 +872,7 @@ Must be one of:
 | ------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------- |
 | - [enabled](#alloyConfig_podLogs_enabled ) | No      | boolean | No         | -          | Enable collection of pod logs from all nodes |
 
-#### <a name="alloyConfig_podLogs_enabled"></a>2.6.1. Property `grafana-alloy > alloyConfig > podLogs > enabled`
+#### <a name="alloyConfig_podLogs_enabled"></a>2.7.1. Property `grafana-alloy > alloyConfig > podLogs > enabled`
 
 |              |           |
 | ------------ | --------- |

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -1113,5 +1113,8 @@ data:
       scrape_interval = "15s"
     }
     {{- end }}
+{{- if .Values.alloyConfig.extraConfig }}
+{{ .Values.alloyConfig.extraConfig | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -302,6 +302,10 @@
             }
           }
         },
+        "extraConfig": {
+          "description": "Raw River config appended after the generated config. Ignored when alloyConfig.content is set. Use this to add custom blocks (e.g. OTLP receivers) without replacing the entire generated config.",
+          "type": "string"
+        },
         "logging": {
           "description": "Logging configuration for Alloy",
           "type": "object",

--- a/grafana-alloy/values.yaml
+++ b/grafana-alloy/values.yaml
@@ -189,6 +189,9 @@ alloyConfig:
   # See https://grafana.com/docs/alloy/latest/reference/config-blocks/
   content: ""
 
+  # @schema description: Raw River config appended after the generated config. Ignored when alloyConfig.content is set. Use this to add custom blocks (e.g. OTLP receivers) without replacing the entire generated config.
+  extraConfig: ""
+
   # @schema description: Logging configuration for Alloy
   logging:
     level: info # @schema enum: [debug, info, warn, error]; description: Log level for Alloy


### PR DESCRIPTION
## Overview

The grafana-alloy chart generates its River config from Helm values via `configmap.yaml`. Today the only way to inject custom River blocks is the `alloyConfig.content` escape hatch, which replaces the entire generated config. That forces you to duplicate the full generated pipeline just to add one extra block.

## Solution

Add an `alloyConfig.extraConfig` field that appends raw River config after the generated config. When set, the template renders the extra content at the end of the generated `config.alloy` without touching the existing pipeline. When `alloyConfig.content` is set instead, `extraConfig` is ignored (the content escape hatch already gives full control).

This is useful for adding OTLP receivers, custom processors, or any other River blocks that need to reference the generated pipeline's receivers (e.g. `prometheus.relabel.filter_metrics.receiver`, `loki.write.endpoints.receiver`) without duplicating the entire config.

## Impact

No behavior change for existing deployments. The new field defaults to an empty string, so no config is appended unless explicitly set.

## References

- Companion PR in argus-infra-stacks will use this to add an OTLP receiver on prod-central-o11y for [agent observability](https://docs.google.com/document/d/1_3f9QFvLudzFeMTri8idLqOPxRc4-Rydqn-16tXx2m8/edit)
- [CCIE-6890](https://czi.atlassian.net/browse/CCIE-6890)

[CCIE-6890]: https://czi.atlassian.net/browse/CCIE-6890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ