### PR TITLE
fix(grafana): relax GrafanaDatasource and loki-monitoring dashboard resync [CCIE-6793]

### DIFF
--- a/grafana/templates/datasources.yaml
+++ b/grafana/templates/datasources.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30s
+  resyncPeriod: 30m
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -30,7 +30,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30s
+  resyncPeriod: 30m
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -51,7 +51,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30s
+  resyncPeriod: 30m
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -73,7 +73,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30s
+  resyncPeriod: 30m
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}

--- a/grafana/tests/datasources_test.yaml
+++ b/grafana/tests/datasources_test.yaml
@@ -22,8 +22,9 @@ tests:
 
   - it: should have a resync period
     asserts:
-      - isNotEmpty:
+      - equal:
           path: spec.resyncPeriod
+          value: 30m
 
   - it: should have an instance selector
     asserts:

--- a/loki-monitoring/templates/dashboard.yaml
+++ b/loki-monitoring/templates/dashboard.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   folderRef: {{.Values.folder.name}}
   allowCrossNamespaceImport: true
-  resyncPeriod: 30s
+  resyncPeriod: 30m
   instanceSelector:
     matchLabels:
       app: {{.Values.grafana.name}}


### PR DESCRIPTION
Jira: [CCIE-6793](https://czi.atlassian.net/browse/CCIE-6793) · AWS support case 178181229500095 · Companion to #508

While tracing the AMG throttling we swept every Grafana CR the fleet renders for aggressive `resyncPeriod` values. The grafana chart's four GrafanaDatasource CRs and the loki-monitoring dashboard CR all re-check every 30 seconds. These select the in-cluster Grafana instances rather than the throttled AMG workspace, so this is hygiene rather than the fix — but datasources and dashboards drift just as rarely here, and on the central-loki cluster the `central-grafana`-named instance's selectors can also match the AMG workspace CR. Same remedy as #508: 30s → 30m. Resync only re-applies drift from manual edits; CR changes still reconcile immediately.

Both charts deploy path-based from HEAD, so this takes effect fleet-wide on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIE-6793]: https://czi.atlassian.net/browse/CCIE-6793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ