### PR TITLE
feat(stack): right-size oidcProxy default resources

### DIFF
--- a/stack/tests/oidc_test.yaml
+++ b/stack/tests/oidc_test.yaml
@@ -39,6 +39,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: sets right-sized default resources on the proxy container
+    set:
+      global:
+        oidcProxy:
+          enabled: true
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
   - it: sets additionalSecrets in envFrom
     set:
       global:

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -389,11 +389,11 @@ global: # @schema description: Global configuration for the stack - this serves 
     #   - --another-flag=2
     resources:
       limits:
-        cpu: "2" # @schema oneOf: [{ "type": "string" },{ "type": "number" }]; description: CPU limit
-        memory: 4Gi # @schema description: Memory limit
+        cpu: 500m # @schema oneOf: [{ "type": "string" },{ "type": "number" }]; description: CPU limit
+        memory: 256Mi # @schema description: Memory limit
       requests:
-        cpu: 2 # @schema oneOf: [{ "type": "string" },{ "type": "number" }]; description: CPU request
-        memory: 4Gi # @schema description: Memory request
+        cpu: 100m # @schema oneOf: [{ "type": "string" },{ "type": "number" }]; description: CPU request
+        memory: 64Mi # @schema description: Memory request
 
   oidcProxyGateway: # @schema description: Envoy Gateway OIDC configuration (used when gateway.oidcProtected is true). Defaults read clientID and clientSecret from the argus-global-oidc ClusterExternalSecret. Override per-service when needed.
     clientID: "" # @schema description: OIDC client ID string override. When empty, clientIDRef reads the value from the secret named by clientSecretName.


### PR DESCRIPTION
## Summary

Right-sizes the stack chart's `oidcProxy` (oauth2-proxy) defaults from requests = limits = 2 CPU / 4Gi to requests **100m / 64Mi**, limits **500m / 256Mi**.

- Sized from fleet measurement (central Prometheus, deduplicated by pod): 444 pods in 154 stacks across 22 clusters, 100% on the chart default, reserving 888 vCPU / ~1.7 TiB while 7-day peaks are 146m CPU / 36 MiB memory with zero OOMKills.
- New limits keep real headroom: 3.4x the worst 5-min CPU burst and 7x the highest memory working set ever observed on any replica.
- Pods move from Guaranteed to Burstable QoS — acceptable with 3 zone-spread replicas and usage far below the new requests. `replicaCount: 3` and per-stack `oidcProxy.resources` overrides are unchanged.
- Rollout is gradual by design: apps pin the stack chart version in `.infra/<env>/Chart.yaml`, so new defaults land per-app on their next chart bump — no fleet-wide restart. Fully adopted, this frees ~844 vCPU / ~1.7 TiB of reservation.
- Adds a unittest pinning the new defaults (resources were previously untested).

## Test plan

- [x] `helm unittest stack` — 195 tests / 25 suites pass, including the new resources assertion
- [x] `helm template` with `global.oidcProxy.enabled=true` renders the new requests/limits; `make update-schema` produces no diff
- [ ] Post-release: watch adopters for OOMKilled terminations and CFS throttling on `.+-oidc-proxy` containers (expected none given the headroom above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)