### PR TITLE
feat(stack): expose Deployment update strategy

### DIFF
--- a/stack/README.md
+++ b/stack/README.md
@@ -102,6 +102,7 @@ must respect the following conditions
 | - [shareProcessNamespace](#cronJobs_pattern1_shareProcessNamespace )         | No      | boolean          | No         | -                       | Share process namespace                                                                                                                                                                                 |
 | - [sidecars](#cronJobs_pattern1_sidecars )                                   | No      | array            | No         | -                       | List of sidecars                                                                                                                                                                                        |
 | - [startupProbe](#cronJobs_pattern1_startupProbe )                           | No      | object           | No         | -                       | Startup probe configuration                                                                                                                                                                             |
+| - [strategy](#cronJobs_pattern1_strategy )                                   | No      | object           | No         | -                       | Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate                                             |
 | - [tolerations](#cronJobs_pattern1_tolerations )                             | No      | array            | No         | -                       | Tolerations for the pod                                                                                                                                                                                 |
 | - [topologySpreadConstraints](#cronJobs_pattern1_topologySpreadConstraints ) | No      | array            | No         | -                       | Topology spread constraints for the pod                                                                                                                                                                 |
 | - [volumeMounts](#cronJobs_pattern1_volumeMounts )                           | No      | array            | No         | -                       | Additional volume mounts on the output Deployment definition                                                                                                                                            |
@@ -4022,7 +4023,17 @@ Must be one of:
 
 **Description:** Timeout for the probe
 
-#### <a name="cronJobs_pattern1_tolerations"></a>2.1.45. Property `stack > cronJobs > ^.*$ > tolerations`
+#### <a name="cronJobs_pattern1_strategy"></a>2.1.45. Property `stack > cronJobs > ^.*$ > strategy`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate
+
+#### <a name="cronJobs_pattern1_tolerations"></a>2.1.46. Property `stack > cronJobs > ^.*$ > tolerations`
 
 |              |         |
 | ------------ | ------- |
@@ -4039,7 +4050,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_topologySpreadConstraints"></a>2.1.46. Property `stack > cronJobs > ^.*$ > topologySpreadConstraints`
+#### <a name="cronJobs_pattern1_topologySpreadConstraints"></a>2.1.47. Property `stack > cronJobs > ^.*$ > topologySpreadConstraints`
 
 |              |         |
 | ------------ | ------- |
@@ -4056,7 +4067,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_volumeMounts"></a>2.1.47. Property `stack > cronJobs > ^.*$ > volumeMounts`
+#### <a name="cronJobs_pattern1_volumeMounts"></a>2.1.48. Property `stack > cronJobs > ^.*$ > volumeMounts`
 
 |              |         |
 | ------------ | ------- |
@@ -4073,7 +4084,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_volumes"></a>2.1.48. Property `stack > cronJobs > ^.*$ > volumes`
+#### <a name="cronJobs_pattern1_volumes"></a>2.1.49. Property `stack > cronJobs > ^.*$ > volumes`
 
 |              |         |
 | ------------ | ------- |
@@ -4146,6 +4157,7 @@ Must be one of:
 | - [shareProcessNamespace](#global_shareProcessNamespace )         | No      | boolean          | No         | -                       | Share process namespace                                                                                                                                                                                 |
 | - [sidecars](#global_sidecars )                                   | No      | array            | No         | -                       | List of sidecars                                                                                                                                                                                        |
 | - [startupProbe](#global_startupProbe )                           | No      | object           | No         | -                       | Startup probe configuration                                                                                                                                                                             |
+| - [strategy](#global_strategy )                                   | No      | object           | No         | -                       | Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate                                             |
 | - [tolerations](#global_tolerations )                             | No      | array            | No         | -                       | Tolerations for the pod                                                                                                                                                                                 |
 | - [topologySpreadConstraints](#global_topologySpreadConstraints ) | No      | array            | No         | -                       | Topology spread constraints for the pod                                                                                                                                                                 |
 | - [volumeMounts](#global_volumeMounts )                           | No      | array            | No         | -                       | Additional volume mounts on the output Deployment definition                                                                                                                                            |
@@ -8066,7 +8078,17 @@ Must be one of:
 
 **Description:** Timeout for the probe
 
-### <a name="global_tolerations"></a>3.45. Property `stack > global > tolerations`
+### <a name="global_strategy"></a>3.45. Property `stack > global > strategy`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate
+
+### <a name="global_tolerations"></a>3.46. Property `stack > global > tolerations`
 
 |              |         |
 | ------------ | ------- |
@@ -8083,7 +8105,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-### <a name="global_topologySpreadConstraints"></a>3.46. Property `stack > global > topologySpreadConstraints`
+### <a name="global_topologySpreadConstraints"></a>3.47. Property `stack > global > topologySpreadConstraints`
 
 |              |         |
 | ------------ | ------- |
@@ -8100,7 +8122,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-### <a name="global_volumeMounts"></a>3.47. Property `stack > global > volumeMounts`
+### <a name="global_volumeMounts"></a>3.48. Property `stack > global > volumeMounts`
 
 |              |         |
 | ------------ | ------- |
@@ -8117,7 +8139,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-### <a name="global_volumes"></a>3.48. Property `stack > global > volumes`
+### <a name="global_volumes"></a>3.49. Property `stack > global > volumes`
 
 |              |         |
 | ------------ | ------- |
@@ -8208,6 +8230,7 @@ must respect the following conditions
 | - [shareProcessNamespace](#cronJobs_pattern1_shareProcessNamespace )         | No      | boolean          | No         | -                       | Share process namespace                                                                                                                                                                                 |
 | - [sidecars](#cronJobs_pattern1_sidecars )                                   | No      | array            | No         | -                       | List of sidecars                                                                                                                                                                                        |
 | - [startupProbe](#cronJobs_pattern1_startupProbe )                           | No      | object           | No         | -                       | Startup probe configuration                                                                                                                                                                             |
+| - [strategy](#cronJobs_pattern1_strategy )                                   | No      | object           | No         | -                       | Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate                                             |
 | - [tolerations](#cronJobs_pattern1_tolerations )                             | No      | array            | No         | -                       | Tolerations for the pod                                                                                                                                                                                 |
 | - [topologySpreadConstraints](#cronJobs_pattern1_topologySpreadConstraints ) | No      | array            | No         | -                       | Topology spread constraints for the pod                                                                                                                                                                 |
 | - [volumeMounts](#cronJobs_pattern1_volumeMounts )                           | No      | array            | No         | -                       | Additional volume mounts on the output Deployment definition                                                                                                                                            |
@@ -12128,7 +12151,17 @@ Must be one of:
 
 **Description:** Timeout for the probe
 
-#### <a name="cronJobs_pattern1_tolerations"></a>4.1.45. Property `stack > cronJobs > ^.*$ > tolerations`
+#### <a name="cronJobs_pattern1_strategy"></a>4.1.45. Property `stack > cronJobs > ^.*$ > strategy`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate
+
+#### <a name="cronJobs_pattern1_tolerations"></a>4.1.46. Property `stack > cronJobs > ^.*$ > tolerations`
 
 |              |         |
 | ------------ | ------- |
@@ -12145,7 +12178,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_topologySpreadConstraints"></a>4.1.46. Property `stack > cronJobs > ^.*$ > topologySpreadConstraints`
+#### <a name="cronJobs_pattern1_topologySpreadConstraints"></a>4.1.47. Property `stack > cronJobs > ^.*$ > topologySpreadConstraints`
 
 |              |         |
 | ------------ | ------- |
@@ -12162,7 +12195,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_volumeMounts"></a>4.1.47. Property `stack > cronJobs > ^.*$ > volumeMounts`
+#### <a name="cronJobs_pattern1_volumeMounts"></a>4.1.48. Property `stack > cronJobs > ^.*$ > volumeMounts`
 
 |              |         |
 | ------------ | ------- |
@@ -12179,7 +12212,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_volumes"></a>4.1.48. Property `stack > cronJobs > ^.*$ > volumes`
+#### <a name="cronJobs_pattern1_volumes"></a>4.1.49. Property `stack > cronJobs > ^.*$ > volumes`
 
 |              |         |
 | ------------ | ------- |
@@ -12734,6 +12767,7 @@ must respect the following conditions
 | - [shareProcessNamespace](#cronJobs_pattern1_shareProcessNamespace )         | No      | boolean          | No         | -                       | Share process namespace                                                                                                                                                                                 |
 | - [sidecars](#cronJobs_pattern1_sidecars )                                   | No      | array            | No         | -                       | List of sidecars                                                                                                                                                                                        |
 | - [startupProbe](#cronJobs_pattern1_startupProbe )                           | No      | object           | No         | -                       | Startup probe configuration                                                                                                                                                                             |
+| - [strategy](#cronJobs_pattern1_strategy )                                   | No      | object           | No         | -                       | Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate                                             |
 | - [tolerations](#cronJobs_pattern1_tolerations )                             | No      | array            | No         | -                       | Tolerations for the pod                                                                                                                                                                                 |
 | - [topologySpreadConstraints](#cronJobs_pattern1_topologySpreadConstraints ) | No      | array            | No         | -                       | Topology spread constraints for the pod                                                                                                                                                                 |
 | - [volumeMounts](#cronJobs_pattern1_volumeMounts )                           | No      | array            | No         | -                       | Additional volume mounts on the output Deployment definition                                                                                                                                            |
@@ -16654,7 +16688,17 @@ Must be one of:
 
 **Description:** Timeout for the probe
 
-#### <a name="cronJobs_pattern1_tolerations"></a>7.1.45. Property `stack > cronJobs > ^.*$ > tolerations`
+#### <a name="cronJobs_pattern1_strategy"></a>7.1.45. Property `stack > cronJobs > ^.*$ > strategy`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate
+
+#### <a name="cronJobs_pattern1_tolerations"></a>7.1.46. Property `stack > cronJobs > ^.*$ > tolerations`
 
 |              |         |
 | ------------ | ------- |
@@ -16671,7 +16715,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_topologySpreadConstraints"></a>7.1.46. Property `stack > cronJobs > ^.*$ > topologySpreadConstraints`
+#### <a name="cronJobs_pattern1_topologySpreadConstraints"></a>7.1.47. Property `stack > cronJobs > ^.*$ > topologySpreadConstraints`
 
 |              |         |
 | ------------ | ------- |
@@ -16688,7 +16732,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_volumeMounts"></a>7.1.47. Property `stack > cronJobs > ^.*$ > volumeMounts`
+#### <a name="cronJobs_pattern1_volumeMounts"></a>7.1.48. Property `stack > cronJobs > ^.*$ > volumeMounts`
 
 |              |         |
 | ------------ | ------- |
@@ -16705,7 +16749,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="cronJobs_pattern1_volumes"></a>7.1.48. Property `stack > cronJobs > ^.*$ > volumes`
+#### <a name="cronJobs_pattern1_volumes"></a>7.1.49. Property `stack > cronJobs > ^.*$ > volumes`
 
 |              |         |
 | ------------ | ------- |

--- a/stack/templates/deployment.yaml
+++ b/stack/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
   {{- end }}
   progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
   revisionHistoryLimit: 3
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "service.selectorLabels" . | nindent 6 }}

--- a/stack/tests/deployment_test.yaml
+++ b/stack/tests/deployment_test.yaml
@@ -312,3 +312,41 @@ tests:
       - equal:
           path: spec.template.spec.volumes[0].configMap.name
           value: "otel-collector-config-literal-str"
+  - it: omits strategy by default
+    set:
+      services:
+        service1: {}
+    asserts:
+      - notExists:
+          path: spec.strategy
+
+  - it: renders strategy from global values
+    set:
+      global:
+        strategy:
+          type: Recreate
+      services:
+        service1: {}
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: renders per-service strategy override
+    set:
+      global:
+        strategy:
+          type: Recreate
+      services:
+        service1:
+          strategy:
+            type: RollingUpdate
+            rollingUpdate:
+              maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -1379,6 +1379,10 @@
             }
           }
         },
+        "strategy": {
+          "description": "Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate",
+          "type": "object"
+        },
         "tolerations": {
           "description": "Tolerations for the pod",
           "type": "array"

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -107,6 +107,8 @@ global: # @schema description: Global configuration for the stack - this serves 
 
   progressDeadlineSeconds: 600 # @schema description: the number of seconds the Deployment controller waits before indicating (in the Deployment status) that the Deployment progress has stalled
 
+  strategy: {} # @schema description: Deployment update strategy (for example type Recreate for single-replica pods with ReadWriteOnce volumes) - empty uses the Kubernetes default RollingUpdate
+
   resources: # @schema description: Resource requests and limits for the primary container
     limits: # @schema description: Resource limits
       cpu: "1" # @schema oneOf: [{ "type": "string" },{ "type": "number" }]; description: CPU limit


### PR DESCRIPTION
Stateful single-replica stack services with a ReadWriteOnce/ReadWriteOncePod PVC currently have no way to avoid the Kubernetes default RollingUpdate: at replicas:1 the surge pod is created before the old one dies, which either wedges on the EBS multi-attach error (new pod on a different node) or briefly runs two writers against the same volume (same node). The chart's Deployment template has no `strategy` field at all today — only Argo Rollouts services can control this.

This adds a `strategy` passthrough on Deployment services, settable globally or per service, empty by default (unchanged behavior — Kubernetes RollingUpdate). First consumer is the upcoming karpenter-lens app, which runs a single replica with SQLite on an RWOP gp3 volume and needs `type: Recreate`.

`values.schema.json` regenerated via `make update-schema`; three unit tests added (default omitted, global value, per-service override). Full suite passes: 185/185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)