### PR TITLE
fix(grafana-alloy): derive ConfigMap name from configMap.name value

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,4 +16,4 @@ jobs:
   conventional_commit_title:
     runs-on: ARM64
     steps:
-      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.4.0
+      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v6

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-alloy-config
+  name: {{ .Values.alloy.alloy.configMap.name }}
   labels:
     {{- include "grafana-alloy.labels" . | nindent 4 }}
 data:

--- a/grafana-alloy/tests/configmap_test.yaml
+++ b/grafana-alloy/tests/configmap_test.yaml
@@ -21,7 +21,7 @@ tests:
       - isKind:
           of: ConfigMap
 
-  - it: should have the correct name
+  - it: should default the name to grafana-alloy-config
     set:
       enabled: true
       clusterName: test-cluster
@@ -29,6 +29,19 @@ tests:
       - equal:
           path: metadata.name
           value: grafana-alloy-config
+
+  - it: should follow alloy.alloy.configMap.name so multiple releases can share a namespace
+    set:
+      enabled: true
+      clusterName: test-cluster
+      alloy:
+        alloy:
+          configMap:
+            name: grafana-alloy-otlp-config
+    asserts:
+      - equal:
+          path: metadata.name
+          value: grafana-alloy-otlp-config
 
   - it: should contain config.alloy key in data
     set:


### PR DESCRIPTION
## Problem

Two releases of the `grafana-alloy` chart cannot coexist in the same namespace. The ConfigMap name is hardcoded to `grafana-alloy-config`, so both releases produce the same object and overwrite each other. On dev-central-o11y, the main `grafana-alloy` DaemonSet and a second `grafana-alloy-otlp` Deployment share the `loki` namespace. Their ArgoCD apps (both `selfHeal: true`) fight over the single ConfigMap: when one release wins, the other mounts the wrong config and either crash-loops or silently stops scraping.

## Solution

Template the ConfigMap name from the existing `alloy.alloy.configMap.name` value that the alloy subchart already uses to locate its config mount. The created object and the mount now always agree. The default is unchanged (`grafana-alloy-config`), so existing single-release deployments are unaffected. A second release just sets a distinct name (e.g. `grafana-alloy-otlp-config`) and the two can run side by side.

Also bumps the conventional-commits action to v6.