### PR TITLE
feat(grafana-alloy): tail Fargate pod logs via the Kubernetes API (apiPodLogs)

### DIFF
--- a/grafana-alloy/Chart.yaml
+++ b/grafana-alloy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-alloy
 description: A Helm chart for deploying Grafana Alloy with custom configuration
 type: application
-version: 0.10.1
+version: 0.11.0
 
 dependencies:
   - name: alloy

--- a/grafana-alloy/README.md
+++ b/grafana-alloy/README.md
@@ -708,16 +708,56 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                           | Pattern | Type   | Deprecated | Definition | Title/Description                                                                            |
-| ---------------------------------- | ------- | ------ | ---------- | ---------- | -------------------------------------------------------------------------------------------- |
-| - [beyla](#alloyConfig_beyla )     | No      | object | No         | -          | Enable Beyla integration for eBPF-based application instrumentation                          |
-| - [content](#alloyConfig_content ) | No      | string | No         | -          | Custom Alloy configuration content (River format). If empty, uses default collection config. |
-| - [events](#alloyConfig_events )   | No      | object | No         | -          | Enable Kubernetes events collection                                                          |
-| - [logging](#alloyConfig_logging ) | No      | object | No         | -          | Logging configuration for Alloy                                                              |
-| - [metrics](#alloyConfig_metrics ) | No      | object | No         | -          | Enable Prometheus metrics collection                                                         |
-| - [podLogs](#alloyConfig_podLogs ) | No      | object | No         | -          | Enable pod log collection                                                                    |
+| Property                                 | Pattern | Type   | Deprecated | Definition | Title/Description                                                                            |
+| ---------------------------------------- | ------- | ------ | ---------- | ---------- | -------------------------------------------------------------------------------------------- |
+| - [apiPodLogs](#alloyConfig_apiPodLogs ) | No      | object | No         | -          | -                                                                                            |
+| - [beyla](#alloyConfig_beyla )           | No      | object | No         | -          | Enable Beyla integration for eBPF-based application instrumentation                          |
+| - [content](#alloyConfig_content )       | No      | string | No         | -          | Custom Alloy configuration content (River format). If empty, uses default collection config. |
+| - [events](#alloyConfig_events )         | No      | object | No         | -          | Enable Kubernetes events collection                                                          |
+| - [logging](#alloyConfig_logging )       | No      | object | No         | -          | Logging configuration for Alloy                                                              |
+| - [metrics](#alloyConfig_metrics )       | No      | object | No         | -          | Enable Prometheus metrics collection                                                         |
+| - [podLogs](#alloyConfig_podLogs )       | No      | object | No         | -          | Enable pod log collection                                                                    |
 
-### <a name="alloyConfig_beyla"></a>2.1. Property `grafana-alloy > alloyConfig > beyla`
+### <a name="alloyConfig_apiPodLogs"></a>2.1. Property `grafana-alloy > alloyConfig > apiPodLogs`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                            | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                      |
+| --------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| - [enabled](#alloyConfig_apiPodLogs_enabled )       | No      | boolean | No         | -          | Tail pods in the listed namespaces via the Kubernetes API (loki.source.kubernetes) instead of node log files. For Fargate/API-only pods. Enable only in a deployment-type release, never the daemonset |
+| - [namespaces](#alloyConfig_apiPodLogs_namespaces ) | No      | array   | No         | -          | Namespaces whose pods are tailed via the API                                                                                                                                                           |
+
+#### <a name="alloyConfig_apiPodLogs_enabled"></a>2.1.1. Property `grafana-alloy > alloyConfig > apiPodLogs > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Tail pods in the listed namespaces via the Kubernetes API (loki.source.kubernetes) instead of node log files. For Fargate/API-only pods. Enable only in a deployment-type release, never the daemonset
+
+#### <a name="alloyConfig_apiPodLogs_namespaces"></a>2.1.2. Property `grafana-alloy > alloyConfig > apiPodLogs > namespaces`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Namespaces whose pods are tailed via the API
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+### <a name="alloyConfig_beyla"></a>2.2. Property `grafana-alloy > alloyConfig > beyla`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -732,7 +772,7 @@ Must be one of:
 | - [debug](#alloyConfig_beyla_debug )     | No      | boolean | No         | -          | Enable debug logging for Beyla BPF component                           |
 | - [enabled](#alloyConfig_beyla_enabled ) | No      | boolean | No         | -          | Enable Beyla integration (requires prometheusRemoteWrite.enabled=true) |
 
-#### <a name="alloyConfig_beyla_debug"></a>2.1.1. Property `grafana-alloy > alloyConfig > beyla > debug`
+#### <a name="alloyConfig_beyla_debug"></a>2.2.1. Property `grafana-alloy > alloyConfig > beyla > debug`
 
 |              |           |
 | ------------ | --------- |
@@ -741,7 +781,7 @@ Must be one of:
 
 **Description:** Enable debug logging for Beyla BPF component
 
-#### <a name="alloyConfig_beyla_enabled"></a>2.1.2. Property `grafana-alloy > alloyConfig > beyla > enabled`
+#### <a name="alloyConfig_beyla_enabled"></a>2.2.2. Property `grafana-alloy > alloyConfig > beyla > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -750,7 +790,7 @@ Must be one of:
 
 **Description:** Enable Beyla integration (requires prometheusRemoteWrite.enabled=true)
 
-### <a name="alloyConfig_content"></a>2.2. Property `grafana-alloy > alloyConfig > content`
+### <a name="alloyConfig_content"></a>2.3. Property `grafana-alloy > alloyConfig > content`
 
 |              |          |
 | ------------ | -------- |
@@ -759,7 +799,7 @@ Must be one of:
 
 **Description:** Custom Alloy configuration content (River format). If empty, uses default collection config.
 
-### <a name="alloyConfig_events"></a>2.3. Property `grafana-alloy > alloyConfig > events`
+### <a name="alloyConfig_events"></a>2.4. Property `grafana-alloy > alloyConfig > events`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -773,7 +813,7 @@ Must be one of:
 | ----------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------- |
 | - [enabled](#alloyConfig_events_enabled ) | No      | boolean | No         | -          | Enable collection of Kubernetes events |
 
-#### <a name="alloyConfig_events_enabled"></a>2.3.1. Property `grafana-alloy > alloyConfig > events > enabled`
+#### <a name="alloyConfig_events_enabled"></a>2.4.1. Property `grafana-alloy > alloyConfig > events > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -782,7 +822,7 @@ Must be one of:
 
 **Description:** Enable collection of Kubernetes events
 
-### <a name="alloyConfig_logging"></a>2.4. Property `grafana-alloy > alloyConfig > logging`
+### <a name="alloyConfig_logging"></a>2.5. Property `grafana-alloy > alloyConfig > logging`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -797,7 +837,7 @@ Must be one of:
 | - [format](#alloyConfig_logging_format ) | No      | enum (of string) | No         | -          | Log format for Alloy |
 | - [level](#alloyConfig_logging_level )   | No      | enum (of string) | No         | -          | Log level for Alloy  |
 
-#### <a name="alloyConfig_logging_format"></a>2.4.1. Property `grafana-alloy > alloyConfig > logging > format`
+#### <a name="alloyConfig_logging_format"></a>2.5.1. Property `grafana-alloy > alloyConfig > logging > format`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -810,7 +850,7 @@ Must be one of:
 * "logfmt"
 * "json"
 
-#### <a name="alloyConfig_logging_level"></a>2.4.2. Property `grafana-alloy > alloyConfig > logging > level`
+#### <a name="alloyConfig_logging_level"></a>2.5.2. Property `grafana-alloy > alloyConfig > logging > level`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -825,7 +865,7 @@ Must be one of:
 * "warn"
 * "error"
 
-### <a name="alloyConfig_metrics"></a>2.5. Property `grafana-alloy > alloyConfig > metrics`
+### <a name="alloyConfig_metrics"></a>2.6. Property `grafana-alloy > alloyConfig > metrics`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -839,7 +879,7 @@ Must be one of:
 | ------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------- |
 | - [enabled](#alloyConfig_metrics_enabled ) | No      | boolean | No         | -          | Enable scraping of Prometheus metrics from pods (requires prometheusRemoteWrite.enabled=true) |
 
-#### <a name="alloyConfig_metrics_enabled"></a>2.5.1. Property `grafana-alloy > alloyConfig > metrics > enabled`
+#### <a name="alloyConfig_metrics_enabled"></a>2.6.1. Property `grafana-alloy > alloyConfig > metrics > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -848,7 +888,7 @@ Must be one of:
 
 **Description:** Enable scraping of Prometheus metrics from pods (requires prometheusRemoteWrite.enabled=true)
 
-### <a name="alloyConfig_podLogs"></a>2.6. Property `grafana-alloy > alloyConfig > podLogs`
+### <a name="alloyConfig_podLogs"></a>2.7. Property `grafana-alloy > alloyConfig > podLogs`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -862,7 +902,7 @@ Must be one of:
 | ------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------- |
 | - [enabled](#alloyConfig_podLogs_enabled ) | No      | boolean | No         | -          | Enable collection of pod logs from all nodes |
 
-#### <a name="alloyConfig_podLogs_enabled"></a>2.6.1. Property `grafana-alloy > alloyConfig > podLogs > enabled`
+#### <a name="alloyConfig_podLogs_enabled"></a>2.7.1. Property `grafana-alloy > alloyConfig > podLogs > enabled`
 
 |              |           |
 | ------------ | --------- |

--- a/grafana-alloy/templates/configmap.yaml
+++ b/grafana-alloy/templates/configmap.yaml
@@ -196,6 +196,9 @@ data:
 
       forward_to = [loki.relabel.normalize_level.receiver]
     }
+    {{- end }}
+
+    {{- if or .Values.alloyConfig.podLogs.enabled .Values.alloyConfig.apiPodLogs.enabled }}
 
     loki.relabel "normalize_level" {
       forward_to = [loki.write.endpoints.receiver]
@@ -260,6 +263,80 @@ data:
         {{- end }}
       }
       {{- end }}
+    }
+    {{- end }}
+
+    {{- if .Values.alloyConfig.apiPodLogs.enabled }}
+    discovery.kubernetes "api_pods" {
+      role = "pod"
+      namespaces {
+        names = [{{ range $i, $ns := .Values.alloyConfig.apiPodLogs.namespaces }}{{ if $i }}, {{ end }}{{ $ns | quote }}{{ end }}]
+      }
+    }
+
+    discovery.relabel "api_pods" {
+      targets = discovery.kubernetes.api_pods.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+        action        = "replace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+        action        = "replace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+        action        = "replace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app"
+        action        = "replace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "job"
+        action        = "replace"
+      }
+    }
+
+    loki.source.kubernetes "api_pods" {
+      targets    = discovery.relabel.api_pods.output
+      forward_to = [loki.process.api_pod_logs.receiver]
+    }
+
+    loki.process "api_pod_logs" {
+      stage.static_labels {
+        values = {
+          cluster  = {{ .Values.clusterName | quote }},
+          exporter = "grafana-alloy",
+        }
+      }
+
+      stage.replace {
+        expression = "\\x1b\\[[0-9;]*m"
+        replace    = ""
+      }
+
+      stage.regex {
+        expression = "(?i)(?:^|[\\s\"'\\[{(,:=])(?P<level>\\b(?:trace|debug|dbg|trc|verbose|info|inf|information|notice|informational|warn|warning|wrn|error|err|fail|failure|severe|exception|critical|crit|fatal|ftl|panic|emerg|alert)\\b)(?:[\\s\"'\\]}),.:=]|$)"
+      }
+
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+
+      forward_to = [loki.relabel.normalize_level.receiver]
     }
     {{- end }}
 

--- a/grafana-alloy/values.schema.json
+++ b/grafana-alloy/values.schema.json
@@ -274,6 +274,19 @@
     "alloyConfig": {
       "type": "object",
       "properties": {
+        "apiPodLogs": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Tail pods in the listed namespaces via the Kubernetes API (loki.source.kubernetes) instead of node log files. For Fargate/API-only pods. Enable only in a deployment-type release, never the daemonset",
+              "type": "boolean"
+            },
+            "namespaces": {
+              "description": "Namespaces whose pods are tailed via the API",
+              "type": "array"
+            }
+          }
+        },
         "beyla": {
           "description": "Enable Beyla integration for eBPF-based application instrumentation",
           "type": "object",

--- a/grafana-alloy/values.yaml
+++ b/grafana-alloy/values.yaml
@@ -197,7 +197,11 @@ alloyConfig:
   # @schema description: Enable pod log collection
   podLogs:
     enabled: true # @schema description: Enable collection of pod logs from all nodes
-  
+
+  apiPodLogs:
+    enabled: false # @schema description: Tail pods in the listed namespaces via the Kubernetes API (loki.source.kubernetes) instead of node log files. For Fargate/API-only pods. Enable only in a deployment-type release, never the daemonset
+    namespaces: [] # @schema description: Namespaces whose pods are tailed via the API
+
   # @schema description: Enable Kubernetes events collection
   events:
     enabled: true # @schema description: Enable collection of Kubernetes events


### PR DESCRIPTION
Karpenter on dev-bhp runs on Fargate, where no Alloy DaemonSet pod ever lands: the fleet's log pipeline discovers pods by `spec.nodeName=<self>` and tails node log files, so the Karpenter controller's decision logs never reach central Loki. karpenter-lens needs those logs, and simply removing the node filter from the DaemonSet would open ~58 concurrent API log streams. The design instead is a second, single-replica Deployment release of this chart that tails just the namespaces it is told to, over the Kubernetes API.

This PR adds that capability to the chart:

- New `alloyConfig.apiPodLogs.{enabled, namespaces}` values. When enabled, a `discovery.kubernetes` (role=pod, namespace-scoped) -> `discovery.relabel` -> `loki.source.kubernetes` -> `loki.process "api_pod_logs"` pipeline tails the listed namespaces' pods via the API and feeds the existing `normalize_level` -> `loki.write` plumbing. Labels mirror the file-based pipeline (`namespace`/`pod`/`container`/`app`, with `job` derived from `app.kubernetes.io/name`, which Karpenter pods carry as `karpenter` - nothing hardcoded). Three deliberate deltas from the file pipeline: no `stream` label (the kubelet merges stdout/stderr on the `pods/log` path), no `stage.cri` (lines arrive raw, not CRI-framed), and no `drop older_than` (the first deploy intentionally backfills the current log file - at measured Karpenter volume that is days of history at roughly 1 MB/day of ingest).
- A re-gate that the above depends on and that fixes a latent bug: `loki.relabel "normalize_level"` and `loki.write "endpoints"` previously rendered only inside the `podLogs.enabled` gate. They are now gated on `podLogs OR apiPodLogs`, so an API-only release gets a write path.
- `values.schema.json` regenerated via `make update-schema`; chart bumped 0.10.1 -> 0.11.0 (the fleet ApplicationSets consume this chart at HEAD, so the bump ships with the change).

Because the fleet `grafana-alloy` ApplicationSet tracks chart HEAD, the bar for the template surgery is render-identity for every existing release. Verified: `helm template` of the main release using the live `argus-infra-stacks` `common.yaml` + `dev-bhp` values, before vs after this change, is byte-identical with the chart version held constant (with the version bump, the only diff is the `helm.sh/chart` label). All 91 existing unit tests pass. Also smoke-rendered the new deployment-style release with `apiPodLogs` enabled and disabled.

The companion argus-infra-stacks PR adds the `grafana-alloy-api-logs` ApplicationSet and values that consume this. Nothing deploys from this PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)