### PR TITLE
fix(stack): oidc-proxy envFrom and skipAuth render errors, vanity OIDC route attachment

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -235,19 +235,13 @@ app.kubernetes.io/name: {{ include "oidcProxy.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-{{ define "oidcProxy.envFromArgusSecrets" -}}
-{{- include "service.configuration" . -}}
-{{- end -}}
-
-{{ define "oidcProxy.additionalSecrets" -}}
-{{ if gt (len .Values.oidcProxy.additionalSecrets) 0 }}
-{{ toYaml .Values.oidcProxy.additionalSecrets }}
-{{- end -}}
-{{- end -}}
-
 {{- define "oidcProxy.envFrom" -}}
-{{- include "oidcProxy.envFromArgusSecrets" . }}
-{{- include "oidcProxy.additionalSecrets" . }}
+{{- $envFrom := list -}}
+{{- with fromYaml (include "service.configuration" .) -}}
+{{- $envFrom = concat $envFrom (default (list) .envFrom) -}}
+{{- end -}}
+{{- $envFrom = concat $envFrom (default (list) .Values.oidcProxy.additionalSecrets) -}}
+{{- toYaml $envFrom -}}
 {{- end -}}
 
 {{- define "oidcProxy.authDomain" -}}

--- a/stack/templates/gateway-oidc.yaml
+++ b/stack/templates/gateway-oidc.yaml
@@ -58,11 +58,17 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if .Values.gateway.vanity.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ include "service.vanityListenerSetName" . }}
+    {{- else }}
     - name: {{ .Values.gateway.gatewayName }}
       namespace: {{ .Values.gateway.gatewayNamespace }}
       {{- if .Values.gateway.sectionName }}
       sectionName: {{ .Values.gateway.sectionName }}
       {{- end }}
+    {{- end }}
   hostnames:
     - {{ .Values.gateway.host }}
   {{- range $i, $rule := .Values.gateway.rules }}
@@ -100,11 +106,17 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if .Values.gateway.vanity.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ include "service.vanityListenerSetName" . }}
+    {{- else }}
     - name: {{ .Values.gateway.gatewayName }}
       namespace: {{ .Values.gateway.gatewayNamespace }}
       {{- if .Values.gateway.sectionName }}
       sectionName: {{ .Values.gateway.sectionName }}
       {{- end }}
+    {{- end }}
   hostnames:
     - {{ .Values.gateway.host }}
   rules:

--- a/stack/templates/oidc_proxy.yaml
+++ b/stack/templates/oidc_proxy.yaml
@@ -96,13 +96,13 @@ spec:
             {{- end -}}
 
             {{- range .Values.oidcProxy.skipAuth }}
-            {{ if contains "*" .method }}
-            # for backwards compatibility, could also just be provided using extraArgs
+            {{- $method := default "*" .method }}
+            {{- if contains "*" $method }}
             - --skip-auth-route={{ .path }}
-            {{- else -}}
-            - --skip-auth-route={{ .method }}={{ .path }}
-            {{- end -}}
-            {{- end -}}
+            {{- else }}
+            - --skip-auth-route={{ $method }}={{ .path }}
+            {{- end }}
+            {{- end }}
 
             {{ $cookiePrefix := list }}
             {{ range .Values.oidcProxy.extraArgs }}
@@ -124,8 +124,10 @@ spec:
             {{- toYaml .Values.oidcProxy.extraArgs | nindent 12}}
             {{- end }}
           {{- include "image" .Values.oidcProxy  | nindent 10 }}
-          {{- if gt (len (fromYamlArray (include "oidcProxy.envFrom" .))) 0 }}
-          {{- include "oidcProxy.envFrom" . | nindent 10 }}
+          {{- $envFrom := fromYamlArray (include "oidcProxy.envFrom" .) }}
+          {{- if $envFrom }}
+          envFrom:
+            {{- toYaml $envFrom | nindent 12 }}
           {{- else }}
           envFrom: []
           {{- end }}

--- a/stack/tests/gateway_oidc_test.yaml
+++ b/stack/tests/gateway_oidc_test.yaml
@@ -223,6 +223,99 @@ tests:
           path: spec.rules[0].matches[0].path.value
           value: /
 
+  - it: should attach the primary HTTPRoute to the vanity ListenerSet when vanity is enabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          vanity:
+            enabled: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.parentRefs[0]
+          value:
+            group: gateway.networking.k8s.io
+            kind: ListenerSet
+            name: release-name-stack-service1-vanity
+
+  - it: should attach the public skipAuth HTTPRoute to the vanity ListenerSet when vanity is enabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          vanity:
+            enabled: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          skipAuth:
+            - path: /healthz
+              method: GET
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-public
+      - documentIndex: 0
+        equal:
+          path: spec.parentRefs[0]
+          value:
+            group: gateway.networking.k8s.io
+            kind: ListenerSet
+            name: release-name-stack-service1-vanity
+      - documentIndex: 1
+        equal:
+          path: spec.parentRefs[0]
+          value:
+            group: gateway.networking.k8s.io
+            kind: ListenerSet
+            name: release-name-stack-service1-vanity
+
+  - it: should attach to the shared gateway when vanity is disabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          sectionName: https
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.parentRefs[0]
+          value:
+            name: envoy-gateway
+            namespace: envoy-gateway
+            sectionName: https
+
   - it: should include service labels on the HTTPRoutes
     set:
       global:

--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -91,6 +91,56 @@ tests:
         lengthEqual:
           path: spec.template.spec.containers[0].envFrom
           count: 6
+  - it: sets additionalSecrets in envFrom without argus secrets
+    set:
+      global:
+        oidcProxy:
+          enabled: true
+          additionalSecrets:
+            - secretRef:
+                name: blah1
+                optional: true
+            - secretRef:
+                name: blah2
+                optional: true
+    asserts:
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.template.spec.containers[0].envFrom
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: blah1
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: blah2
+  - it: puts argus secrets before additionalSecrets in envFrom
+    set:
+      global:
+        appSecrets:
+          envSecret:
+            secretName: argus-env
+        oidcProxy:
+          enabled: true
+          additionalSecrets:
+            - secretRef:
+                name: blah1
+                optional: true
+    asserts:
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.template.spec.containers[0].envFrom
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: argus-env
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: blah1
   - it: defaults to 0 envFrom object
     set:
       global:
@@ -150,6 +200,24 @@ tests:
         contains:
           path: spec.template.spec.containers[0].args
           content: "--cookie-refresh=1h23m45s"
+  - it: treats skipAuth entries without a method as all-methods
+    set:
+      global:
+        oidcProxy:
+          enabled: true
+          skipAuth:
+            - path: "/healthz"
+            - path: "/v1/api/docs"
+              method: GET
+    asserts:
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-auth-route=/healthz"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--skip-auth-route=GET=/v1/api/docs"
   - it: overwrites the name
     set:
       global:


### PR DESCRIPTION
## Summary

Sweep of the stack chart for the failure class behind #504 (gateway-oidc rendered invalid YAML when `gateway.paths` lacked a root entry): value combinations no test exercises that render invalid YAML or broken resources. Every template was rendered across ~60 value scenarios with each output parsed; three bugs were confirmed and fixed.

- `oidcProxy.additionalSecrets` with no Argus-provided secrets rendered bare `- secretRef:` items with no `envFrom:` key — invalid YAML at deploy time. The helper now builds one combined list (Argus entries first) and the template always emits the key.
- `oidcProxy.skipAuth` entries without a `method` key failed the render with a type error. A missing method now means all methods, matching the gateway-side `oidcProxyGateway.skipAuth` behavior.
- `gateway.vanity.enabled` + `gateway.oidcProtected` rendered the vanity ListenerSet but attached the OIDC HTTPRoutes (primary and public) to the shared gateway, leaving the vanity listener with no route. Their parentRefs now mirror the vanity branch in the non-OIDC HTTPRoute template.

Known gap left out of scope: per-rule `vanity` combined with `skipAuth` still attaches the single public route wherever the primary route goes, since one public route covers all hosts.

## Test plan

- Six new helm-unittest cases cover exactly the previously broken branches. On the pre-fix templates they are the only failures (two reproduce the render errors); with the fixes, all 189 tests pass.
- Render-matrix check: `helm template` across 61 value scenarios, every document YAML-parsed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)