### PR TITLE
fix(stack): fix YAML parse error in gateway-oidc when paths lack a root entry

### DIFF
--- a/stack/templates/gateway-oidc.yaml
+++ b/stack/templates/gateway-oidc.yaml
@@ -115,8 +115,7 @@ spec:
         {{- $hasRootPath = true -}}
       {{- end -}}
     {{- end -}}
-    {{- if not $hasRootPath -}}
-    {{- /* Add a default / route to ensure /oauth2/callback works */ -}}
+    {{- if not $hasRootPath }}
     - matches:
         - path:
             type: PathPrefix
@@ -190,8 +189,7 @@ spec:
         {{- $hasRootPath = true -}}
       {{- end -}}
     {{- end -}}
-    {{- if not $hasRootPath -}}
-    {{- /* Add a default / route to ensure /oauth2/callback works */ -}}
+    {{- if not $hasRootPath }}
     - matches:
         - path:
             type: PathPrefix

--- a/stack/tests/gateway_oidc_test.yaml
+++ b/stack/tests/gateway_oidc_test.yaml
@@ -163,6 +163,38 @@ tests:
           path: spec.rules[1].matches[0].path.value
           value: /metrics
 
+  - it: should add default root path when no root path exists
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          paths:
+            - path: /backend
+              pathType: Prefix
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.rules
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - documentIndex: 0
+        equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /backend
+
   - it: should not add default root path when root path already exists
     set:
       global:


### PR DESCRIPTION
## Overview

The `gateway-oidc.yaml` template produces invalid YAML when `gateway.oidcProtected` is true and `gateway.paths` does not include a root `/` path (e.g. only `path: /backend`). The rendered output runs `rules:` and `- matches:` together on the same line, which fails YAML parsing at deploy time.

## Solution

The `if not $hasRootPath` block and its preceding inline comment both used `{{- ... -}}` (trim on both sides). Because every template tag between `rules:` and `- matches:` stripped whitespace bidirectionally, all newlines were consumed. Changing the `if` tag to `{{- if not $hasRootPath }}` (no trailing trim) preserves the newline before the first list item. Both the primary rules block and the per-rule block had the same issue and are fixed.

A new test case covers OIDC-protected gateway with a non-root path, which is the exact scenario that was broken. Every existing test used `path: /`, so the `if not $hasRootPath` branch was never exercised.