### PR TITLE
feat(stack): gateway OIDC 401 semantics (denyRedirect + apiRoutes), deterministic cookie names

### DIFF
--- a/stack/README.md
+++ b/stack/README.md
@@ -2651,22 +2651,23 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
-| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
-| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
-| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
-| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
-| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
-| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
-| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
-| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
-| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
-| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
-| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
-| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
-| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| - [apiRoutes](#cronJobs_pattern1_oidcProxyGateway_apiRoutes )                   | No      | array of object | No         | -          | API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true. |
+| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                                                                                                                                                                                                             |
+| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.                                                                                                                                                                                      |
+| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ##### <a name="cronJobs_pattern1_oidcProxyGateway_annotations"></a>2.1.27.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > annotations`
 
@@ -2678,7 +2679,55 @@ Must be one of:
 
 **Description:** Annotations to add to SecurityPolicy resources
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_clientID"></a>2.1.27.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientID`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes"></a>2.1.27.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+**Description:** API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                                        | Description |
+| ---------------------------------------------------------------------- | ----------- |
+| [apiRoutes items](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items) | -           |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items"></a>2.1.27.2.1. stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [matchType](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_matchType ) | No      | string | No         | -          | -                 |
+| - [path](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_path )           | No      | string | No         | -          | -                 |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_matchType"></a>2.1.27.2.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items > matchType`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_path"></a>2.1.27.2.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_clientID"></a>2.1.27.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientID`
 
 |              |          |
 | ------------ | -------- |
@@ -2687,7 +2736,7 @@ Must be one of:
 
 **Description:** OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_clientSecretName"></a>2.1.27.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientSecretName`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_clientSecretName"></a>2.1.27.4. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientSecretName`
 
 |              |          |
 | ------------ | -------- |
@@ -2696,7 +2745,7 @@ Must be one of:
 
 **Description:** Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieDomain"></a>2.1.27.4. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieDomain`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieDomain"></a>2.1.27.5. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieDomain`
 
 |              |          |
 | ------------ | -------- |
@@ -2705,7 +2754,7 @@ Must be one of:
 
 **Description:** Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames"></a>2.1.27.5. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames"></a>2.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -2720,7 +2769,7 @@ Must be one of:
 | - [accessToken](#cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken ) | No      | string | No         | -          | Custom name for access token cookie |
 | - [idToken](#cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken )         | No      | string | No         | -          | Custom name for ID token cookie     |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken"></a>2.1.27.5.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > accessToken`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken"></a>2.1.27.6.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > accessToken`
 
 |              |          |
 | ------------ | -------- |
@@ -2729,7 +2778,7 @@ Must be one of:
 
 **Description:** Custom name for access token cookie
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken"></a>2.1.27.5.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > idToken`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken"></a>2.1.27.6.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > idToken`
 
 |              |          |
 | ------------ | -------- |
@@ -2738,7 +2787,7 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>2.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>2.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
 
 |              |          |
 | ------------ | -------- |
@@ -2747,7 +2796,7 @@ Must be one of:
 
 **Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>2.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>2.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -2757,20 +2806,20 @@ Must be one of:
 
 **Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
 
-| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
-| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                      |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false. |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>2.1.27.7.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>2.1.27.8.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Disable per-service only if a client depends on receiving the 302
+**Description:** Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false.
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>2.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>2.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -2779,7 +2828,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>2.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>2.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -2788,7 +2837,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>2.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>2.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -2804,7 +2853,7 @@ Must be one of:
 | - [issuer](#cronJobs_pattern1_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>2.1.27.10.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>2.1.27.11.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -2813,7 +2862,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>2.1.27.10.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>2.1.27.11.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -2822,7 +2871,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>2.1.27.10.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>2.1.27.11.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -2831,7 +2880,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>2.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>2.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -2840,7 +2889,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>2.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>2.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -2857,7 +2906,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>2.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>2.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -2878,14 +2927,14 @@ Must be one of:
 | ---------------------------------------------------------------- | ----------- |
 | [scopes items](#cronJobs_pattern1_oidcProxyGateway_scopes_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>2.1.27.13.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>2.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>2.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>2.1.27.15. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -2906,7 +2955,7 @@ Must be one of:
 | -------------------------------------------------------------------- | ----------- |
 | [skipAuth items](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>2.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>2.1.27.15.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -2919,14 +2968,14 @@ Must be one of:
 | - [method](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>2.1.27.14.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>2.1.27.15.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>2.1.27.14.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>2.1.27.15.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -6757,22 +6806,23 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                             | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
-| -------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#global_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
-| - [clientID](#global_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
-| - [clientSecretName](#global_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
-| - [cookieDomain](#global_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
-| - [cookieNames](#global_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
-| - [csrfTokenTTL](#global_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
-| - [denyRedirect](#global_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
-| - [forwardAccessToken](#global_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
-| - [logoutPath](#global_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
-| - [provider](#global_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
-| - [refreshToken](#global_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
-| - [resources](#global_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
-| - [scopes](#global_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
-| - [skipAuth](#global_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
+| Property                                                             | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#global_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| - [apiRoutes](#global_oidcProxyGateway_apiRoutes )                   | No      | array of object | No         | -          | API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true. |
+| - [clientID](#global_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| - [clientSecretName](#global_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieDomain](#global_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieNames](#global_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                                                                                                                                                                                                             |
+| - [csrfTokenTTL](#global_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| - [denyRedirect](#global_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.                                                                                                                                                                                      |
+| - [forwardAccessToken](#global_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| - [logoutPath](#global_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| - [provider](#global_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [refreshToken](#global_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [resources](#global_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [scopes](#global_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [skipAuth](#global_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 #### <a name="global_oidcProxyGateway_annotations"></a>3.27.1. Property `stack > global > oidcProxyGateway > annotations`
 
@@ -6784,7 +6834,55 @@ Must be one of:
 
 **Description:** Annotations to add to SecurityPolicy resources
 
-#### <a name="global_oidcProxyGateway_clientID"></a>3.27.2. Property `stack > global > oidcProxyGateway > clientID`
+#### <a name="global_oidcProxyGateway_apiRoutes"></a>3.27.2. Property `stack > global > oidcProxyGateway > apiRoutes`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+**Description:** API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                             | Description |
+| ----------------------------------------------------------- | ----------- |
+| [apiRoutes items](#global_oidcProxyGateway_apiRoutes_items) | -           |
+
+##### <a name="global_oidcProxyGateway_apiRoutes_items"></a>3.27.2.1. stack > global > oidcProxyGateway > apiRoutes > apiRoutes items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                           | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [matchType](#global_oidcProxyGateway_apiRoutes_items_matchType ) | No      | string | No         | -          | -                 |
+| - [path](#global_oidcProxyGateway_apiRoutes_items_path )           | No      | string | No         | -          | -                 |
+
+###### <a name="global_oidcProxyGateway_apiRoutes_items_matchType"></a>3.27.2.1.1. Property `stack > global > oidcProxyGateway > apiRoutes > apiRoutes items > matchType`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="global_oidcProxyGateway_apiRoutes_items_path"></a>3.27.2.1.2. Property `stack > global > oidcProxyGateway > apiRoutes > apiRoutes items > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+#### <a name="global_oidcProxyGateway_clientID"></a>3.27.3. Property `stack > global > oidcProxyGateway > clientID`
 
 |              |          |
 | ------------ | -------- |
@@ -6793,7 +6891,7 @@ Must be one of:
 
 **Description:** OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.
 
-#### <a name="global_oidcProxyGateway_clientSecretName"></a>3.27.3. Property `stack > global > oidcProxyGateway > clientSecretName`
+#### <a name="global_oidcProxyGateway_clientSecretName"></a>3.27.4. Property `stack > global > oidcProxyGateway > clientSecretName`
 
 |              |          |
 | ------------ | -------- |
@@ -6802,7 +6900,7 @@ Must be one of:
 
 **Description:** Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)
 
-#### <a name="global_oidcProxyGateway_cookieDomain"></a>3.27.4. Property `stack > global > oidcProxyGateway > cookieDomain`
+#### <a name="global_oidcProxyGateway_cookieDomain"></a>3.27.5. Property `stack > global > oidcProxyGateway > cookieDomain`
 
 |              |          |
 | ------------ | -------- |
@@ -6811,7 +6909,7 @@ Must be one of:
 
 **Description:** Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)
 
-#### <a name="global_oidcProxyGateway_cookieNames"></a>3.27.5. Property `stack > global > oidcProxyGateway > cookieNames`
+#### <a name="global_oidcProxyGateway_cookieNames"></a>3.27.6. Property `stack > global > oidcProxyGateway > cookieNames`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -6826,7 +6924,7 @@ Must be one of:
 | - [accessToken](#global_oidcProxyGateway_cookieNames_accessToken ) | No      | string | No         | -          | Custom name for access token cookie |
 | - [idToken](#global_oidcProxyGateway_cookieNames_idToken )         | No      | string | No         | -          | Custom name for ID token cookie     |
 
-##### <a name="global_oidcProxyGateway_cookieNames_accessToken"></a>3.27.5.1. Property `stack > global > oidcProxyGateway > cookieNames > accessToken`
+##### <a name="global_oidcProxyGateway_cookieNames_accessToken"></a>3.27.6.1. Property `stack > global > oidcProxyGateway > cookieNames > accessToken`
 
 |              |          |
 | ------------ | -------- |
@@ -6835,7 +6933,7 @@ Must be one of:
 
 **Description:** Custom name for access token cookie
 
-##### <a name="global_oidcProxyGateway_cookieNames_idToken"></a>3.27.5.2. Property `stack > global > oidcProxyGateway > cookieNames > idToken`
+##### <a name="global_oidcProxyGateway_cookieNames_idToken"></a>3.27.6.2. Property `stack > global > oidcProxyGateway > cookieNames > idToken`
 
 |              |          |
 | ------------ | -------- |
@@ -6844,7 +6942,7 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-#### <a name="global_oidcProxyGateway_csrfTokenTTL"></a>3.27.6. Property `stack > global > oidcProxyGateway > csrfTokenTTL`
+#### <a name="global_oidcProxyGateway_csrfTokenTTL"></a>3.27.7. Property `stack > global > oidcProxyGateway > csrfTokenTTL`
 
 |              |          |
 | ------------ | -------- |
@@ -6853,7 +6951,7 @@ Must be one of:
 
 **Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
 
-#### <a name="global_oidcProxyGateway_denyRedirect"></a>3.27.7. Property `stack > global > oidcProxyGateway > denyRedirect`
+#### <a name="global_oidcProxyGateway_denyRedirect"></a>3.27.8. Property `stack > global > oidcProxyGateway > denyRedirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -6863,20 +6961,20 @@ Must be one of:
 
 **Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
 
-| Property                                                    | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
-| ----------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
-| - [enabled](#global_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+| Property                                                    | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                      |
+| ----------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#global_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false. |
 
-##### <a name="global_oidcProxyGateway_denyRedirect_enabled"></a>3.27.7.1. Property `stack > global > oidcProxyGateway > denyRedirect > enabled`
+##### <a name="global_oidcProxyGateway_denyRedirect_enabled"></a>3.27.8.1. Property `stack > global > oidcProxyGateway > denyRedirect > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Disable per-service only if a client depends on receiving the 302
+**Description:** Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false.
 
-#### <a name="global_oidcProxyGateway_forwardAccessToken"></a>3.27.8. Property `stack > global > oidcProxyGateway > forwardAccessToken`
+#### <a name="global_oidcProxyGateway_forwardAccessToken"></a>3.27.9. Property `stack > global > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -6885,7 +6983,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-#### <a name="global_oidcProxyGateway_logoutPath"></a>3.27.9. Property `stack > global > oidcProxyGateway > logoutPath`
+#### <a name="global_oidcProxyGateway_logoutPath"></a>3.27.10. Property `stack > global > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -6894,7 +6992,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-#### <a name="global_oidcProxyGateway_provider"></a>3.27.10. Property `stack > global > oidcProxyGateway > provider`
+#### <a name="global_oidcProxyGateway_provider"></a>3.27.11. Property `stack > global > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -6910,7 +7008,7 @@ Must be one of:
 | - [issuer](#global_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#global_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-##### <a name="global_oidcProxyGateway_provider_authorizationEndpoint"></a>3.27.10.1. Property `stack > global > oidcProxyGateway > provider > authorizationEndpoint`
+##### <a name="global_oidcProxyGateway_provider_authorizationEndpoint"></a>3.27.11.1. Property `stack > global > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -6919,7 +7017,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-##### <a name="global_oidcProxyGateway_provider_issuer"></a>3.27.10.2. Property `stack > global > oidcProxyGateway > provider > issuer`
+##### <a name="global_oidcProxyGateway_provider_issuer"></a>3.27.11.2. Property `stack > global > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -6928,7 +7026,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-##### <a name="global_oidcProxyGateway_provider_tokenEndpoint"></a>3.27.10.3. Property `stack > global > oidcProxyGateway > provider > tokenEndpoint`
+##### <a name="global_oidcProxyGateway_provider_tokenEndpoint"></a>3.27.11.3. Property `stack > global > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -6937,7 +7035,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-#### <a name="global_oidcProxyGateway_refreshToken"></a>3.27.11. Property `stack > global > oidcProxyGateway > refreshToken`
+#### <a name="global_oidcProxyGateway_refreshToken"></a>3.27.12. Property `stack > global > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -6946,7 +7044,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-#### <a name="global_oidcProxyGateway_resources"></a>3.27.12. Property `stack > global > oidcProxyGateway > resources`
+#### <a name="global_oidcProxyGateway_resources"></a>3.27.13. Property `stack > global > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -6963,7 +7061,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="global_oidcProxyGateway_scopes"></a>3.27.13. Property `stack > global > oidcProxyGateway > scopes`
+#### <a name="global_oidcProxyGateway_scopes"></a>3.27.14. Property `stack > global > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -6984,14 +7082,14 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [scopes items](#global_oidcProxyGateway_scopes_items) | -           |
 
-##### <a name="global_oidcProxyGateway_scopes_items"></a>3.27.13.1. stack > global > oidcProxyGateway > scopes > scopes items
+##### <a name="global_oidcProxyGateway_scopes_items"></a>3.27.14.1. stack > global > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="global_oidcProxyGateway_skipAuth"></a>3.27.14. Property `stack > global > oidcProxyGateway > skipAuth`
+#### <a name="global_oidcProxyGateway_skipAuth"></a>3.27.15. Property `stack > global > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -7012,7 +7110,7 @@ Must be one of:
 | --------------------------------------------------------- | ----------- |
 | [skipAuth items](#global_oidcProxyGateway_skipAuth_items) | -           |
 
-##### <a name="global_oidcProxyGateway_skipAuth_items"></a>3.27.14.1. stack > global > oidcProxyGateway > skipAuth > skipAuth items
+##### <a name="global_oidcProxyGateway_skipAuth_items"></a>3.27.15.1. stack > global > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -7025,14 +7123,14 @@ Must be one of:
 | - [method](#global_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#global_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="global_oidcProxyGateway_skipAuth_items_method"></a>3.27.14.1.1. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="global_oidcProxyGateway_skipAuth_items_method"></a>3.27.15.1.1. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="global_oidcProxyGateway_skipAuth_items_path"></a>3.27.14.1.2. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="global_oidcProxyGateway_skipAuth_items_path"></a>3.27.15.1.2. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -10881,22 +10979,23 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
-| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
-| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
-| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
-| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
-| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
-| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
-| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
-| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
-| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
-| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
-| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
-| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
-| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| - [apiRoutes](#cronJobs_pattern1_oidcProxyGateway_apiRoutes )                   | No      | array of object | No         | -          | API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true. |
+| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                                                                                                                                                                                                             |
+| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.                                                                                                                                                                                      |
+| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ##### <a name="cronJobs_pattern1_oidcProxyGateway_annotations"></a>4.1.27.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > annotations`
 
@@ -10908,7 +11007,55 @@ Must be one of:
 
 **Description:** Annotations to add to SecurityPolicy resources
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_clientID"></a>4.1.27.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientID`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes"></a>4.1.27.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+**Description:** API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                                        | Description |
+| ---------------------------------------------------------------------- | ----------- |
+| [apiRoutes items](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items) | -           |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items"></a>4.1.27.2.1. stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [matchType](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_matchType ) | No      | string | No         | -          | -                 |
+| - [path](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_path )           | No      | string | No         | -          | -                 |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_matchType"></a>4.1.27.2.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items > matchType`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_path"></a>4.1.27.2.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_clientID"></a>4.1.27.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientID`
 
 |              |          |
 | ------------ | -------- |
@@ -10917,7 +11064,7 @@ Must be one of:
 
 **Description:** OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_clientSecretName"></a>4.1.27.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientSecretName`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_clientSecretName"></a>4.1.27.4. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientSecretName`
 
 |              |          |
 | ------------ | -------- |
@@ -10926,7 +11073,7 @@ Must be one of:
 
 **Description:** Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieDomain"></a>4.1.27.4. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieDomain`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieDomain"></a>4.1.27.5. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieDomain`
 
 |              |          |
 | ------------ | -------- |
@@ -10935,7 +11082,7 @@ Must be one of:
 
 **Description:** Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames"></a>4.1.27.5. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames"></a>4.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -10950,7 +11097,7 @@ Must be one of:
 | - [accessToken](#cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken ) | No      | string | No         | -          | Custom name for access token cookie |
 | - [idToken](#cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken )         | No      | string | No         | -          | Custom name for ID token cookie     |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken"></a>4.1.27.5.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > accessToken`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken"></a>4.1.27.6.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > accessToken`
 
 |              |          |
 | ------------ | -------- |
@@ -10959,7 +11106,7 @@ Must be one of:
 
 **Description:** Custom name for access token cookie
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken"></a>4.1.27.5.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > idToken`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken"></a>4.1.27.6.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > idToken`
 
 |              |          |
 | ------------ | -------- |
@@ -10968,7 +11115,7 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>4.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>4.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
 
 |              |          |
 | ------------ | -------- |
@@ -10977,7 +11124,7 @@ Must be one of:
 
 **Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>4.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>4.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -10987,20 +11134,20 @@ Must be one of:
 
 **Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
 
-| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
-| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                      |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false. |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>4.1.27.7.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>4.1.27.8.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Disable per-service only if a client depends on receiving the 302
+**Description:** Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false.
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>4.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>4.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -11009,7 +11156,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>4.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>4.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -11018,7 +11165,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>4.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>4.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -11034,7 +11181,7 @@ Must be one of:
 | - [issuer](#cronJobs_pattern1_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>4.1.27.10.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>4.1.27.11.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -11043,7 +11190,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>4.1.27.10.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>4.1.27.11.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -11052,7 +11199,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>4.1.27.10.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>4.1.27.11.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -11061,7 +11208,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>4.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>4.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -11070,7 +11217,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>4.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>4.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -11087,7 +11234,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>4.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>4.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -11108,14 +11255,14 @@ Must be one of:
 | ---------------------------------------------------------------- | ----------- |
 | [scopes items](#cronJobs_pattern1_oidcProxyGateway_scopes_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>4.1.27.13.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>4.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>4.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>4.1.27.15. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -11136,7 +11283,7 @@ Must be one of:
 | -------------------------------------------------------------------- | ----------- |
 | [skipAuth items](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>4.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>4.1.27.15.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -11149,14 +11296,14 @@ Must be one of:
 | - [method](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>4.1.27.14.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>4.1.27.15.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>4.1.27.14.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>4.1.27.15.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -15469,22 +15616,23 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
-| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
-| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
-| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
-| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
-| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
-| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
-| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
-| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
-| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
-| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
-| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
-| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
-| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| - [apiRoutes](#cronJobs_pattern1_oidcProxyGateway_apiRoutes )                   | No      | array of object | No         | -          | API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true. |
+| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                                                                                                                                                                                                             |
+| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.                                                                                                                                                                                      |
+| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ##### <a name="cronJobs_pattern1_oidcProxyGateway_annotations"></a>7.1.27.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > annotations`
 
@@ -15496,7 +15644,55 @@ Must be one of:
 
 **Description:** Annotations to add to SecurityPolicy resources
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_clientID"></a>7.1.27.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientID`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes"></a>7.1.27.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+**Description:** API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                                        | Description |
+| ---------------------------------------------------------------------- | ----------- |
+| [apiRoutes items](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items) | -           |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items"></a>7.1.27.2.1. stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [matchType](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_matchType ) | No      | string | No         | -          | -                 |
+| - [path](#cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_path )           | No      | string | No         | -          | -                 |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_matchType"></a>7.1.27.2.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items > matchType`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_apiRoutes_items_path"></a>7.1.27.2.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > apiRoutes > apiRoutes items > path`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_clientID"></a>7.1.27.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientID`
 
 |              |          |
 | ------------ | -------- |
@@ -15505,7 +15701,7 @@ Must be one of:
 
 **Description:** OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_clientSecretName"></a>7.1.27.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientSecretName`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_clientSecretName"></a>7.1.27.4. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > clientSecretName`
 
 |              |          |
 | ------------ | -------- |
@@ -15514,7 +15710,7 @@ Must be one of:
 
 **Description:** Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieDomain"></a>7.1.27.4. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieDomain`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieDomain"></a>7.1.27.5. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieDomain`
 
 |              |          |
 | ------------ | -------- |
@@ -15523,7 +15719,7 @@ Must be one of:
 
 **Description:** Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames"></a>7.1.27.5. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames"></a>7.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -15538,7 +15734,7 @@ Must be one of:
 | - [accessToken](#cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken ) | No      | string | No         | -          | Custom name for access token cookie |
 | - [idToken](#cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken )         | No      | string | No         | -          | Custom name for ID token cookie     |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken"></a>7.1.27.5.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > accessToken`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_accessToken"></a>7.1.27.6.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > accessToken`
 
 |              |          |
 | ------------ | -------- |
@@ -15547,7 +15743,7 @@ Must be one of:
 
 **Description:** Custom name for access token cookie
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken"></a>7.1.27.5.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > idToken`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_cookieNames_idToken"></a>7.1.27.6.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > cookieNames > idToken`
 
 |              |          |
 | ------------ | -------- |
@@ -15556,7 +15752,7 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>7.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>7.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
 
 |              |          |
 | ------------ | -------- |
@@ -15565,7 +15761,7 @@ Must be one of:
 
 **Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>7.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>7.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -15575,20 +15771,20 @@ Must be one of:
 
 **Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
 
-| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
-| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                      |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false. |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>7.1.27.7.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>7.1.27.8.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Disable per-service only if a client depends on receiving the 302
+**Description:** Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false.
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>7.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>7.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -15597,7 +15793,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>7.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>7.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -15606,7 +15802,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>7.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>7.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -15622,7 +15818,7 @@ Must be one of:
 | - [issuer](#cronJobs_pattern1_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>7.1.27.10.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>7.1.27.11.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -15631,7 +15827,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>7.1.27.10.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>7.1.27.11.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -15640,7 +15836,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>7.1.27.10.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>7.1.27.11.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -15649,7 +15845,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>7.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>7.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -15658,7 +15854,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>7.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>7.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -15675,7 +15871,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>7.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>7.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -15696,14 +15892,14 @@ Must be one of:
 | ---------------------------------------------------------------- | ----------- |
 | [scopes items](#cronJobs_pattern1_oidcProxyGateway_scopes_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>7.1.27.13.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>7.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>7.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>7.1.27.15. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -15724,7 +15920,7 @@ Must be one of:
 | -------------------------------------------------------------------- | ----------- |
 | [skipAuth items](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>7.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>7.1.27.15.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -15737,14 +15933,14 @@ Must be one of:
 | - [method](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>7.1.27.14.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>7.1.27.15.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>7.1.27.14.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>7.1.27.15.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/README.md
+++ b/stack/README.md
@@ -2651,20 +2651,22 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                      |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                         |
-| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.     |
-| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret) |
-| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                 |
-| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names                                                                                                 |
-| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                |
-| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                             |
-| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                            |
-| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                    |
-| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                    |
-| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                 |
-| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                       |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
+| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
+| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
+| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
+| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
+| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
+| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
+| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
+| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
+| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
+| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
+| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
+| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
 
 ##### <a name="cronJobs_pattern1_oidcProxyGateway_annotations"></a>2.1.27.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > annotations`
 
@@ -2711,7 +2713,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Customize cookie names
+**Description:** Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.
 
 | Property                                                                      | Pattern | Type   | Deprecated | Definition | Title/Description                   |
 | ----------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------- |
@@ -2736,7 +2738,39 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>2.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>2.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>2.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
+
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>2.1.27.7.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Disable per-service only if a client depends on receiving the 302
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>2.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -2745,7 +2779,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>2.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>2.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -2754,7 +2788,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>2.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>2.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -2770,7 +2804,7 @@ Must be one of:
 | - [issuer](#cronJobs_pattern1_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>2.1.27.8.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>2.1.27.10.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -2779,7 +2813,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>2.1.27.8.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>2.1.27.10.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -2788,7 +2822,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>2.1.27.8.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>2.1.27.10.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -2797,7 +2831,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>2.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>2.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -2806,7 +2840,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>2.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>2.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -2823,7 +2857,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>2.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>2.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -2844,14 +2878,14 @@ Must be one of:
 | ---------------------------------------------------------------- | ----------- |
 | [scopes items](#cronJobs_pattern1_oidcProxyGateway_scopes_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>2.1.27.11.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>2.1.27.13.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>2.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>2.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -2872,7 +2906,7 @@ Must be one of:
 | -------------------------------------------------------------------- | ----------- |
 | [skipAuth items](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>2.1.27.12.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>2.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -2885,14 +2919,14 @@ Must be one of:
 | - [method](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>2.1.27.12.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>2.1.27.14.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>2.1.27.12.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>2.1.27.14.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -6723,20 +6757,22 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                             | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                      |
-| -------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#global_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                         |
-| - [clientID](#global_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.     |
-| - [clientSecretName](#global_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret) |
-| - [cookieDomain](#global_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                 |
-| - [cookieNames](#global_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names                                                                                                 |
-| - [forwardAccessToken](#global_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                |
-| - [logoutPath](#global_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                             |
-| - [provider](#global_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                            |
-| - [refreshToken](#global_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                    |
-| - [resources](#global_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                    |
-| - [scopes](#global_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                 |
-| - [skipAuth](#global_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                       |
+| Property                                                             | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#global_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
+| - [clientID](#global_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
+| - [clientSecretName](#global_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
+| - [cookieDomain](#global_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
+| - [cookieNames](#global_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
+| - [csrfTokenTTL](#global_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
+| - [denyRedirect](#global_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
+| - [forwardAccessToken](#global_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
+| - [logoutPath](#global_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
+| - [provider](#global_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
+| - [refreshToken](#global_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
+| - [resources](#global_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
+| - [scopes](#global_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [skipAuth](#global_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
 
 #### <a name="global_oidcProxyGateway_annotations"></a>3.27.1. Property `stack > global > oidcProxyGateway > annotations`
 
@@ -6783,7 +6819,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Customize cookie names
+**Description:** Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.
 
 | Property                                                           | Pattern | Type   | Deprecated | Definition | Title/Description                   |
 | ------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------------------------- |
@@ -6808,7 +6844,39 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-#### <a name="global_oidcProxyGateway_forwardAccessToken"></a>3.27.6. Property `stack > global > oidcProxyGateway > forwardAccessToken`
+#### <a name="global_oidcProxyGateway_csrfTokenTTL"></a>3.27.6. Property `stack > global > oidcProxyGateway > csrfTokenTTL`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
+
+#### <a name="global_oidcProxyGateway_denyRedirect"></a>3.27.7. Property `stack > global > oidcProxyGateway > denyRedirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
+
+| Property                                                    | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
+| ----------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
+| - [enabled](#global_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+
+##### <a name="global_oidcProxyGateway_denyRedirect_enabled"></a>3.27.7.1. Property `stack > global > oidcProxyGateway > denyRedirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Disable per-service only if a client depends on receiving the 302
+
+#### <a name="global_oidcProxyGateway_forwardAccessToken"></a>3.27.8. Property `stack > global > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -6817,7 +6885,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-#### <a name="global_oidcProxyGateway_logoutPath"></a>3.27.7. Property `stack > global > oidcProxyGateway > logoutPath`
+#### <a name="global_oidcProxyGateway_logoutPath"></a>3.27.9. Property `stack > global > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -6826,7 +6894,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-#### <a name="global_oidcProxyGateway_provider"></a>3.27.8. Property `stack > global > oidcProxyGateway > provider`
+#### <a name="global_oidcProxyGateway_provider"></a>3.27.10. Property `stack > global > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -6842,7 +6910,7 @@ Must be one of:
 | - [issuer](#global_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#global_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-##### <a name="global_oidcProxyGateway_provider_authorizationEndpoint"></a>3.27.8.1. Property `stack > global > oidcProxyGateway > provider > authorizationEndpoint`
+##### <a name="global_oidcProxyGateway_provider_authorizationEndpoint"></a>3.27.10.1. Property `stack > global > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -6851,7 +6919,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-##### <a name="global_oidcProxyGateway_provider_issuer"></a>3.27.8.2. Property `stack > global > oidcProxyGateway > provider > issuer`
+##### <a name="global_oidcProxyGateway_provider_issuer"></a>3.27.10.2. Property `stack > global > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -6860,7 +6928,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-##### <a name="global_oidcProxyGateway_provider_tokenEndpoint"></a>3.27.8.3. Property `stack > global > oidcProxyGateway > provider > tokenEndpoint`
+##### <a name="global_oidcProxyGateway_provider_tokenEndpoint"></a>3.27.10.3. Property `stack > global > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -6869,7 +6937,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-#### <a name="global_oidcProxyGateway_refreshToken"></a>3.27.9. Property `stack > global > oidcProxyGateway > refreshToken`
+#### <a name="global_oidcProxyGateway_refreshToken"></a>3.27.11. Property `stack > global > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -6878,7 +6946,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-#### <a name="global_oidcProxyGateway_resources"></a>3.27.10. Property `stack > global > oidcProxyGateway > resources`
+#### <a name="global_oidcProxyGateway_resources"></a>3.27.12. Property `stack > global > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -6895,7 +6963,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="global_oidcProxyGateway_scopes"></a>3.27.11. Property `stack > global > oidcProxyGateway > scopes`
+#### <a name="global_oidcProxyGateway_scopes"></a>3.27.13. Property `stack > global > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -6916,14 +6984,14 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [scopes items](#global_oidcProxyGateway_scopes_items) | -           |
 
-##### <a name="global_oidcProxyGateway_scopes_items"></a>3.27.11.1. stack > global > oidcProxyGateway > scopes > scopes items
+##### <a name="global_oidcProxyGateway_scopes_items"></a>3.27.13.1. stack > global > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="global_oidcProxyGateway_skipAuth"></a>3.27.12. Property `stack > global > oidcProxyGateway > skipAuth`
+#### <a name="global_oidcProxyGateway_skipAuth"></a>3.27.14. Property `stack > global > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -6944,7 +7012,7 @@ Must be one of:
 | --------------------------------------------------------- | ----------- |
 | [skipAuth items](#global_oidcProxyGateway_skipAuth_items) | -           |
 
-##### <a name="global_oidcProxyGateway_skipAuth_items"></a>3.27.12.1. stack > global > oidcProxyGateway > skipAuth > skipAuth items
+##### <a name="global_oidcProxyGateway_skipAuth_items"></a>3.27.14.1. stack > global > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -6957,14 +7025,14 @@ Must be one of:
 | - [method](#global_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#global_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="global_oidcProxyGateway_skipAuth_items_method"></a>3.27.12.1.1. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="global_oidcProxyGateway_skipAuth_items_method"></a>3.27.14.1.1. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="global_oidcProxyGateway_skipAuth_items_path"></a>3.27.12.1.2. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="global_oidcProxyGateway_skipAuth_items_path"></a>3.27.14.1.2. Property `stack > global > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -10813,20 +10881,22 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                      |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                         |
-| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.     |
-| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret) |
-| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                 |
-| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names                                                                                                 |
-| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                |
-| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                             |
-| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                            |
-| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                    |
-| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                    |
-| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                 |
-| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                       |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
+| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
+| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
+| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
+| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
+| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
+| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
+| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
+| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
+| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
+| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
+| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
+| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
 
 ##### <a name="cronJobs_pattern1_oidcProxyGateway_annotations"></a>4.1.27.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > annotations`
 
@@ -10873,7 +10943,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Customize cookie names
+**Description:** Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.
 
 | Property                                                                      | Pattern | Type   | Deprecated | Definition | Title/Description                   |
 | ----------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------- |
@@ -10898,7 +10968,39 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>4.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>4.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>4.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
+
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>4.1.27.7.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Disable per-service only if a client depends on receiving the 302
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>4.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -10907,7 +11009,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>4.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>4.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -10916,7 +11018,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>4.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>4.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -10932,7 +11034,7 @@ Must be one of:
 | - [issuer](#cronJobs_pattern1_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>4.1.27.8.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>4.1.27.10.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -10941,7 +11043,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>4.1.27.8.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>4.1.27.10.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -10950,7 +11052,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>4.1.27.8.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>4.1.27.10.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -10959,7 +11061,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>4.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>4.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -10968,7 +11070,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>4.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>4.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -10985,7 +11087,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>4.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>4.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -11006,14 +11108,14 @@ Must be one of:
 | ---------------------------------------------------------------- | ----------- |
 | [scopes items](#cronJobs_pattern1_oidcProxyGateway_scopes_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>4.1.27.11.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>4.1.27.13.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>4.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>4.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -11034,7 +11136,7 @@ Must be one of:
 | -------------------------------------------------------------------- | ----------- |
 | [skipAuth items](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>4.1.27.12.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>4.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -11047,14 +11149,14 @@ Must be one of:
 | - [method](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>4.1.27.12.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>4.1.27.14.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>4.1.27.12.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>4.1.27.14.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -15367,20 +15469,22 @@ Must be one of:
 
 **Description:** Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                      |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                         |
-| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.     |
-| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret) |
-| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                 |
-| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names                                                                                                 |
-| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                |
-| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                             |
-| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                            |
-| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                    |
-| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                    |
-| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                 |
-| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                       |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [annotations](#cronJobs_pattern1_oidcProxyGateway_annotations )               | No      | object          | No         | -          | Annotations to add to SecurityPolicy resources                                                                                                                                                                                                                                                                                                                                                                 |
+| - [clientID](#cronJobs_pattern1_oidcProxyGateway_clientID )                     | No      | string          | No         | -          | OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.                                                                                                                                                                                                                                                                                             |
+| - [clientSecretName](#cronJobs_pattern1_oidcProxyGateway_clientSecretName )     | No      | string          | No         | -          | Kubernetes secret containing client-id and client-secret keys (created by the argus-global-oidc ClusterExternalSecret)                                                                                                                                                                                                                                                                                         |
+| - [cookieDomain](#cronJobs_pattern1_oidcProxyGateway_cookieDomain )             | No      | string          | No         | -          | Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)                                                                                                                                                                                                                                                                                                                         |
+| - [cookieNames](#cronJobs_pattern1_oidcProxyGateway_cookieNames )               | No      | object          | No         | -          | Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.                                                                                                                                                                        |
+| - [csrfTokenTTL](#cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL )             | No      | string          | No         | -          | Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)                                                                                                                                                                                                                                                                                                                      |
+| - [denyRedirect](#cronJobs_pattern1_oidcProxyGateway_denyRedirect )             | No      | object          | No         | -          | Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid. |
+| - [forwardAccessToken](#cronJobs_pattern1_oidcProxyGateway_forwardAccessToken ) | No      | boolean         | No         | -          | Forward access token to backend service                                                                                                                                                                                                                                                                                                                                                                        |
+| - [logoutPath](#cronJobs_pattern1_oidcProxyGateway_logoutPath )                 | No      | string          | No         | -          | Path for logout operations                                                                                                                                                                                                                                                                                                                                                                                     |
+| - [provider](#cronJobs_pattern1_oidcProxyGateway_provider )                     | No      | object          | No         | -          | OIDC provider configuration                                                                                                                                                                                                                                                                                                                                                                                    |
+| - [refreshToken](#cronJobs_pattern1_oidcProxyGateway_refreshToken )             | No      | boolean         | No         | -          | Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)                                                                                                                                                                                                                                                                                                                            |
+| - [resources](#cronJobs_pattern1_oidcProxyGateway_resources )                   | No      | array           | No         | -          | Optional OAuth2 resources parameter                                                                                                                                                                                                                                                                                                                                                                            |
+| - [scopes](#cronJobs_pattern1_oidcProxyGateway_scopes )                         | No      | array of string | No         | -          | OIDC scopes to request                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [skipAuth](#cronJobs_pattern1_oidcProxyGateway_skipAuth )                     | No      | array of object | No         | -          | Paths to skip authentication (creates separate public HTTPRoute)                                                                                                                                                                                                                                                                                                                                               |
 
 ##### <a name="cronJobs_pattern1_oidcProxyGateway_annotations"></a>7.1.27.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > annotations`
 
@@ -15427,7 +15531,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Customize cookie names
+**Description:** Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.
 
 | Property                                                                      | Pattern | Type   | Deprecated | Definition | Title/Description                   |
 | ----------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------- |
@@ -15452,7 +15556,39 @@ Must be one of:
 
 **Description:** Custom name for ID token cookie
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>7.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_csrfTokenTTL"></a>7.1.27.6. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > csrfTokenTTL`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect"></a>7.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
+
+| Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                                                 |
+| ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled ) | No      | boolean | No         | -          | Disable per-service only if a client depends on receiving the 302 |
+
+###### <a name="cronJobs_pattern1_oidcProxyGateway_denyRedirect_enabled"></a>7.1.27.7.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > denyRedirect > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Disable per-service only if a client depends on receiving the 302
+
+##### <a name="cronJobs_pattern1_oidcProxyGateway_forwardAccessToken"></a>7.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > forwardAccessToken`
 
 |              |           |
 | ------------ | --------- |
@@ -15461,7 +15597,7 @@ Must be one of:
 
 **Description:** Forward access token to backend service
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>7.1.27.7. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_logoutPath"></a>7.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > logoutPath`
 
 |              |          |
 | ------------ | -------- |
@@ -15470,7 +15606,7 @@ Must be one of:
 
 **Description:** Path for logout operations
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>7.1.27.8. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_provider"></a>7.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -15486,7 +15622,7 @@ Must be one of:
 | - [issuer](#cronJobs_pattern1_oidcProxyGateway_provider_issuer )                               | No      | string | No         | -          | OIDC provider issuer URL                                               |
 | - [tokenEndpoint](#cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint )                 | No      | string | No         | -          | Optional token endpoint (auto-discovered by provider if empty)         |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>7.1.27.8.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_authorizationEndpoint"></a>7.1.27.10.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > authorizationEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -15495,7 +15631,7 @@ Must be one of:
 
 **Description:** Optional authorization endpoint (auto-discovered by provider if empty)
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>7.1.27.8.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_issuer"></a>7.1.27.10.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -15504,7 +15640,7 @@ Must be one of:
 
 **Description:** OIDC provider issuer URL
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>7.1.27.8.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_provider_tokenEndpoint"></a>7.1.27.10.3. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > provider > tokenEndpoint`
 
 |              |          |
 | ------------ | -------- |
@@ -15513,7 +15649,7 @@ Must be one of:
 
 **Description:** Optional token endpoint (auto-discovered by provider if empty)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>7.1.27.9. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_refreshToken"></a>7.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > refreshToken`
 
 |              |           |
 | ------------ | --------- |
@@ -15522,7 +15658,7 @@ Must be one of:
 
 **Description:** Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>7.1.27.10. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_resources"></a>7.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > resources`
 
 |              |         |
 | ------------ | ------- |
@@ -15539,7 +15675,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>7.1.27.11. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_scopes"></a>7.1.27.13. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > scopes`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -15560,14 +15696,14 @@ Must be one of:
 | ---------------------------------------------------------------- | ----------- |
 | [scopes items](#cronJobs_pattern1_oidcProxyGateway_scopes_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>7.1.27.11.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_scopes_items"></a>7.1.27.13.1. stack > cronJobs > ^.*$ > oidcProxyGateway > scopes > scopes items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>7.1.27.12. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
+##### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth"></a>7.1.27.14. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -15588,7 +15724,7 @@ Must be one of:
 | -------------------------------------------------------------------- | ----------- |
 | [skipAuth items](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items) | -           |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>7.1.27.12.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items"></a>7.1.27.14.1. stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -15601,14 +15737,14 @@ Must be one of:
 | - [method](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method ) | No      | string | No         | -          | -                 |
 | - [path](#cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path )     | No      | string | No         | -          | -                 |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>7.1.27.12.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_method"></a>7.1.27.14.1.1. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > method`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>7.1.27.12.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
+###### <a name="cronJobs_pattern1_oidcProxyGateway_skipAuth_items_path"></a>7.1.27.14.1.2. Property `stack > cronJobs > ^.*$ > oidcProxyGateway > skipAuth > skipAuth items > path`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -480,9 +480,32 @@ oidc:
   cookieNames:
     accessToken: {{ $.Values.oidcProxyGateway.cookieNames.accessToken | default (printf "AccessToken-%s-%s" $.Release.Namespace (include "service.name" $)) | quote }}
     idToken: {{ $.Values.oidcProxyGateway.cookieNames.idToken | default (printf "IdToken-%s-%s" $.Release.Namespace (include "service.name" $)) | quote }}
-  {{- if $.Values.oidcProxyGateway.denyRedirect.enabled }}
+  {{- $apiRoutes := $.Values.oidcProxyGateway.apiRoutes | default list }}
+  {{- $denyEnabled := $.Values.oidcProxyGateway.denyRedirect.enabled }}
+  {{- $defaultMatcherCount := 0 }}
+  {{- if $denyEnabled }}{{- $defaultMatcherCount = 3 }}{{- end }}
+  {{- if gt (add (len $apiRoutes) $defaultMatcherCount) 16 }}
+    {{- fail (printf "oidcProxyGateway.apiRoutes: Envoy Gateway caps denyRedirect matchers at 16, got %d apiRoutes plus %d default matchers" (len $apiRoutes) $defaultMatcherCount) }}
+  {{- end }}
+  {{- range $apiRoutes }}
+    {{- $matchType := .matchType | default "Prefix" }}
+    {{- if not (has $matchType (list "Prefix" "Exact" "RegularExpression")) }}
+      {{- fail (printf "oidcProxyGateway.apiRoutes: matchType %q is not one of Prefix, Exact, RegularExpression" $matchType) }}
+    {{- end }}
+    {{- if not .path }}
+      {{- fail "oidcProxyGateway.apiRoutes: path must not be empty" }}
+    {{- end }}
+    {{- if and (ne $matchType "RegularExpression") (not (hasPrefix "/" .path)) }}
+      {{- fail (printf "oidcProxyGateway.apiRoutes: path %q must start with / for %s matching (request paths always do, so it would never match)" .path $matchType) }}
+    {{- end }}
+    {{- if and (eq $matchType "Prefix") (eq .path "/") }}
+      {{- fail "oidcProxyGateway.apiRoutes: Prefix / would 401 every request including browser navigations, making login impossible. For a fully headless API, use matchType RegularExpression deliberately." }}
+    {{- end }}
+  {{- end }}
+  {{- if or $denyEnabled (gt (len $apiRoutes) 0) }}
   denyRedirect:
     headers:
+      {{- if $denyEnabled }}
       - name: Sec-Fetch-Mode
         type: RegularExpression
         value: "cors|no-cors|same-origin"
@@ -492,6 +515,12 @@ oidc:
       - name: X-Requested-With
         type: Exact
         value: XMLHttpRequest
+      {{- end }}
+      {{- range $apiRoutes }}
+      - name: ":path"
+        type: {{ .matchType | default "Prefix" }}
+        value: {{ .path | quote }}
+      {{- end }}
   {{- end }}
   {{- if $.Values.oidcProxyGateway.csrfTokenTTL }}
   csrfTokenTTL: {{ $.Values.oidcProxyGateway.csrfTokenTTL | quote }}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -477,14 +477,24 @@ oidc:
   {{- if $.Values.oidcProxyGateway.cookieDomain }}
   cookieDomain: {{ $.Values.oidcProxyGateway.cookieDomain | quote }}
   {{- end }}
-  {{- if or $.Values.oidcProxyGateway.cookieNames.accessToken $.Values.oidcProxyGateway.cookieNames.idToken }}
   cookieNames:
-    {{- if $.Values.oidcProxyGateway.cookieNames.accessToken }}
-    accessToken: {{ $.Values.oidcProxyGateway.cookieNames.accessToken | quote }}
-    {{- end }}
-    {{- if $.Values.oidcProxyGateway.cookieNames.idToken }}
-    idToken: {{ $.Values.oidcProxyGateway.cookieNames.idToken | quote }}
-    {{- end }}
+    accessToken: {{ $.Values.oidcProxyGateway.cookieNames.accessToken | default (printf "AccessToken-%s-%s" $.Release.Namespace (include "service.name" $)) | quote }}
+    idToken: {{ $.Values.oidcProxyGateway.cookieNames.idToken | default (printf "IdToken-%s-%s" $.Release.Namespace (include "service.name" $)) | quote }}
+  {{- if $.Values.oidcProxyGateway.denyRedirect.enabled }}
+  denyRedirect:
+    headers:
+      - name: Sec-Fetch-Mode
+        type: RegularExpression
+        value: "cors|no-cors|same-origin"
+      - name: Sec-Fetch-Dest
+        type: RegularExpression
+        value: "empty|script|style|image|font"
+      - name: X-Requested-With
+        type: Exact
+        value: XMLHttpRequest
+  {{- end }}
+  {{- if $.Values.oidcProxyGateway.csrfTokenTTL }}
+  csrfTokenTTL: {{ $.Values.oidcProxyGateway.csrfTokenTTL | quote }}
   {{- end }}
   {{- if $.Values.oidcProxyGateway.scopes }}
   scopes:

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -389,6 +389,351 @@ tests:
           path: spec.oidc.cookieNames.idToken
           value: MyId
 
+  - it: should render apiRoutes as :path matchers after the default denyRedirect headers
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          apiRoutes:
+            - path: /api
+            - path: /graphql(\?.*)?$
+              matchType: RegularExpression
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[0].name
+          value: Sec-Fetch-Mode
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[3].name
+          value: ":path"
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[3].type
+          value: Prefix
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[3].value
+          value: /api
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[4].type
+          value: RegularExpression
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[4].value
+          value: /graphql(\?.*)?$
+
+  - it: should render only :path matchers when denyRedirect is disabled but apiRoutes are set
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          denyRedirect:
+            enabled: false
+          apiRoutes:
+            - path: /api
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[0].name
+          value: ":path"
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.oidc.denyRedirect.headers
+          count: 1
+
+  - it: should carry apiRoutes onto per-rule policies and keep the public policy oidc-free
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          rules:
+            - host: alt.example.com
+          cors:
+            enabled: true
+            allowOrigins:
+              - https://api.example.com
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          skipAuth:
+            - path: /healthz
+          apiRoutes:
+            - path: /api
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.oidc.denyRedirect.headers[3].name
+          value: ":path"
+      - documentIndex: 1
+        equal:
+          path: spec.oidc.denyRedirect.headers[3].value
+          value: /api
+      - documentIndex: 2
+        notExists:
+          path: spec.oidc
+
+  - it: should fail on an empty apiRoutes path
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          apiRoutes:
+            - path: ""
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "path must not be empty"
+
+  - it: should fail on a Prefix apiRoutes path without a leading slash
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          apiRoutes:
+            - path: api
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "must start with /"
+
+  - it: should fail on a Prefix apiRoutes path of /
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          apiRoutes:
+            - path: /
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "making login impossible"
+
+  - it: should fail on an unknown apiRoutes matchType
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          apiRoutes:
+            - path: /api
+              matchType: prefix
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "not one of Prefix, Exact, RegularExpression"
+
+  - it: should allow 13 apiRoutes with default matchers and fail on 14
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          apiRoutes:
+            - path: /a1
+            - path: /a2
+            - path: /a3
+            - path: /a4
+            - path: /a5
+            - path: /a6
+            - path: /a7
+            - path: /a8
+            - path: /a9
+            - path: /a10
+            - path: /a11
+            - path: /a12
+            - path: /a13
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.oidc.denyRedirect.headers
+          count: 16
+
+  - it: should fail on 14 apiRoutes with default matchers enabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          apiRoutes:
+            - path: /a1
+            - path: /a2
+            - path: /a3
+            - path: /a4
+            - path: /a5
+            - path: /a6
+            - path: /a7
+            - path: /a8
+            - path: /a9
+            - path: /a10
+            - path: /a11
+            - path: /a12
+            - path: /a13
+            - path: /a14
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "caps denyRedirect matchers at 16"
+
+  - it: should allow 16 apiRoutes when default matchers are disabled and fail on 17
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          denyRedirect:
+            enabled: false
+          apiRoutes:
+            - path: /a1
+            - path: /a2
+            - path: /a3
+            - path: /a4
+            - path: /a5
+            - path: /a6
+            - path: /a7
+            - path: /a8
+            - path: /a9
+            - path: /a10
+            - path: /a11
+            - path: /a12
+            - path: /a13
+            - path: /a14
+            - path: /a15
+            - path: /a16
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        lengthEqual:
+          path: spec.oidc.denyRedirect.headers
+          count: 16
+
+  - it: should fail on 17 apiRoutes when default matchers are disabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          denyRedirect:
+            enabled: false
+          apiRoutes:
+            - path: /a1
+            - path: /a2
+            - path: /a3
+            - path: /a4
+            - path: /a5
+            - path: /a6
+            - path: /a7
+            - path: /a8
+            - path: /a9
+            - path: /a10
+            - path: /a11
+            - path: /a12
+            - path: /a13
+            - path: /a14
+            - path: /a15
+            - path: /a16
+            - path: /a17
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "caps denyRedirect matchers at 16"
+
   - it: should render identical cookie names on per-rule policies and none on public
     release:
       name: release-name

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -303,3 +303,131 @@ tests:
       - documentIndex: 1
         exists:
           path: spec.cors
+
+  - it: should render denyRedirect by default and deterministic cookie names
+    release:
+      name: release-name
+      namespace: argus-karpenter-lens-rdev
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        app: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[0].name
+          value: Sec-Fetch-Mode
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[0].type
+          value: RegularExpression
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[0].value
+          value: cors|no-cors|same-origin
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.denyRedirect.headers[2].name
+          value: X-Requested-With
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.cookieNames.accessToken
+          value: AccessToken-argus-karpenter-lens-rdev-app
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.cookieNames.idToken
+          value: IdToken-argus-karpenter-lens-rdev-app
+      - documentIndex: 0
+        notExists:
+          path: spec.oidc.csrfTokenTTL
+
+  - it: should omit denyRedirect when disabled and let cookieNames overrides win
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          denyRedirect:
+            enabled: false
+          csrfTokenTTL: 5m
+          cookieNames:
+            accessToken: MyAccess
+            idToken: MyId
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: spec.oidc.denyRedirect
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.csrfTokenTTL
+          value: 5m
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.cookieNames.accessToken
+          value: MyAccess
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.cookieNames.idToken
+          value: MyId
+
+  - it: should render identical cookie names on per-rule policies and none on public
+    release:
+      name: release-name
+      namespace: testns
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          rules:
+            - host: alt.example.com
+          cors:
+            enabled: true
+            allowOrigins:
+              - https://api.example.com
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          skipAuth:
+            - path: /healthz
+      services:
+        app: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.oidc.cookieNames.accessToken
+          value: AccessToken-testns-app
+      - documentIndex: 1
+        equal:
+          path: spec.oidc.cookieNames.accessToken
+          value: AccessToken-testns-app
+      - documentIndex: 1
+        equal:
+          path: spec.oidc.denyRedirect.headers[0].name
+          value: Sec-Fetch-Mode
+      - documentIndex: 2
+        notExists:
+          path: spec.oidc

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -950,6 +950,21 @@
               "description": "Annotations to add to SecurityPolicy resources",
               "type": "object"
             },
+            "apiRoutes": {
+              "description": "API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "matchType": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "clientID": {
               "description": "OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.",
               "type": "string"
@@ -985,7 +1000,7 @@
               "type": "object",
               "properties": {
                 "enabled": {
-                  "description": "Disable per-service only if a client depends on receiving the 302",
+                  "description": "Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false.",
                   "type": "boolean"
                 }
               }

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -963,7 +963,7 @@
               "type": "string"
             },
             "cookieNames": {
-              "description": "Customize cookie names",
+              "description": "Customize cookie names. When empty, deterministic names are generated as AccessToken-\u003cnamespace\u003e-\u003cservice\u003e / IdToken-\u003cnamespace\u003e-\u003cservice\u003e. With cookieDomain set, two stacks of the same app in one namespace would share these names.",
               "type": "object",
               "properties": {
                 "accessToken": {
@@ -973,6 +973,20 @@
                 "idToken": {
                   "description": "Custom name for ID token cookie",
                   "type": "string"
+                }
+              }
+            },
+            "csrfTokenTTL": {
+              "description": "Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)",
+              "type": "string"
+            },
+            "denyRedirect": {
+              "description": "Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Disable per-service only if a client depends on receiving the 302",
+                  "type": "boolean"
                 }
               }
             },

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -407,9 +407,12 @@ global: # @schema description: Global configuration for the stack - this serves 
     forwardAccessToken: false # @schema description: Forward access token to backend service
     refreshToken: true # @schema description: Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
     cookieDomain: "" # @schema description: Optional root domain for sharing tokens across subdomains (e.g., cluster.dev.czi.team)
-    cookieNames: # @schema description: Customize cookie names
+    cookieNames: # @schema description: Customize cookie names. When empty, deterministic names are generated as AccessToken-<namespace>-<service> / IdToken-<namespace>-<service>. With cookieDomain set, two stacks of the same app in one namespace would share these names.
       accessToken: "" # @schema description: Custom name for access token cookie
       idToken: "" # @schema description: Custom name for ID token cookie
+    denyRedirect: # @schema description: Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
+      enabled: true # @schema description: Disable per-service only if a client depends on receiving the 302
+    csrfTokenTTL: "" # @schema description: Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
     scopes: # @schema description: OIDC scopes to request
       - "openid"
       - "profile"

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -403,6 +403,7 @@ global: # @schema description: Global configuration for the stack - this serves 
       authorizationEndpoint: "" # @schema description: Optional authorization endpoint (auto-discovered by provider if empty)
       tokenEndpoint: "" # @schema description: Optional token endpoint (auto-discovered by provider if empty)
     skipAuth: [] # @schema type: array; item: object; itemProperties: {"path": {"type": "string"}, "method": {"type": "string"}}; description: Paths to skip authentication (creates separate public HTTPRoute)
+    apiRoutes: [] # @schema type: array; item: object; itemProperties: {"path": {"type": "string"}, "matchType": {"type": "string"}}; description: API paths where unauthenticated requests get 401 instead of a login redirect. Auth is still enforced - unlike skipAuth, which removes it entirely. Replaces the oauth2-proxy --api-route flag. matchType is Prefix (default), Exact, or RegularExpression. Matching runs on the full request path including the query string - Exact and anchored regex values need a (\?.*)?$ tail to match requests carrying queries. Prefix is a plain string prefix (/api also matches /apikeys). A service-level list replaces the global list entirely. Only takes effect when gateway.oidcProtected is true.
     logoutPath: "/logout" # @schema description: Path for logout operations
     forwardAccessToken: false # @schema description: Forward access token to backend service
     refreshToken: true # @schema description: Use refresh tokens to refresh access tokens (default true in Envoy Gateway v1.6.0+)
@@ -411,7 +412,7 @@ global: # @schema description: Global configuration for the stack - this serves 
       accessToken: "" # @schema description: Custom name for access token cookie
       idToken: "" # @schema description: Custom name for ID token cookie
     denyRedirect: # @schema description: Return 401 instead of a 302-to-IdP for non-navigation requests (fetch/XHR/EventSource) with missing or expired tokens. Browsers cannot complete the OIDC redirect from fetch. The 401 gives SPAs a deterministic session-expired signal and stops per-request nonce/verifier cookie minting. Navigations still redirect, and matched requests still get silent token refresh while the refresh token is valid.
-      enabled: true # @schema description: Disable per-service only if a client depends on receiving the 302
+      enabled: true # @schema description: Disable per-service only if a client depends on receiving the 302. apiRoutes still return 401 even when this is false.
     csrfTokenTTL: "" # @schema description: Optional TTL for the OauthNonce/CodeVerifier cookies, e.g. 5m (Envoy Gateway default 10m)
     scopes: # @schema description: OIDC scopes to request
       - "openid"


### PR DESCRIPTION
## The problem

When an Okta session expires, the Gateway-variant OIDC SecurityPolicy answers **every** request with a 302 to Okta — including the background API polls and SSE streams an open SPA tab keeps running. A fetch can never complete that redirect (CORS), but each 302 mints a fresh `OauthNonce.<flow-id>` + `CodeVerifier.<flow-id>` cookie pair, and the abandoned pairs are never cleaned up (Max-Age 600). An idle karpenter-lens tab accumulated ~50 pairs in 10 minutes, the Cookie header outgrew HTTP/2 limits, and the user saw `ERR_HTTP2_PROTOCOL_ERROR` until they cleared cookies. Non-browser clients hit the same wall differently: curl and python-requests send no auth cookies and get an Okta HTML page instead of a usable 401 (requests even follows the redirect and returns 200 HTML). The ingress variant had neither problem — oauth2-proxy's `isAjax` returns 401 to JSON clients, and `--api-route` (used by at least seven app repos and the edu-rust-api-template) did the same per path.

## The fix

**`denyRedirect` (default on)** — requests bearing non-navigation Fetch Metadata (`Sec-Fetch-Mode: cors|no-cors|same-origin`, `Sec-Fetch-Dest: empty|script|style|image|font`, or `X-Requested-With: XMLHttpRequest`, OR-combined) get a **401 with no Set-Cookie** instead of the 302. Navigations never match, so login, deep links, and the callback flow are untouched; matched requests still get silent token refresh while a refresh token is valid, so 401s only appear when interactive re-auth is genuinely required.

**`apiRoutes`** (review-requested `--api-route` parity) — headers can't help header-less clients, so `oidcProxyGateway.apiRoutes: [{path: /api}]` renders `:path` matchers into the same denyRedirect list: every unauthenticated request under `/api` gets a clean 401, browser or not. `matchType` is `Prefix` (default), `Exact`, or `RegularExpression` (RE2 full-string). Matching runs on the full `:path` **including the query string** (Exact/anchored regexes need a `(\?.*)?$` tail); `Prefix` is a plain string prefix (`/api` also matches `/apikeys`) — both tighter than oauth2-proxy's unanchored regex. `/oauth2/callback` and `/logout` are exempt by Envoy filter structure, and this is response-mode selection, not an authz boundary — auth is enforced either way. Template guards fail fast on the footguns: empty path, missing leading `/`, `Prefix: /` (would 401 every navigation and make login impossible), unknown matchType, and Envoy Gateway's 16-matcher cap. A second SecurityPolicy on a split-out API route was not an option: each policy gets its own hash-suffixed `OauthHMAC`/`OauthExpires` cookies and could never validate the main policy's session. Usual values-merge rule applies: a service-level list replaces the global one.

**Deterministic cookie names** — `cookieNames` always renders as `AccessToken-<namespace>-<service>` / `IdToken-<namespace>-<service>` (values override wins) instead of the hash-of-SecurityPolicy-UID suffix, enabling future JWT-from-cookie extraction and predictable debugging. Sessions still don't survive stack recreation — the session-validating `OauthHMAC`/`OauthExpires` cookies keep the UID hash and aren't renameable upstream (envoyproxy/gateway#5152, #7359).

**`csrfTokenTTL`** — optional knob for the nonce/verifier cookie TTL (unset everywhere; Envoy Gateway default 10m).

## Session model vs the redis-backed ingress variant (review-raised)

oauth2-proxy stores sessions in redis: logout deletes the session, revoking it everywhere immediately. The Gateway variant is stateless — logout clears that browser's cookies, and a captured session cookie replays until the access token's `exp` (~1h); Envoy never calls a revocation endpoint. (The redis model had the same replay gap for JWTs already forwarded via `--pass-authorization-header`.) Logout does end the Okta SSO session: with our defaults EG discovers `end_session_endpoint` from the issuer (confirmed in czi.okta.com's discovery doc) and Envoy 302s there with `id_token_hint` after deleting all five session cookies. The catch, from Envoy source: `post_logout_redirect_uri=https://<host>/` is always sent and not configurable, and Okta rejects an unregistered URI with a 400 error page **without ending the SSO session** — each gateway host's sign-out redirect URI must be registered on the argus-global-oidc Okta app. Tracked with the redis decommission in CCIE-6977. Two more edges: overriding both provider endpoints skips discovery and silently degrades logout to cookie-clear-only, and successful end-session logout is org-wide Okta logout — more aggressive than oauth2-proxy's. Bearer-JWT machine clients (`--skip-jwt-bearer-tokens` was hardcoded on for every ingress app) are a separate gap: CCIE-6979.

## Consumer impact (adopting at your next chart bump)

- One-time re-auth when the cookie names change (a redirect flicker with a live Okta session).
- **SPA contract**: treat API 401 as session-expired — latch, stop polling/streams, offer a Reload. **Never redirect to `/oauth2/start`** (oauth2-proxy endpoint, 404s under the Gateway variant). Recipe: `fetch(url, {redirect: 'manual'})`, check `response.type === 'opaqueredirect'` before `ok`, latch on 401, close EventSources via the latch. Reference: karpenter-lens `web/src/session.ts` + `api.ts`.
- Migrating from the ingress variant: `oidcProxy.extraArgs: ["--api-route=/api"]` → `oidcProxyGateway.apiRoutes: [{path: /api}]` (docs tracked in CCIE-6978).

## Verified

Matcher OR-semantics and the `:path` idiom source-verified at EG v1.8.1 / Envoy v1.38.1 (CRD pattern, reconciler pass-through, PGV on the xDS proto, header-map evaluation); rendered SecurityPolicy validated against the upstream v1.8.1 CRD schema; helm-unittest 208/208 including apiRoutes ordering, per-rule carry, public-policy exclusion, all five fail-guards, and the 13/14/16/17 matcher-cap boundaries. Post-deploy matrix: `Sec-Fetch-Mode: cors` → 401 no Set-Cookie; bare curl on an apiRoutes path → 401; navigation → 302; logout → 302 to Okta end-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
