### PR TITLE
feat(stack): opt-in gateway.jwt for Bearer-token auth on the Envoy SecurityPolicy

### DIFF
--- a/stack/README.md
+++ b/stack/README.md
@@ -1026,32 +1026,14 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
-| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
-| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
+| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_audiences"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > audiences`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
+###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
 
 |              |         |
 | ------------ | ------- |
@@ -1068,32 +1050,32 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>2.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
-
-###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>2.1.16.12.5. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>2.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>2.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>2.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
@@ -5261,32 +5243,14 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
-| ------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#global_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
-| - [claimToHeaders](#global_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#global_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
-| - [issuer](#global_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
-| - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
+| Property                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [claimToHeaders](#global_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
+| - [enabled](#global_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#global_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-##### <a name="global_gateway_jwt_audiences"></a>3.16.12.1. Property `stack > global > gateway > jwt > audiences`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-##### <a name="global_gateway_jwt_claimToHeaders"></a>3.16.12.2. Property `stack > global > gateway > jwt > claimToHeaders`
+##### <a name="global_gateway_jwt_claimToHeaders"></a>3.16.12.1. Property `stack > global > gateway > jwt > claimToHeaders`
 
 |              |         |
 | ------------ | ------- |
@@ -5303,32 +5267,32 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="global_gateway_jwt_enabled"></a>3.16.12.3. Property `stack > global > gateway > jwt > enabled`
+##### <a name="global_gateway_jwt_enabled"></a>3.16.12.2. Property `stack > global > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-##### <a name="global_gateway_jwt_issuer"></a>3.16.12.4. Property `stack > global > gateway > jwt > issuer`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
-
-##### <a name="global_gateway_jwt_remoteJWKSUri"></a>3.16.12.5. Property `stack > global > gateway > jwt > remoteJWKSUri`
+##### <a name="global_gateway_jwt_issuer"></a>3.16.12.3. Property `stack > global > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+
+##### <a name="global_gateway_jwt_remoteJWKSUri"></a>3.16.12.4. Property `stack > global > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
 
 #### <a name="global_gateway_oidcProtected"></a>3.16.13. Property `stack > global > gateway > oidcProtected`
 
@@ -9514,32 +9478,14 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
-| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
-| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
+| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_audiences"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > audiences`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
+###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
 
 |              |         |
 | ------------ | ------- |
@@ -9556,32 +9502,32 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>4.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
-
-###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>4.1.16.12.5. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>4.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>4.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>4.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
@@ -14231,32 +14177,14 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
-| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
-| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
+| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_audiences"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > audiences`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
+###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
 
 |              |         |
 | ------------ | ------- |
@@ -14273,32 +14201,32 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>7.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
-
-###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>7.1.16.12.5. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>7.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>7.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>7.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -1028,9 +1028,9 @@ Must be one of:
 
 | Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
 | ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
 | - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
 | - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
 | - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
@@ -1041,7 +1041,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
+**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -1075,7 +1075,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>2.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
@@ -5263,9 +5263,9 @@ Must be one of:
 
 | Property                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
 | ------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#global_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [audiences](#global_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
 | - [claimToHeaders](#global_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#global_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [enabled](#global_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
 | - [issuer](#global_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
 | - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
@@ -5276,7 +5276,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
+**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -5310,7 +5310,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
 
 ##### <a name="global_gateway_jwt_issuer"></a>3.16.12.4. Property `stack > global > gateway > jwt > issuer`
 
@@ -9516,9 +9516,9 @@ Must be one of:
 
 | Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
 | ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
 | - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
 | - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
 | - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
@@ -9529,7 +9529,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
+**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -9563,7 +9563,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>4.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
@@ -14233,9 +14233,9 @@ Must be one of:
 
 | Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
 | ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API                                                                                      |
 | - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri                                                                                                                                                                         |
 | - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
 | - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
@@ -14246,7 +14246,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
+**Description:** Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -14280,7 +14280,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+**Description:** Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>7.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -1026,28 +1026,22 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
-| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
-| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
+| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
-
-|              |           |
-| ------------ | --------- |
-| **Type**     | `boolean` |
-| **Required** | No        |
-
-**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
-
-###### <a name="cronJobs_pattern1_gateway_jwt_providers"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > providers`
+###### <a name="cronJobs_pattern1_gateway_jwt_audiences"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > audiences`
 
 |              |         |
 | ------------ | ------- |
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
+**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -1056,6 +1050,50 @@ Must be one of:
 | **Items unicity**    | False              |
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>2.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
+
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>2.1.16.12.5. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>2.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
@@ -5223,28 +5261,22 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                      | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
-| --------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#global_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
-| - [providers](#global_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
+| Property                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
+| ------------------------------------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [audiences](#global_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [claimToHeaders](#global_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
+| - [enabled](#global_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [issuer](#global_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
+| - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
-##### <a name="global_gateway_jwt_enabled"></a>3.16.12.1. Property `stack > global > gateway > jwt > enabled`
-
-|              |           |
-| ------------ | --------- |
-| **Type**     | `boolean` |
-| **Required** | No        |
-
-**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
-
-##### <a name="global_gateway_jwt_providers"></a>3.16.12.2. Property `stack > global > gateway > jwt > providers`
+##### <a name="global_gateway_jwt_audiences"></a>3.16.12.1. Property `stack > global > gateway > jwt > audiences`
 
 |              |         |
 | ------------ | ------- |
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
+**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -5253,6 +5285,50 @@ Must be one of:
 | **Items unicity**    | False              |
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_jwt_claimToHeaders"></a>3.16.12.2. Property `stack > global > gateway > jwt > claimToHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="global_gateway_jwt_enabled"></a>3.16.12.3. Property `stack > global > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+
+##### <a name="global_gateway_jwt_issuer"></a>3.16.12.4. Property `stack > global > gateway > jwt > issuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
+
+##### <a name="global_gateway_jwt_remoteJWKSUri"></a>3.16.12.5. Property `stack > global > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
 
 #### <a name="global_gateway_oidcProtected"></a>3.16.13. Property `stack > global > gateway > oidcProtected`
 
@@ -9438,28 +9514,22 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
-| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
-| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
+| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
-
-|              |           |
-| ------------ | --------- |
-| **Type**     | `boolean` |
-| **Required** | No        |
-
-**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
-
-###### <a name="cronJobs_pattern1_gateway_jwt_providers"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > providers`
+###### <a name="cronJobs_pattern1_gateway_jwt_audiences"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > audiences`
 
 |              |         |
 | ------------ | ------- |
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
+**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -9468,6 +9538,50 @@ Must be one of:
 | **Items unicity**    | False              |
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>4.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
+
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>4.1.16.12.5. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>4.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
@@ -14117,28 +14231,22 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
-| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
-| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
+| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [audiences](#cronJobs_pattern1_gateway_jwt_audiences )           | No      | array   | No         | -          | Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps                                                                                                                      |
+| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                                     |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri                                                                                                                                                          |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider                                                                                               |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
-
-|              |           |
-| ------------ | --------- |
-| **Type**     | `boolean` |
-| **Required** | No        |
-
-**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
-
-###### <a name="cronJobs_pattern1_gateway_jwt_providers"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > providers`
+###### <a name="cronJobs_pattern1_gateway_jwt_audiences"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > audiences`
 
 |              |         |
 | ------------ | ------- |
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
+**Description:** Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -14147,6 +14255,50 @@ Must be one of:
 | **Items unicity**    | False              |
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>7.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
+
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>7.1.16.12.5. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>7.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -1026,10 +1026,10 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
-| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
-| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
+| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
@@ -1047,7 +1047,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -5223,10 +5223,10 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                      | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
-| --------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#global_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
-| - [providers](#global_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+| Property                                      | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
+| --------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#global_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
+| - [providers](#global_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
 
 ##### <a name="global_gateway_jwt_enabled"></a>3.16.12.1. Property `stack > global > gateway > jwt > enabled`
 
@@ -5244,7 +5244,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -9438,10 +9438,10 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
-| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
-| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
+| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
@@ -9459,7 +9459,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -14117,10 +14117,10 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
-| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
-| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                                                                                                                                                          |
+| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend) |
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
@@ -14138,7 +14138,7 @@ Must be one of:
 | **Type**     | `array` |
 | **Required** | No      |
 
-**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |

--- a/stack/README.md
+++ b/stack/README.md
@@ -697,6 +697,7 @@ Must be one of:
 | - [host](#cronJobs_pattern1_gateway_host )                         | No      | string           | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | - [hostRewrite](#cronJobs_pattern1_gateway_hostRewrite )           | No      | string           | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | - [ipAllowList](#cronJobs_pattern1_gateway_ipAllowList )           | No      | array            | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [jwt](#cronJobs_pattern1_gateway_jwt )                           | No      | object           | No         | -          | JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent                                                                                              |
 | - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean          | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway                                                                                                                                                                                                                                                                          |
 | - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object  | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | - [rateLimit](#cronJobs_pattern1_gateway_rateLimit )               | No      | object           | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
@@ -1015,7 +1016,48 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>2.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
+##### <a name="cronJobs_pattern1_gateway_jwt"></a>2.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > jwt`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
+
+| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
+| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
+| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
+
+###### <a name="cronJobs_pattern1_gateway_jwt_providers"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > providers`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>2.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -1024,7 +1066,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway
 
-##### <a name="cronJobs_pattern1_gateway_paths"></a>2.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > paths`
+##### <a name="cronJobs_pattern1_gateway_paths"></a>2.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -1045,7 +1087,7 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [paths items](#cronJobs_pattern1_gateway_paths_items) | -           |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items"></a>2.1.16.13.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
+###### <a name="cronJobs_pattern1_gateway_paths_items"></a>2.1.16.14.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1058,7 +1100,7 @@ Must be one of:
 | - [path](#cronJobs_pattern1_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#cronJobs_pattern1_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>2.1.16.13.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
+###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>2.1.16.14.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -1067,7 +1109,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>2.1.16.13.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
+###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>2.1.16.14.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -1076,7 +1118,7 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>2.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
+##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>2.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1092,7 +1134,7 @@ Must be one of:
 | - [requests](#cronJobs_pattern1_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
 | - [unit](#cronJobs_pattern1_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>2.1.16.14.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>2.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1101,7 +1143,7 @@ Must be one of:
 
 **Description:** Enable local rate limiting
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>2.1.16.14.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>2.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
 
 |              |           |
 | ------------ | --------- |
@@ -1110,7 +1152,7 @@ Must be one of:
 
 **Description:** Allowed requests per unit
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>2.1.16.14.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>2.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
 
 |              |          |
 | ------------ | -------- |
@@ -1119,7 +1161,7 @@ Must be one of:
 
 **Description:** Rate limit unit (Second, Minute, Hour, Day)
 
-##### <a name="cronJobs_pattern1_gateway_redirect"></a>2.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > redirect`
+##### <a name="cronJobs_pattern1_gateway_redirect"></a>2.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > redirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1137,7 +1179,7 @@ Must be one of:
 | - [scheme](#cronJobs_pattern1_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
 | - [statusCode](#cronJobs_pattern1_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
 
-###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>2.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
+###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>2.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1146,7 +1188,7 @@ Must be one of:
 
 **Description:** Enable a redirect-only route
 
-###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>2.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
+###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>2.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -1155,7 +1197,7 @@ Must be one of:
 
 **Description:** Target hostname, empty keeps the request host
 
-###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>2.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
+###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>2.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
 
 |              |          |
 | ------------ | -------- |
@@ -1164,7 +1206,7 @@ Must be one of:
 
 **Description:** Replacement full path via ReplaceFullPath, empty keeps the path
 
-###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>2.1.16.15.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
+###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>2.1.16.16.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
 
 |              |          |
 | ------------ | -------- |
@@ -1173,7 +1215,7 @@ Must be one of:
 
 **Description:** Target scheme, e.g. https
 
-###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>2.1.16.15.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
+###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>2.1.16.16.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
 
 |              |           |
 | ------------ | --------- |
@@ -1182,7 +1224,7 @@ Must be one of:
 
 **Description:** Redirect status code (301 or 302)
 
-##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>2.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
+##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>2.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1198,7 +1240,7 @@ Must be one of:
 | - [remove](#cronJobs_pattern1_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#cronJobs_pattern1_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>2.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>2.1.16.17.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -1215,7 +1257,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>2.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>2.1.16.17.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -1232,7 +1274,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>2.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>2.1.16.17.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -1249,7 +1291,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>2.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
+##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>2.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1265,7 +1307,7 @@ Must be one of:
 | - [remove](#cronJobs_pattern1_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#cronJobs_pattern1_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>2.1.16.17.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>2.1.16.18.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -1282,7 +1324,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>2.1.16.17.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>2.1.16.18.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -1299,7 +1341,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>2.1.16.17.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>2.1.16.18.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -1316,7 +1358,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_rules"></a>2.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > rules`
+##### <a name="cronJobs_pattern1_gateway_rules"></a>2.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -1333,7 +1375,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_sectionName"></a>2.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
+##### <a name="cronJobs_pattern1_gateway_sectionName"></a>2.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -1342,7 +1384,7 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>2.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
+##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>2.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1358,7 +1400,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
 | - [ttl](#cronJobs_pattern1_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>2.1.16.20.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>2.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
 
 |              |          |
 | ------------ | -------- |
@@ -1367,7 +1409,7 @@ Must be one of:
 
 **Description:** Affinity cookie name
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>2.1.16.20.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>2.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1376,7 +1418,7 @@ Must be one of:
 
 **Description:** Enable consistent-hash cookie session affinity
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>2.1.16.20.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>2.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
 
 |              |          |
 | ------------ | -------- |
@@ -1385,7 +1427,7 @@ Must be one of:
 
 **Description:** Affinity cookie TTL
 
-##### <a name="cronJobs_pattern1_gateway_timeouts"></a>2.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
+##### <a name="cronJobs_pattern1_gateway_timeouts"></a>2.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1401,7 +1443,7 @@ Must be one of:
 | - [connect](#cronJobs_pattern1_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
 | - [request](#cronJobs_pattern1_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>2.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
+###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>2.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
 
 |              |          |
 | ------------ | -------- |
@@ -1410,7 +1452,7 @@ Must be one of:
 
 **Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>2.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
+###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>2.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
 
 |              |          |
 | ------------ | -------- |
@@ -1419,7 +1461,7 @@ Must be one of:
 
 **Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>2.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
+###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>2.1.16.22.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
 
 |              |          |
 | ------------ | -------- |
@@ -1428,7 +1470,7 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>2.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
+##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>2.1.16.23. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1443,7 +1485,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
 | - [sectionName](#cronJobs_pattern1_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
 
-###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>2.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>2.1.16.23.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1452,7 +1494,7 @@ Must be one of:
 
 **Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
 
-###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>2.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>2.1.16.23.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -1461,7 +1503,7 @@ Must be one of:
 
 **Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>2.1.16.23. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>2.1.16.24. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -1477,7 +1519,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>2.1.16.23.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>2.1.16.24.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -1486,7 +1528,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>2.1.16.23.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>2.1.16.24.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1495,7 +1537,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>2.1.16.23.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>2.1.16.24.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -4852,6 +4894,7 @@ Must be one of:
 | - [host](#global_gateway_host )                         | No      | string           | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | - [hostRewrite](#global_gateway_hostRewrite )           | No      | string           | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | - [ipAllowList](#global_gateway_ipAllowList )           | No      | array            | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [jwt](#global_gateway_jwt )                           | No      | object           | No         | -          | JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent                                                                                              |
 | - [oidcProtected](#global_gateway_oidcProtected )       | No      | boolean          | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway                                                                                                                                                                                                                                                                          |
 | - [paths](#global_gateway_paths )                       | No      | array of object  | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | - [rateLimit](#global_gateway_rateLimit )               | No      | object           | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
@@ -5170,7 +5213,48 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="global_gateway_oidcProtected"></a>3.16.12. Property `stack > global > gateway > oidcProtected`
+#### <a name="global_gateway_jwt"></a>3.16.12. Property `stack > global > gateway > jwt`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
+
+| Property                                      | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
+| --------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#global_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
+| - [providers](#global_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+
+##### <a name="global_gateway_jwt_enabled"></a>3.16.12.1. Property `stack > global > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
+
+##### <a name="global_gateway_jwt_providers"></a>3.16.12.2. Property `stack > global > gateway > jwt > providers`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+#### <a name="global_gateway_oidcProtected"></a>3.16.13. Property `stack > global > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -5179,7 +5263,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway
 
-#### <a name="global_gateway_paths"></a>3.16.13. Property `stack > global > gateway > paths`
+#### <a name="global_gateway_paths"></a>3.16.14. Property `stack > global > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -5200,7 +5284,7 @@ Must be one of:
 | ------------------------------------------ | ----------- |
 | [paths items](#global_gateway_paths_items) | -           |
 
-##### <a name="global_gateway_paths_items"></a>3.16.13.1. stack > global > gateway > paths > paths items
+##### <a name="global_gateway_paths_items"></a>3.16.14.1. stack > global > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5213,7 +5297,7 @@ Must be one of:
 | - [path](#global_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#global_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="global_gateway_paths_items_path"></a>3.16.13.1.1. Property `stack > global > gateway > paths > paths items > path`
+###### <a name="global_gateway_paths_items_path"></a>3.16.14.1.1. Property `stack > global > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -5222,7 +5306,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="global_gateway_paths_items_pathType"></a>3.16.13.1.2. Property `stack > global > gateway > paths > paths items > pathType`
+###### <a name="global_gateway_paths_items_pathType"></a>3.16.14.1.2. Property `stack > global > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -5231,7 +5315,7 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-#### <a name="global_gateway_rateLimit"></a>3.16.14. Property `stack > global > gateway > rateLimit`
+#### <a name="global_gateway_rateLimit"></a>3.16.15. Property `stack > global > gateway > rateLimit`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5247,7 +5331,7 @@ Must be one of:
 | - [requests](#global_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
 | - [unit](#global_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
 
-##### <a name="global_gateway_rateLimit_enabled"></a>3.16.14.1. Property `stack > global > gateway > rateLimit > enabled`
+##### <a name="global_gateway_rateLimit_enabled"></a>3.16.15.1. Property `stack > global > gateway > rateLimit > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -5256,7 +5340,7 @@ Must be one of:
 
 **Description:** Enable local rate limiting
 
-##### <a name="global_gateway_rateLimit_requests"></a>3.16.14.2. Property `stack > global > gateway > rateLimit > requests`
+##### <a name="global_gateway_rateLimit_requests"></a>3.16.15.2. Property `stack > global > gateway > rateLimit > requests`
 
 |              |           |
 | ------------ | --------- |
@@ -5265,7 +5349,7 @@ Must be one of:
 
 **Description:** Allowed requests per unit
 
-##### <a name="global_gateway_rateLimit_unit"></a>3.16.14.3. Property `stack > global > gateway > rateLimit > unit`
+##### <a name="global_gateway_rateLimit_unit"></a>3.16.15.3. Property `stack > global > gateway > rateLimit > unit`
 
 |              |          |
 | ------------ | -------- |
@@ -5274,7 +5358,7 @@ Must be one of:
 
 **Description:** Rate limit unit (Second, Minute, Hour, Day)
 
-#### <a name="global_gateway_redirect"></a>3.16.15. Property `stack > global > gateway > redirect`
+#### <a name="global_gateway_redirect"></a>3.16.16. Property `stack > global > gateway > redirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5292,7 +5376,7 @@ Must be one of:
 | - [scheme](#global_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
 | - [statusCode](#global_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
 
-##### <a name="global_gateway_redirect_enabled"></a>3.16.15.1. Property `stack > global > gateway > redirect > enabled`
+##### <a name="global_gateway_redirect_enabled"></a>3.16.16.1. Property `stack > global > gateway > redirect > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -5301,7 +5385,7 @@ Must be one of:
 
 **Description:** Enable a redirect-only route
 
-##### <a name="global_gateway_redirect_hostname"></a>3.16.15.2. Property `stack > global > gateway > redirect > hostname`
+##### <a name="global_gateway_redirect_hostname"></a>3.16.16.2. Property `stack > global > gateway > redirect > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -5310,7 +5394,7 @@ Must be one of:
 
 **Description:** Target hostname, empty keeps the request host
 
-##### <a name="global_gateway_redirect_path"></a>3.16.15.3. Property `stack > global > gateway > redirect > path`
+##### <a name="global_gateway_redirect_path"></a>3.16.16.3. Property `stack > global > gateway > redirect > path`
 
 |              |          |
 | ------------ | -------- |
@@ -5319,7 +5403,7 @@ Must be one of:
 
 **Description:** Replacement full path via ReplaceFullPath, empty keeps the path
 
-##### <a name="global_gateway_redirect_scheme"></a>3.16.15.4. Property `stack > global > gateway > redirect > scheme`
+##### <a name="global_gateway_redirect_scheme"></a>3.16.16.4. Property `stack > global > gateway > redirect > scheme`
 
 |              |          |
 | ------------ | -------- |
@@ -5328,7 +5412,7 @@ Must be one of:
 
 **Description:** Target scheme, e.g. https
 
-##### <a name="global_gateway_redirect_statusCode"></a>3.16.15.5. Property `stack > global > gateway > redirect > statusCode`
+##### <a name="global_gateway_redirect_statusCode"></a>3.16.16.5. Property `stack > global > gateway > redirect > statusCode`
 
 |              |           |
 | ------------ | --------- |
@@ -5337,7 +5421,7 @@ Must be one of:
 
 **Description:** Redirect status code (301 or 302)
 
-#### <a name="global_gateway_requestHeaders"></a>3.16.16. Property `stack > global > gateway > requestHeaders`
+#### <a name="global_gateway_requestHeaders"></a>3.16.17. Property `stack > global > gateway > requestHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5353,7 +5437,7 @@ Must be one of:
 | - [remove](#global_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#global_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-##### <a name="global_gateway_requestHeaders_add"></a>3.16.16.1. Property `stack > global > gateway > requestHeaders > add`
+##### <a name="global_gateway_requestHeaders_add"></a>3.16.17.1. Property `stack > global > gateway > requestHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -5370,7 +5454,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="global_gateway_requestHeaders_remove"></a>3.16.16.2. Property `stack > global > gateway > requestHeaders > remove`
+##### <a name="global_gateway_requestHeaders_remove"></a>3.16.17.2. Property `stack > global > gateway > requestHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -5387,7 +5471,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="global_gateway_requestHeaders_set"></a>3.16.16.3. Property `stack > global > gateway > requestHeaders > set`
+##### <a name="global_gateway_requestHeaders_set"></a>3.16.17.3. Property `stack > global > gateway > requestHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -5404,7 +5488,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="global_gateway_responseHeaders"></a>3.16.17. Property `stack > global > gateway > responseHeaders`
+#### <a name="global_gateway_responseHeaders"></a>3.16.18. Property `stack > global > gateway > responseHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5420,7 +5504,7 @@ Must be one of:
 | - [remove](#global_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#global_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-##### <a name="global_gateway_responseHeaders_add"></a>3.16.17.1. Property `stack > global > gateway > responseHeaders > add`
+##### <a name="global_gateway_responseHeaders_add"></a>3.16.18.1. Property `stack > global > gateway > responseHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -5437,7 +5521,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="global_gateway_responseHeaders_remove"></a>3.16.17.2. Property `stack > global > gateway > responseHeaders > remove`
+##### <a name="global_gateway_responseHeaders_remove"></a>3.16.18.2. Property `stack > global > gateway > responseHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -5454,7 +5538,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="global_gateway_responseHeaders_set"></a>3.16.17.3. Property `stack > global > gateway > responseHeaders > set`
+##### <a name="global_gateway_responseHeaders_set"></a>3.16.18.3. Property `stack > global > gateway > responseHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -5471,7 +5555,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="global_gateway_rules"></a>3.16.18. Property `stack > global > gateway > rules`
+#### <a name="global_gateway_rules"></a>3.16.19. Property `stack > global > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -5488,7 +5572,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-#### <a name="global_gateway_sectionName"></a>3.16.19. Property `stack > global > gateway > sectionName`
+#### <a name="global_gateway_sectionName"></a>3.16.20. Property `stack > global > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -5497,7 +5581,7 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-#### <a name="global_gateway_sessionAffinity"></a>3.16.20. Property `stack > global > gateway > sessionAffinity`
+#### <a name="global_gateway_sessionAffinity"></a>3.16.21. Property `stack > global > gateway > sessionAffinity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5513,7 +5597,7 @@ Must be one of:
 | - [enabled](#global_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
 | - [ttl](#global_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
 
-##### <a name="global_gateway_sessionAffinity_cookieName"></a>3.16.20.1. Property `stack > global > gateway > sessionAffinity > cookieName`
+##### <a name="global_gateway_sessionAffinity_cookieName"></a>3.16.21.1. Property `stack > global > gateway > sessionAffinity > cookieName`
 
 |              |          |
 | ------------ | -------- |
@@ -5522,7 +5606,7 @@ Must be one of:
 
 **Description:** Affinity cookie name
 
-##### <a name="global_gateway_sessionAffinity_enabled"></a>3.16.20.2. Property `stack > global > gateway > sessionAffinity > enabled`
+##### <a name="global_gateway_sessionAffinity_enabled"></a>3.16.21.2. Property `stack > global > gateway > sessionAffinity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -5531,7 +5615,7 @@ Must be one of:
 
 **Description:** Enable consistent-hash cookie session affinity
 
-##### <a name="global_gateway_sessionAffinity_ttl"></a>3.16.20.3. Property `stack > global > gateway > sessionAffinity > ttl`
+##### <a name="global_gateway_sessionAffinity_ttl"></a>3.16.21.3. Property `stack > global > gateway > sessionAffinity > ttl`
 
 |              |          |
 | ------------ | -------- |
@@ -5540,7 +5624,7 @@ Must be one of:
 
 **Description:** Affinity cookie TTL
 
-#### <a name="global_gateway_timeouts"></a>3.16.21. Property `stack > global > gateway > timeouts`
+#### <a name="global_gateway_timeouts"></a>3.16.22. Property `stack > global > gateway > timeouts`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5556,7 +5640,7 @@ Must be one of:
 | - [connect](#global_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
 | - [request](#global_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
 
-##### <a name="global_gateway_timeouts_backendRequest"></a>3.16.21.1. Property `stack > global > gateway > timeouts > backendRequest`
+##### <a name="global_gateway_timeouts_backendRequest"></a>3.16.22.1. Property `stack > global > gateway > timeouts > backendRequest`
 
 |              |          |
 | ------------ | -------- |
@@ -5565,7 +5649,7 @@ Must be one of:
 
 **Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
 
-##### <a name="global_gateway_timeouts_connect"></a>3.16.21.2. Property `stack > global > gateway > timeouts > connect`
+##### <a name="global_gateway_timeouts_connect"></a>3.16.22.2. Property `stack > global > gateway > timeouts > connect`
 
 |              |          |
 | ------------ | -------- |
@@ -5574,7 +5658,7 @@ Must be one of:
 
 **Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
 
-##### <a name="global_gateway_timeouts_request"></a>3.16.21.3. Property `stack > global > gateway > timeouts > request`
+##### <a name="global_gateway_timeouts_request"></a>3.16.22.3. Property `stack > global > gateway > timeouts > request`
 
 |              |          |
 | ------------ | -------- |
@@ -5583,7 +5667,7 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-#### <a name="global_gateway_tlsPassthrough"></a>3.16.22. Property `stack > global > gateway > tlsPassthrough`
+#### <a name="global_gateway_tlsPassthrough"></a>3.16.23. Property `stack > global > gateway > tlsPassthrough`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5598,7 +5682,7 @@ Must be one of:
 | - [enabled](#global_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
 | - [sectionName](#global_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
 
-##### <a name="global_gateway_tlsPassthrough_enabled"></a>3.16.22.1. Property `stack > global > gateway > tlsPassthrough > enabled`
+##### <a name="global_gateway_tlsPassthrough_enabled"></a>3.16.23.1. Property `stack > global > gateway > tlsPassthrough > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -5607,7 +5691,7 @@ Must be one of:
 
 **Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
 
-##### <a name="global_gateway_tlsPassthrough_sectionName"></a>3.16.22.2. Property `stack > global > gateway > tlsPassthrough > sectionName`
+##### <a name="global_gateway_tlsPassthrough_sectionName"></a>3.16.23.2. Property `stack > global > gateway > tlsPassthrough > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -5616,7 +5700,7 @@ Must be one of:
 
 **Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
 
-#### <a name="global_gateway_vanity"></a>3.16.23. Property `stack > global > gateway > vanity`
+#### <a name="global_gateway_vanity"></a>3.16.24. Property `stack > global > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -5632,7 +5716,7 @@ Must be one of:
 | - [enabled](#global_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#global_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-##### <a name="global_gateway_vanity_clusterIssuer"></a>3.16.23.1. Property `stack > global > gateway > vanity > clusterIssuer`
+##### <a name="global_gateway_vanity_clusterIssuer"></a>3.16.24.1. Property `stack > global > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -5641,7 +5725,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-##### <a name="global_gateway_vanity_enabled"></a>3.16.23.2. Property `stack > global > gateway > vanity > enabled`
+##### <a name="global_gateway_vanity_enabled"></a>3.16.24.2. Property `stack > global > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -5650,7 +5734,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-##### <a name="global_gateway_vanity_hostname"></a>3.16.23.3. Property `stack > global > gateway > vanity > hostname`
+##### <a name="global_gateway_vanity_hostname"></a>3.16.24.3. Property `stack > global > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -9025,6 +9109,7 @@ Must be one of:
 | - [host](#cronJobs_pattern1_gateway_host )                         | No      | string           | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | - [hostRewrite](#cronJobs_pattern1_gateway_hostRewrite )           | No      | string           | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | - [ipAllowList](#cronJobs_pattern1_gateway_ipAllowList )           | No      | array            | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [jwt](#cronJobs_pattern1_gateway_jwt )                           | No      | object           | No         | -          | JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent                                                                                              |
 | - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean          | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway                                                                                                                                                                                                                                                                          |
 | - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object  | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | - [rateLimit](#cronJobs_pattern1_gateway_rateLimit )               | No      | object           | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
@@ -9343,7 +9428,48 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>4.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
+##### <a name="cronJobs_pattern1_gateway_jwt"></a>4.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > jwt`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
+
+| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
+| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
+| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
+
+###### <a name="cronJobs_pattern1_gateway_jwt_providers"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > providers`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>4.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -9352,7 +9478,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway
 
-##### <a name="cronJobs_pattern1_gateway_paths"></a>4.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > paths`
+##### <a name="cronJobs_pattern1_gateway_paths"></a>4.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -9373,7 +9499,7 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [paths items](#cronJobs_pattern1_gateway_paths_items) | -           |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items"></a>4.1.16.13.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
+###### <a name="cronJobs_pattern1_gateway_paths_items"></a>4.1.16.14.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9386,7 +9512,7 @@ Must be one of:
 | - [path](#cronJobs_pattern1_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#cronJobs_pattern1_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>4.1.16.13.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
+###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>4.1.16.14.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -9395,7 +9521,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>4.1.16.13.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
+###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>4.1.16.14.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -9404,7 +9530,7 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>4.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
+##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>4.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9420,7 +9546,7 @@ Must be one of:
 | - [requests](#cronJobs_pattern1_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
 | - [unit](#cronJobs_pattern1_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>4.1.16.14.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>4.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -9429,7 +9555,7 @@ Must be one of:
 
 **Description:** Enable local rate limiting
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>4.1.16.14.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>4.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
 
 |              |           |
 | ------------ | --------- |
@@ -9438,7 +9564,7 @@ Must be one of:
 
 **Description:** Allowed requests per unit
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>4.1.16.14.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>4.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
 
 |              |          |
 | ------------ | -------- |
@@ -9447,7 +9573,7 @@ Must be one of:
 
 **Description:** Rate limit unit (Second, Minute, Hour, Day)
 
-##### <a name="cronJobs_pattern1_gateway_redirect"></a>4.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > redirect`
+##### <a name="cronJobs_pattern1_gateway_redirect"></a>4.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > redirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9465,7 +9591,7 @@ Must be one of:
 | - [scheme](#cronJobs_pattern1_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
 | - [statusCode](#cronJobs_pattern1_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
 
-###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>4.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
+###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>4.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -9474,7 +9600,7 @@ Must be one of:
 
 **Description:** Enable a redirect-only route
 
-###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>4.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
+###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>4.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -9483,7 +9609,7 @@ Must be one of:
 
 **Description:** Target hostname, empty keeps the request host
 
-###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>4.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
+###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>4.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
 
 |              |          |
 | ------------ | -------- |
@@ -9492,7 +9618,7 @@ Must be one of:
 
 **Description:** Replacement full path via ReplaceFullPath, empty keeps the path
 
-###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>4.1.16.15.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
+###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>4.1.16.16.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
 
 |              |          |
 | ------------ | -------- |
@@ -9501,7 +9627,7 @@ Must be one of:
 
 **Description:** Target scheme, e.g. https
 
-###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>4.1.16.15.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
+###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>4.1.16.16.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
 
 |              |           |
 | ------------ | --------- |
@@ -9510,7 +9636,7 @@ Must be one of:
 
 **Description:** Redirect status code (301 or 302)
 
-##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>4.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
+##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>4.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9526,7 +9652,7 @@ Must be one of:
 | - [remove](#cronJobs_pattern1_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#cronJobs_pattern1_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>4.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>4.1.16.17.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -9543,7 +9669,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>4.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>4.1.16.17.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -9560,7 +9686,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>4.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>4.1.16.17.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -9577,7 +9703,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>4.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
+##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>4.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9593,7 +9719,7 @@ Must be one of:
 | - [remove](#cronJobs_pattern1_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#cronJobs_pattern1_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>4.1.16.17.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>4.1.16.18.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -9610,7 +9736,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>4.1.16.17.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>4.1.16.18.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -9627,7 +9753,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>4.1.16.17.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>4.1.16.18.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -9644,7 +9770,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_rules"></a>4.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > rules`
+##### <a name="cronJobs_pattern1_gateway_rules"></a>4.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -9661,7 +9787,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_sectionName"></a>4.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
+##### <a name="cronJobs_pattern1_gateway_sectionName"></a>4.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -9670,7 +9796,7 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>4.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
+##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>4.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9686,7 +9812,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
 | - [ttl](#cronJobs_pattern1_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>4.1.16.20.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>4.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
 
 |              |          |
 | ------------ | -------- |
@@ -9695,7 +9821,7 @@ Must be one of:
 
 **Description:** Affinity cookie name
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>4.1.16.20.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>4.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -9704,7 +9830,7 @@ Must be one of:
 
 **Description:** Enable consistent-hash cookie session affinity
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>4.1.16.20.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>4.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
 
 |              |          |
 | ------------ | -------- |
@@ -9713,7 +9839,7 @@ Must be one of:
 
 **Description:** Affinity cookie TTL
 
-##### <a name="cronJobs_pattern1_gateway_timeouts"></a>4.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
+##### <a name="cronJobs_pattern1_gateway_timeouts"></a>4.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9729,7 +9855,7 @@ Must be one of:
 | - [connect](#cronJobs_pattern1_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
 | - [request](#cronJobs_pattern1_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>4.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
+###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>4.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
 
 |              |          |
 | ------------ | -------- |
@@ -9738,7 +9864,7 @@ Must be one of:
 
 **Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>4.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
+###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>4.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
 
 |              |          |
 | ------------ | -------- |
@@ -9747,7 +9873,7 @@ Must be one of:
 
 **Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>4.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
+###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>4.1.16.22.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
 
 |              |          |
 | ------------ | -------- |
@@ -9756,7 +9882,7 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>4.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
+##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>4.1.16.23. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9771,7 +9897,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
 | - [sectionName](#cronJobs_pattern1_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
 
-###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>4.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>4.1.16.23.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -9780,7 +9906,7 @@ Must be one of:
 
 **Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
 
-###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>4.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>4.1.16.23.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -9789,7 +9915,7 @@ Must be one of:
 
 **Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>4.1.16.23. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>4.1.16.24. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -9805,7 +9931,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>4.1.16.23.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>4.1.16.24.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -9814,7 +9940,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>4.1.16.23.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>4.1.16.24.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -9823,7 +9949,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>4.1.16.23.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>4.1.16.24.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -13662,6 +13788,7 @@ Must be one of:
 | - [host](#cronJobs_pattern1_gateway_host )                         | No      | string           | No         | -          | Hostname for HTTPRoute                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | - [hostRewrite](#cronJobs_pattern1_gateway_hostRewrite )           | No      | string           | No         | -          | Rewrite the Host header sent upstream via an HTTPRoute URLRewrite filter, empty disables it                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | - [ipAllowList](#cronJobs_pattern1_gateway_ipAllowList )           | No      | array            | No         | -          | Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [jwt](#cronJobs_pattern1_gateway_jwt )                           | No      | object           | No         | -          | JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent                                                                                              |
 | - [oidcProtected](#cronJobs_pattern1_gateway_oidcProtected )       | No      | boolean          | No         | -          | Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway                                                                                                                                                                                                                                                                          |
 | - [paths](#cronJobs_pattern1_gateway_paths )                       | No      | array of object  | No         | -          | List of HTTPRoute paths                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | - [rateLimit](#cronJobs_pattern1_gateway_rateLimit )               | No      | object           | No         | -          | Local rate limit via a BackendTrafficPolicy (Envoy local token bucket, no burst concept)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
@@ -13980,7 +14107,48 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>7.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
+##### <a name="cronJobs_pattern1_gateway_jwt"></a>7.1.16.12. Property `stack > cronJobs > ^.*$ > gateway > jwt`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
+
+| Property                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                   |
+| -------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )     | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires at least one entry in providers                                                                                                                        |
+| - [providers](#cronJobs_pattern1_gateway_jwt_providers ) | No      | array   | No         | -          | JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim}) |
+
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Enable JWT bearer-token validation. Requires at least one entry in providers
+
+###### <a name="cronJobs_pattern1_gateway_jwt_providers"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > providers`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>7.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
 |              |           |
 | ------------ | --------- |
@@ -13989,7 +14157,7 @@ Must be one of:
 
 **Description:** Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway
 
-##### <a name="cronJobs_pattern1_gateway_paths"></a>7.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > paths`
+##### <a name="cronJobs_pattern1_gateway_paths"></a>7.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > paths`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -14010,7 +14178,7 @@ Must be one of:
 | ----------------------------------------------------- | ----------- |
 | [paths items](#cronJobs_pattern1_gateway_paths_items) | -           |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items"></a>7.1.16.13.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
+###### <a name="cronJobs_pattern1_gateway_paths_items"></a>7.1.16.14.1. stack > cronJobs > ^.*$ > gateway > paths > paths items
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14023,7 +14191,7 @@ Must be one of:
 | - [path](#cronJobs_pattern1_gateway_paths_items_path )         | No      | string | No         | -          | HTTPRoute path                        |
 | - [pathType](#cronJobs_pattern1_gateway_paths_items_pathType ) | No      | string | No         | -          | HTTPRoute path type (Exact or Prefix) |
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>7.1.16.13.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
+###### <a name="cronJobs_pattern1_gateway_paths_items_path"></a>7.1.16.14.1.1. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > path`
 
 |              |          |
 | ------------ | -------- |
@@ -14032,7 +14200,7 @@ Must be one of:
 
 **Description:** HTTPRoute path
 
-###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>7.1.16.13.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
+###### <a name="cronJobs_pattern1_gateway_paths_items_pathType"></a>7.1.16.14.1.2. Property `stack > cronJobs > ^.*$ > gateway > paths > paths items > pathType`
 
 |              |          |
 | ------------ | -------- |
@@ -14041,7 +14209,7 @@ Must be one of:
 
 **Description:** HTTPRoute path type (Exact or Prefix)
 
-##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>7.1.16.14. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
+##### <a name="cronJobs_pattern1_gateway_rateLimit"></a>7.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > rateLimit`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14057,7 +14225,7 @@ Must be one of:
 | - [requests](#cronJobs_pattern1_gateway_rateLimit_requests ) | No      | integer | No         | -          | Allowed requests per unit                   |
 | - [unit](#cronJobs_pattern1_gateway_rateLimit_unit )         | No      | string  | No         | -          | Rate limit unit (Second, Minute, Hour, Day) |
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>7.1.16.14.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_enabled"></a>7.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -14066,7 +14234,7 @@ Must be one of:
 
 **Description:** Enable local rate limiting
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>7.1.16.14.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_requests"></a>7.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > requests`
 
 |              |           |
 | ------------ | --------- |
@@ -14075,7 +14243,7 @@ Must be one of:
 
 **Description:** Allowed requests per unit
 
-###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>7.1.16.14.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
+###### <a name="cronJobs_pattern1_gateway_rateLimit_unit"></a>7.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > rateLimit > unit`
 
 |              |          |
 | ------------ | -------- |
@@ -14084,7 +14252,7 @@ Must be one of:
 
 **Description:** Rate limit unit (Second, Minute, Hour, Day)
 
-##### <a name="cronJobs_pattern1_gateway_redirect"></a>7.1.16.15. Property `stack > cronJobs > ^.*$ > gateway > redirect`
+##### <a name="cronJobs_pattern1_gateway_redirect"></a>7.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > redirect`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14102,7 +14270,7 @@ Must be one of:
 | - [scheme](#cronJobs_pattern1_gateway_redirect_scheme )         | No      | string  | No         | -          | Target scheme, e.g. https                                       |
 | - [statusCode](#cronJobs_pattern1_gateway_redirect_statusCode ) | No      | integer | No         | -          | Redirect status code (301 or 302)                               |
 
-###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>7.1.16.15.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
+###### <a name="cronJobs_pattern1_gateway_redirect_enabled"></a>7.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > redirect > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -14111,7 +14279,7 @@ Must be one of:
 
 **Description:** Enable a redirect-only route
 
-###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>7.1.16.15.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
+###### <a name="cronJobs_pattern1_gateway_redirect_hostname"></a>7.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > redirect > hostname`
 
 |              |          |
 | ------------ | -------- |
@@ -14120,7 +14288,7 @@ Must be one of:
 
 **Description:** Target hostname, empty keeps the request host
 
-###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>7.1.16.15.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
+###### <a name="cronJobs_pattern1_gateway_redirect_path"></a>7.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > redirect > path`
 
 |              |          |
 | ------------ | -------- |
@@ -14129,7 +14297,7 @@ Must be one of:
 
 **Description:** Replacement full path via ReplaceFullPath, empty keeps the path
 
-###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>7.1.16.15.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
+###### <a name="cronJobs_pattern1_gateway_redirect_scheme"></a>7.1.16.16.4. Property `stack > cronJobs > ^.*$ > gateway > redirect > scheme`
 
 |              |          |
 | ------------ | -------- |
@@ -14138,7 +14306,7 @@ Must be one of:
 
 **Description:** Target scheme, e.g. https
 
-###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>7.1.16.15.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
+###### <a name="cronJobs_pattern1_gateway_redirect_statusCode"></a>7.1.16.16.5. Property `stack > cronJobs > ^.*$ > gateway > redirect > statusCode`
 
 |              |           |
 | ------------ | --------- |
@@ -14147,7 +14315,7 @@ Must be one of:
 
 **Description:** Redirect status code (301 or 302)
 
-##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>7.1.16.16. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
+##### <a name="cronJobs_pattern1_gateway_requestHeaders"></a>7.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14163,7 +14331,7 @@ Must be one of:
 | - [remove](#cronJobs_pattern1_gateway_requestHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#cronJobs_pattern1_gateway_requestHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>7.1.16.16.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_add"></a>7.1.16.17.1. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -14180,7 +14348,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>7.1.16.16.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_remove"></a>7.1.16.17.2. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -14197,7 +14365,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>7.1.16.16.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
+###### <a name="cronJobs_pattern1_gateway_requestHeaders_set"></a>7.1.16.17.3. Property `stack > cronJobs > ^.*$ > gateway > requestHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -14214,7 +14382,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>7.1.16.17. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
+##### <a name="cronJobs_pattern1_gateway_responseHeaders"></a>7.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14230,7 +14398,7 @@ Must be one of:
 | - [remove](#cronJobs_pattern1_gateway_responseHeaders_remove ) | No      | array | No         | -          | Header names to remove               |
 | - [set](#cronJobs_pattern1_gateway_responseHeaders_set )       | No      | array | No         | -          | Headers to set, list of {name,value} |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>7.1.16.17.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_add"></a>7.1.16.18.1. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > add`
 
 |              |         |
 | ------------ | ------- |
@@ -14247,7 +14415,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>7.1.16.17.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_remove"></a>7.1.16.18.2. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > remove`
 
 |              |         |
 | ------------ | ------- |
@@ -14264,7 +14432,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>7.1.16.17.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
+###### <a name="cronJobs_pattern1_gateway_responseHeaders_set"></a>7.1.16.18.3. Property `stack > cronJobs > ^.*$ > gateway > responseHeaders > set`
 
 |              |         |
 | ------------ | ------- |
@@ -14281,7 +14449,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_rules"></a>7.1.16.18. Property `stack > cronJobs > ^.*$ > gateway > rules`
+##### <a name="cronJobs_pattern1_gateway_rules"></a>7.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > rules`
 
 |              |         |
 | ------------ | ------- |
@@ -14298,7 +14466,7 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-##### <a name="cronJobs_pattern1_gateway_sectionName"></a>7.1.16.19. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
+##### <a name="cronJobs_pattern1_gateway_sectionName"></a>7.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -14307,7 +14475,7 @@ Must be one of:
 
 **Description:** Optional section name (listener name) on the Gateway
 
-##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>7.1.16.20. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
+##### <a name="cronJobs_pattern1_gateway_sessionAffinity"></a>7.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14323,7 +14491,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_sessionAffinity_enabled )       | No      | boolean | No         | -          | Enable consistent-hash cookie session affinity |
 | - [ttl](#cronJobs_pattern1_gateway_sessionAffinity_ttl )               | No      | string  | No         | -          | Affinity cookie TTL                            |
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>7.1.16.20.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_cookieName"></a>7.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > cookieName`
 
 |              |          |
 | ------------ | -------- |
@@ -14332,7 +14500,7 @@ Must be one of:
 
 **Description:** Affinity cookie name
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>7.1.16.20.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_enabled"></a>7.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -14341,7 +14509,7 @@ Must be one of:
 
 **Description:** Enable consistent-hash cookie session affinity
 
-###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>7.1.16.20.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
+###### <a name="cronJobs_pattern1_gateway_sessionAffinity_ttl"></a>7.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > sessionAffinity > ttl`
 
 |              |          |
 | ------------ | -------- |
@@ -14350,7 +14518,7 @@ Must be one of:
 
 **Description:** Affinity cookie TTL
 
-##### <a name="cronJobs_pattern1_gateway_timeouts"></a>7.1.16.21. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
+##### <a name="cronJobs_pattern1_gateway_timeouts"></a>7.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > timeouts`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14366,7 +14534,7 @@ Must be one of:
 | - [connect](#cronJobs_pattern1_gateway_timeouts_connect )               | No      | string | No         | -          | Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default |
 | - [request](#cronJobs_pattern1_gateway_timeouts_request )               | No      | string | No         | -          | Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets           |
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>7.1.16.21.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
+###### <a name="cronJobs_pattern1_gateway_timeouts_backendRequest"></a>7.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > timeouts > backendRequest`
 
 |              |          |
 | ------------ | -------- |
@@ -14375,7 +14543,7 @@ Must be one of:
 
 **Description:** Per-try backend request timeout (HTTPRoute rules[].timeouts.backendRequest). Must be <= request
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>7.1.16.21.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
+###### <a name="cronJobs_pattern1_gateway_timeouts_connect"></a>7.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > timeouts > connect`
 
 |              |          |
 | ------------ | -------- |
@@ -14384,7 +14552,7 @@ Must be one of:
 
 **Description:** Optional upstream TCP connect timeout (renders BackendTrafficPolicy timeout.tcp.connectTimeout), empty uses the Envoy default
 
-###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>7.1.16.21.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
+###### <a name="cronJobs_pattern1_gateway_timeouts_request"></a>7.1.16.22.3. Property `stack > cronJobs > ^.*$ > gateway > timeouts > request`
 
 |              |          |
 | ------------ | -------- |
@@ -14393,7 +14561,7 @@ Must be one of:
 
 **Description:** Overall request timeout (HTTPRoute rules[].timeouts.request). Set "0s" to disable, e.g. for streaming or websockets
 
-##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>7.1.16.22. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
+##### <a name="cronJobs_pattern1_gateway_tlsPassthrough"></a>7.1.16.23. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14408,7 +14576,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_tlsPassthrough_enabled )         | No      | boolean | No         | -          | Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service                                 |
 | - [sectionName](#cronJobs_pattern1_gateway_tlsPassthrough_sectionName ) | No      | string  | No         | -          | Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case |
 
-###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>7.1.16.22.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_enabled"></a>7.1.16.23.1. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -14417,7 +14585,7 @@ Must be one of:
 
 **Description:** Render a TLSRoute instead of an HTTPRoute and skip TLS termination for this service
 
-###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>7.1.16.22.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
+###### <a name="cronJobs_pattern1_gateway_tlsPassthrough_sectionName"></a>7.1.16.23.2. Property `stack > cronJobs > ^.*$ > gateway > tlsPassthrough > sectionName`
 
 |              |          |
 | ------------ | -------- |
@@ -14426,7 +14594,7 @@ Must be one of:
 
 **Description:** Optional Passthrough listener name to pin to. Empty attaches by hostname plus TLS protocol, which is the usual case
 
-##### <a name="cronJobs_pattern1_gateway_vanity"></a>7.1.16.23. Property `stack > cronJobs > ^.*$ > gateway > vanity`
+##### <a name="cronJobs_pattern1_gateway_vanity"></a>7.1.16.24. Property `stack > cronJobs > ^.*$ > gateway > vanity`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -14442,7 +14610,7 @@ Must be one of:
 | - [enabled](#cronJobs_pattern1_gateway_vanity_enabled )             | No      | boolean | No         | -          | Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway                                                  |
 | - [hostname](#cronJobs_pattern1_gateway_vanity_hostname )           | No      | string  | No         | -          | Listener SNI hostname (defaults to gateway.host). A wildcard such as *.parent requires a dns01-capable issuer because http01 cannot issue wildcard certs |
 
-###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>7.1.16.23.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
+###### <a name="cronJobs_pattern1_gateway_vanity_clusterIssuer"></a>7.1.16.24.1. Property `stack > cronJobs > ^.*$ > gateway > vanity > clusterIssuer`
 
 |              |          |
 | ------------ | -------- |
@@ -14451,7 +14619,7 @@ Must be one of:
 
 **Description:** cert-manager ClusterIssuer used by the gateway-shim to issue the listener certificate
 
-###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>7.1.16.23.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
+###### <a name="cronJobs_pattern1_gateway_vanity_enabled"></a>7.1.16.24.2. Property `stack > cronJobs > ^.*$ > gateway > vanity > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -14460,7 +14628,7 @@ Must be one of:
 
 **Description:** Render a ListenerSet attaching an HTTPS listener for this service's vanity domain to the shared Gateway
 
-###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>7.1.16.23.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
+###### <a name="cronJobs_pattern1_gateway_vanity_hostname"></a>7.1.16.24.3. Property `stack > cronJobs > ^.*$ > gateway > vanity > hostname`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/README.md
+++ b/stack/README.md
@@ -1026,31 +1026,13 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -1059,7 +1041,7 @@ Must be one of:
 
 **Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>2.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -1068,7 +1050,7 @@ Must be one of:
 
 **Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
-###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>2.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>2.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
 
 |              |          |
 | ------------ | -------- |
@@ -5243,31 +5225,13 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [claimToHeaders](#global_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
-| - [enabled](#global_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#global_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                              | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ----------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#global_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#global_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-##### <a name="global_gateway_jwt_claimToHeaders"></a>3.16.12.1. Property `stack > global > gateway > jwt > claimToHeaders`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-##### <a name="global_gateway_jwt_enabled"></a>3.16.12.2. Property `stack > global > gateway > jwt > enabled`
+##### <a name="global_gateway_jwt_enabled"></a>3.16.12.1. Property `stack > global > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -5276,7 +5240,7 @@ Must be one of:
 
 **Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-##### <a name="global_gateway_jwt_issuer"></a>3.16.12.3. Property `stack > global > gateway > jwt > issuer`
+##### <a name="global_gateway_jwt_issuer"></a>3.16.12.2. Property `stack > global > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -5285,7 +5249,7 @@ Must be one of:
 
 **Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
-##### <a name="global_gateway_jwt_remoteJWKSUri"></a>3.16.12.4. Property `stack > global > gateway > jwt > remoteJWKSUri`
+##### <a name="global_gateway_jwt_remoteJWKSUri"></a>3.16.12.3. Property `stack > global > gateway > jwt > remoteJWKSUri`
 
 |              |          |
 | ------------ | -------- |
@@ -9478,31 +9442,13 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -9511,7 +9457,7 @@ Must be one of:
 
 **Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>4.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -9520,7 +9466,7 @@ Must be one of:
 
 **Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
-###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>4.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>4.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
 
 |              |          |
 | ------------ | -------- |
@@ -14177,31 +14123,13 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [claimToHeaders](#cronJobs_pattern1_gateway_jwt_claimToHeaders ) | No      | array   | No         | -          | Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend                                                                                                                          |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )               | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )                 | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri )   | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
 
-###### <a name="cronJobs_pattern1_gateway_jwt_claimToHeaders"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > claimToHeaders`
-
-|              |         |
-| ------------ | ------- |
-| **Type**     | `array` |
-| **Required** | No      |
-
-**Description:** Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | N/A                |
-
-###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
+###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -14210,7 +14138,7 @@ Must be one of:
 
 **Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
 
-###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>7.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
+###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
 |              |          |
 | ------------ | -------- |
@@ -14219,7 +14147,7 @@ Must be one of:
 
 **Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
-###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>7.1.16.12.4. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
+###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>7.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
 
 |              |          |
 | ------------ | -------- |

--- a/stack/README.md
+++ b/stack/README.md
@@ -1026,11 +1026,11 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                          |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires remoteJWKSUri                                                                                                                                                                                                 |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login                                                            |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with \`curl -s <issuer>/.well-known/openid-configuration \| jq -r .jwks_uri\` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys) |
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>2.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
@@ -1039,7 +1039,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
+**Description:** Enable JWT bearer-token validation. Requires remoteJWKSUri
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>2.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
@@ -1048,7 +1048,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+**Description:** Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>2.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
 
@@ -1057,7 +1057,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
+**Description:** JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with `curl -s <issuer>/.well-known/openid-configuration | jq -r .jwks_uri` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys)
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>2.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
@@ -5201,11 +5201,11 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                              | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ----------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#global_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#global_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                              | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                          |
+| ----------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#global_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires remoteJWKSUri                                                                                                                                                                                                 |
+| - [issuer](#global_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login                                                            |
+| - [remoteJWKSUri](#global_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with \`curl -s <issuer>/.well-known/openid-configuration \| jq -r .jwks_uri\` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys) |
 
 ##### <a name="global_gateway_jwt_enabled"></a>3.16.12.1. Property `stack > global > gateway > jwt > enabled`
 
@@ -5214,7 +5214,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
+**Description:** Enable JWT bearer-token validation. Requires remoteJWKSUri
 
 ##### <a name="global_gateway_jwt_issuer"></a>3.16.12.2. Property `stack > global > gateway > jwt > issuer`
 
@@ -5223,7 +5223,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+**Description:** Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
 ##### <a name="global_gateway_jwt_remoteJWKSUri"></a>3.16.12.3. Property `stack > global > gateway > jwt > remoteJWKSUri`
 
@@ -5232,7 +5232,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
+**Description:** JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with `curl -s <issuer>/.well-known/openid-configuration | jq -r .jwks_uri` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys)
 
 #### <a name="global_gateway_oidcProtected"></a>3.16.13. Property `stack > global > gateway > oidcProtected`
 
@@ -9394,11 +9394,11 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                          |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires remoteJWKSUri                                                                                                                                                                                                 |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login                                                            |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with \`curl -s <issuer>/.well-known/openid-configuration \| jq -r .jwks_uri\` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys) |
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>4.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
@@ -9407,7 +9407,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
+**Description:** Enable JWT bearer-token validation. Requires remoteJWKSUri
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>4.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
@@ -9416,7 +9416,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+**Description:** Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>4.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
 
@@ -9425,7 +9425,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
+**Description:** JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with `curl -s <issuer>/.well-known/openid-configuration | jq -r .jwks_uri` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys)
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>4.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 
@@ -14051,11 +14051,11 @@ Must be one of:
 
 **Description:** JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
 
-| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                 |
-| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case                                  |
-| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login |
-| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider                                                 |
+| Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                          |
+| ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| - [enabled](#cronJobs_pattern1_gateway_jwt_enabled )             | No      | boolean | No         | -          | Enable JWT bearer-token validation. Requires remoteJWKSUri                                                                                                                                                                                                 |
+| - [issuer](#cronJobs_pattern1_gateway_jwt_issuer )               | No      | string  | No         | -          | Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login                                                            |
+| - [remoteJWKSUri](#cronJobs_pattern1_gateway_jwt_remoteJWKSUri ) | No      | string  | No         | -          | JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with \`curl -s <issuer>/.well-known/openid-configuration \| jq -r .jwks_uri\` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys) |
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_enabled"></a>7.1.16.12.1. Property `stack > cronJobs > ^.*$ > gateway > jwt > enabled`
 
@@ -14064,7 +14064,7 @@ Must be one of:
 | **Type**     | `boolean` |
 | **Required** | No        |
 
-**Description:** Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
+**Description:** Enable JWT bearer-token validation. Requires remoteJWKSUri
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_issuer"></a>7.1.16.12.2. Property `stack > cronJobs > ^.*$ > gateway > jwt > issuer`
 
@@ -14073,7 +14073,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+**Description:** Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
 
 ###### <a name="cronJobs_pattern1_gateway_jwt_remoteJWKSUri"></a>7.1.16.12.3. Property `stack > cronJobs > ^.*$ > gateway > jwt > remoteJWKSUri`
 
@@ -14082,7 +14082,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
+**Description:** JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with `curl -s <issuer>/.well-known/openid-configuration | jq -r .jwks_uri` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys)
 
 ##### <a name="cronJobs_pattern1_gateway_oidcProtected"></a>7.1.16.13. Property `stack > cronJobs > ^.*$ > gateway > oidcProtected`
 

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -539,9 +539,14 @@ oidc:
 jwt:
   providers:
     {{- range $g.jwt.providers }}
+    {{- $jwks := .remoteJWKSUri }}
+    {{- if not $jwks }}
+      {{- if .issuer }}{{- $jwks = printf "%s/v1/keys" (trimSuffix "/" .issuer) }}
+      {{- else }}{{- fail "gateway.jwt.providers[]: set remoteJWKSUri, or set issuer to derive it (<issuer>/v1/keys)" }}{{- end }}
+    {{- end }}
     - name: {{ required "gateway.jwt.providers[].name is required" .name }}
       remoteJWKS:
-        uri: {{ required "gateway.jwt.providers[].remoteJWKSUri is required" .remoteJWKSUri | quote }}
+        uri: {{ $jwks | quote }}
       {{- if .issuer }}
       issuer: {{ .issuer | quote }}
       {{- end }}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -540,6 +540,8 @@ jwt:
   providers:
     {{- range $g.jwt.providers }}
     - name: {{ required "gateway.jwt.providers[].name is required" .name }}
+      remoteJWKS:
+        uri: {{ required "gateway.jwt.providers[].remoteJWKSUri is required" .remoteJWKSUri | quote }}
       {{- if .issuer }}
       issuer: {{ .issuer | quote }}
       {{- end }}
@@ -547,8 +549,6 @@ jwt:
       audiences:
         {{- toYaml .audiences | nindent 8 }}
       {{- end }}
-      remoteJWKS:
-        uri: {{ required "gateway.jwt.providers[].remoteJWKSUri is required" .remoteJWKSUri | quote }}
       {{- if .claimToHeaders }}
       claimToHeaders:
         {{- toYaml .claimToHeaders | nindent 8 }}

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -538,7 +538,6 @@ oidc:
 {{- $issuer := $g.jwt.issuer | default $.Values.oidcProxyGateway.provider.issuer }}
 {{- $jwks := $g.jwt.remoteJWKSUri }}
 {{- if not $jwks }}
-  {{- if not $issuer }}{{- fail "gateway.jwt.enabled needs an issuer: set gateway.jwt.issuer, oidcProxyGateway.provider.issuer, or gateway.jwt.remoteJWKSUri" }}{{- end }}
   {{- $base := trimSuffix "/" $issuer }}
   {{- /* Okta JWKS: a custom auth server issuer already carries an /oauth2/<id> path (keys at <issuer>/v1/keys); a bare org issuer serves them at /oauth2/v1/keys. */ -}}
   {{- if (urlParse $base).path }}{{- $jwks = printf "%s/v1/keys" $base }}
@@ -549,13 +548,7 @@ jwt:
     - name: default
       remoteJWKS:
         uri: {{ $jwks | quote }}
-      {{- if $issuer }}
       issuer: {{ $issuer | quote }}
-      {{- end }}
-      {{- if $g.jwt.claimToHeaders }}
-      claimToHeaders:
-        {{- toYaml $g.jwt.claimToHeaders | nindent 8 }}
-      {{- end }}
 {{- end }}
 {{- if and (not .public) $g.basicAuth.enabled }}
 basicAuth:

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -535,30 +535,26 @@ oidc:
   {{- end }}
 {{- end }}
 {{- if and (not .public) $g.jwt.enabled }}
-{{- if not $g.jwt.providers }}{{- fail "gateway.jwt.enabled is true but gateway.jwt.providers is empty; add at least one provider" }}{{- end }}
+{{- $jwks := $g.jwt.remoteJWKSUri }}
+{{- if not $jwks }}
+  {{- if $g.jwt.issuer }}{{- $jwks = printf "%s/v1/keys" (trimSuffix "/" $g.jwt.issuer) }}
+  {{- else }}{{- fail "gateway.jwt.enabled requires gateway.jwt.issuer (or gateway.jwt.remoteJWKSUri)" }}{{- end }}
+{{- end }}
+{{- if not $g.jwt.audiences }}{{- fail "gateway.jwt.enabled requires gateway.jwt.audiences" }}{{- end }}
 jwt:
   providers:
-    {{- range $g.jwt.providers }}
-    {{- $jwks := .remoteJWKSUri }}
-    {{- if not $jwks }}
-      {{- if .issuer }}{{- $jwks = printf "%s/v1/keys" (trimSuffix "/" .issuer) }}
-      {{- else }}{{- fail "gateway.jwt.providers[]: set remoteJWKSUri, or set issuer to derive it (<issuer>/v1/keys)" }}{{- end }}
-    {{- end }}
-    - name: {{ required "gateway.jwt.providers[].name is required" .name }}
+    - name: default
       remoteJWKS:
         uri: {{ $jwks | quote }}
-      {{- if .issuer }}
-      issuer: {{ .issuer | quote }}
-      {{- end }}
-      {{- if .audiences }}
       audiences:
-        {{- toYaml .audiences | nindent 8 }}
+        {{- toYaml $g.jwt.audiences | nindent 8 }}
+      {{- if $g.jwt.issuer }}
+      issuer: {{ $g.jwt.issuer | quote }}
       {{- end }}
-      {{- if .claimToHeaders }}
+      {{- if $g.jwt.claimToHeaders }}
       claimToHeaders:
-        {{- toYaml .claimToHeaders | nindent 8 }}
+        {{- toYaml $g.jwt.claimToHeaders | nindent 8 }}
       {{- end }}
-    {{- end }}
 {{- end }}
 {{- if and (not .public) $g.basicAuth.enabled }}
 basicAuth:

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -540,7 +540,8 @@ oidc:
 {{- if not $jwks }}
   {{- if not $issuer }}{{- fail "gateway.jwt.enabled needs an issuer: set gateway.jwt.issuer, oidcProxyGateway.provider.issuer, or gateway.jwt.remoteJWKSUri" }}{{- end }}
   {{- $base := trimSuffix "/" $issuer }}
-  {{- if contains "/oauth2/" $base }}{{- $jwks = printf "%s/v1/keys" $base }}
+  {{- /* Okta JWKS: a custom auth server issuer already carries an /oauth2/<id> path (keys at <issuer>/v1/keys); a bare org issuer serves them at /oauth2/v1/keys. */ -}}
+  {{- if (urlParse $base).path }}{{- $jwks = printf "%s/v1/keys" $base }}
   {{- else }}{{- $jwks = printf "%s/oauth2/v1/keys" $base }}{{- end }}
 {{- end }}
 jwt:

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -535,22 +535,21 @@ oidc:
   {{- end }}
 {{- end }}
 {{- if and (not .public) $g.jwt.enabled }}
+{{- $issuer := $g.jwt.issuer | default $.Values.oidcProxyGateway.provider.issuer }}
 {{- $jwks := $g.jwt.remoteJWKSUri }}
 {{- if not $jwks }}
-  {{- if $g.jwt.issuer }}{{- $jwks = printf "%s/v1/keys" (trimSuffix "/" $g.jwt.issuer) }}
-  {{- else }}{{- fail "gateway.jwt.enabled requires gateway.jwt.issuer (or gateway.jwt.remoteJWKSUri)" }}{{- end }}
+  {{- if not $issuer }}{{- fail "gateway.jwt.enabled needs an issuer: set gateway.jwt.issuer, oidcProxyGateway.provider.issuer, or gateway.jwt.remoteJWKSUri" }}{{- end }}
+  {{- $base := trimSuffix "/" $issuer }}
+  {{- if contains "/oauth2/" $base }}{{- $jwks = printf "%s/v1/keys" $base }}
+  {{- else }}{{- $jwks = printf "%s/oauth2/v1/keys" $base }}{{- end }}
 {{- end }}
 jwt:
   providers:
     - name: default
       remoteJWKS:
         uri: {{ $jwks | quote }}
-      {{- if $g.jwt.issuer }}
-      issuer: {{ $g.jwt.issuer | quote }}
-      {{- end }}
-      {{- if $g.jwt.audiences }}
-      audiences:
-        {{- toYaml $g.jwt.audiences | nindent 8 }}
+      {{- if $issuer }}
+      issuer: {{ $issuer | quote }}
       {{- end }}
       {{- if $g.jwt.claimToHeaders }}
       claimToHeaders:

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -359,7 +359,7 @@ Returns "true"/"" .
 */}}
 {{- define "gateway.hasSecurityPolicy" -}}
 {{- $g := .Values.gateway -}}
-{{- if or $g.oidcProtected $g.basicAuth.enabled $g.cors.enabled (gt (len $g.ipAllowList) 0) -}}true{{- end -}}
+{{- if or $g.oidcProtected $g.basicAuth.enabled $g.cors.enabled (gt (len $g.ipAllowList) 0) $g.jwt.enabled -}}true{{- end -}}
 {{- end -}}
 
 {{/*
@@ -533,6 +533,27 @@ oidc:
   resources:
     {{- toYaml $.Values.oidcProxyGateway.resources | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- if and (not .public) $g.jwt.enabled }}
+{{- if not $g.jwt.providers }}{{- fail "gateway.jwt.enabled is true but gateway.jwt.providers is empty; add at least one provider" }}{{- end }}
+jwt:
+  providers:
+    {{- range $g.jwt.providers }}
+    - name: {{ required "gateway.jwt.providers[].name is required" .name }}
+      {{- if .issuer }}
+      issuer: {{ .issuer | quote }}
+      {{- end }}
+      {{- if .audiences }}
+      audiences:
+        {{- toYaml .audiences | nindent 8 }}
+      {{- end }}
+      remoteJWKS:
+        uri: {{ required "gateway.jwt.providers[].remoteJWKSUri is required" .remoteJWKSUri | quote }}
+      {{- if .claimToHeaders }}
+      claimToHeaders:
+        {{- toYaml .claimToHeaders | nindent 8 }}
+      {{- end }}
+    {{- end }}
 {{- end }}
 {{- if and (not .public) $g.basicAuth.enabled }}
 basicAuth:

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -540,16 +540,17 @@ oidc:
   {{- if $g.jwt.issuer }}{{- $jwks = printf "%s/v1/keys" (trimSuffix "/" $g.jwt.issuer) }}
   {{- else }}{{- fail "gateway.jwt.enabled requires gateway.jwt.issuer (or gateway.jwt.remoteJWKSUri)" }}{{- end }}
 {{- end }}
-{{- if not $g.jwt.audiences }}{{- fail "gateway.jwt.enabled requires gateway.jwt.audiences" }}{{- end }}
 jwt:
   providers:
     - name: default
       remoteJWKS:
         uri: {{ $jwks | quote }}
-      audiences:
-        {{- toYaml $g.jwt.audiences | nindent 8 }}
       {{- if $g.jwt.issuer }}
       issuer: {{ $g.jwt.issuer | quote }}
+      {{- end }}
+      {{- if $g.jwt.audiences }}
+      audiences:
+        {{- toYaml $g.jwt.audiences | nindent 8 }}
       {{- end }}
       {{- if $g.jwt.claimToHeaders }}
       claimToHeaders:

--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -535,20 +535,12 @@ oidc:
   {{- end }}
 {{- end }}
 {{- if and (not .public) $g.jwt.enabled }}
-{{- $issuer := $g.jwt.issuer | default $.Values.oidcProxyGateway.provider.issuer }}
-{{- $jwks := $g.jwt.remoteJWKSUri }}
-{{- if not $jwks }}
-  {{- $base := trimSuffix "/" $issuer }}
-  {{- /* Okta JWKS: a custom auth server issuer already carries an /oauth2/<id> path (keys at <issuer>/v1/keys); a bare org issuer serves them at /oauth2/v1/keys. */ -}}
-  {{- if (urlParse $base).path }}{{- $jwks = printf "%s/v1/keys" $base }}
-  {{- else }}{{- $jwks = printf "%s/oauth2/v1/keys" $base }}{{- end }}
-{{- end }}
 jwt:
   providers:
     - name: default
       remoteJWKS:
-        uri: {{ $jwks | quote }}
-      issuer: {{ $issuer | quote }}
+        uri: {{ required "gateway.jwt.remoteJWKSUri is required when gateway.jwt.enabled is true. Find it with: curl -s <issuer>/.well-known/openid-configuration | jq -r .jwks_uri" $g.jwt.remoteJWKSUri | quote }}
+      issuer: {{ required "gateway.jwt.issuer is required when gateway.jwt.enabled is true (or set oidcProxyGateway.provider.issuer)" ($g.jwt.issuer | default $.Values.oidcProxyGateway.provider.issuer) | quote }}
 {{- end }}
 {{- if and (not .public) $g.basicAuth.enabled }}
 basicAuth:

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -777,7 +777,7 @@ tests:
         notExists:
           path: spec.oidc
 
-  - it: should render a jwt provider (JWKS derived from issuer) when enabled
+  - it: should enable jwt with just the flag (reuses the OIDC issuer, derives JWKS)
     set:
       global:
         ingress:
@@ -787,9 +787,6 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
-            issuer: https://czi.okta.com/oauth2/aus123
-            audiences:
-              - my-api-audience
       services:
         service1: {}
     asserts:
@@ -807,19 +804,40 @@ tests:
         equal:
           path: spec.jwt.providers[0].name
           value: default
+      # issuer defaults to oidcProxyGateway.provider.issuer
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].issuer
+          value: https://czi.okta.com
+      # org-server JWKS lives under /oauth2/v1/keys
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].remoteJWKS.uri
+          value: https://czi.okta.com/oauth2/v1/keys
+
+  - it: should derive the JWKS from a custom authorization-server issuer
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          jwt:
+            enabled: true
+            issuer: https://czi.okta.com/oauth2/aus123
+      services:
+        service1: {}
+    asserts:
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].issuer
           value: https://czi.okta.com/oauth2/aus123
-      # JWKS derived as <issuer>/v1/keys
+      # custom server: JWKS is <issuer>/v1/keys
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].remoteJWKS.uri
           value: https://czi.okta.com/oauth2/aus123/v1/keys
-      - documentIndex: 0
-        equal:
-          path: spec.jwt.providers[0].audiences[0]
-          value: my-api-audience
 
   - it: should use an explicit remoteJWKSUri override
     set:
@@ -831,17 +849,14 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
-            issuer: https://czi.okta.com
-            remoteJWKSUri: https://czi.okta.com/oauth2/v1/keys
-            audiences:
-              - my-api-audience
+            remoteJWKSUri: https://idp.example.com/keys
       services:
         service1: {}
     asserts:
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].remoteJWKS.uri
-          value: https://czi.okta.com/oauth2/v1/keys
+          value: https://idp.example.com/keys
 
   - it: should render both oidc and jwt on one SecurityPolicy when both are enabled
     set:
@@ -854,9 +869,6 @@ tests:
           oidcProtected: true
           jwt:
             enabled: true
-            issuer: https://czi.okta.com/oauth2/aus123
-            audiences:
-              - my-api-audience
         oidcProxyGateway:
           clientID: my-client-id
           provider:
@@ -877,6 +889,11 @@ tests:
         equal:
           path: spec.jwt.providers[0].name
           value: default
+      # jwt reuses the same OIDC issuer
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].issuer
+          value: https://auth.example.com
 
   - it: should not render jwt on a public (skipAuth) SecurityPolicy
     set:
@@ -892,9 +909,6 @@ tests:
             allowOrigins: ["*"]
           jwt:
             enabled: true
-            issuer: https://czi.okta.com/oauth2/aus123
-            audiences:
-              - my-api-audience
         oidcProxyGateway:
           clientID: my-client-id
           provider:
@@ -918,7 +932,7 @@ tests:
         notExists:
           path: spec.oidc
 
-  - it: should fail when jwt is enabled without issuer or remoteJWKSUri
+  - it: should fail when jwt is enabled and no issuer or JWKS can be resolved
     set:
       global:
         ingress:
@@ -928,31 +942,11 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
-            audiences:
-              - my-api-audience
+        oidcProxyGateway:
+          provider:
+            issuer: ""
       services:
         service1: {}
     asserts:
       - failedTemplate:
-          errorMessage: "gateway.jwt.enabled requires gateway.jwt.issuer (or gateway.jwt.remoteJWKSUri)"
-
-  - it: should omit audiences when not set (audiences is optional)
-    set:
-      global:
-        ingress:
-          enabled: false
-        gateway:
-          enabled: true
-          host: api.example.com
-          jwt:
-            enabled: true
-            issuer: https://czi.okta.com/oauth2/aus123
-      services:
-        service1: {}
-    asserts:
-      - documentIndex: 0
-        isNotEmpty:
-          path: spec.jwt.providers[0].remoteJWKS.uri
-      - documentIndex: 0
-        notExists:
-          path: spec.jwt.providers[0].audiences
+          errorMessage: "gateway.jwt.enabled needs an issuer: set gateway.jwt.issuer, oidcProxyGateway.provider.issuer, or gateway.jwt.remoteJWKSUri"

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -898,6 +898,49 @@ tests:
         notExists:
           path: spec.oidc
 
+  - it: should derive remoteJWKS uri from issuer when remoteJWKSUri is omitted
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          jwt:
+            enabled: true
+            providers:
+              - name: okta
+                issuer: https://czi.okta.com/oauth2/aus123
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].remoteJWKS.uri
+          value: https://czi.okta.com/oauth2/aus123/v1/keys
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].issuer
+          value: https://czi.okta.com/oauth2/aus123
+
+  - it: should fail when a provider has neither remoteJWKSUri nor issuer
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          jwt:
+            enabled: true
+            providers:
+              - name: okta
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.jwt.providers[]: set remoteJWKSUri, or set issuer to derive it (<issuer>/v1/keys)"
+
   - it: should fail when gateway.jwt.enabled but providers is empty
     set:
       global:

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -777,7 +777,7 @@ tests:
         notExists:
           path: spec.oidc
 
-  - it: should render a jwt block when gateway.jwt.enabled with providers
+  - it: should render a jwt provider (JWKS derived from issuer) when enabled
     set:
       global:
         ingress:
@@ -787,12 +787,9 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
-            providers:
-              - name: okta
-                issuer: https://czi.okta.com/oauth2/aus123
-                remoteJWKSUri: https://czi.okta.com/oauth2/aus123/v1/keys
-                audiences:
-                  - my-api-audience
+            issuer: https://czi.okta.com/oauth2/aus123
+            audiences:
+              - my-api-audience
       services:
         service1: {}
     asserts:
@@ -809,11 +806,12 @@ tests:
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].name
-          value: okta
+          value: default
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].issuer
           value: https://czi.okta.com/oauth2/aus123
+      # JWKS derived as <issuer>/v1/keys
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].remoteJWKS.uri
@@ -822,6 +820,28 @@ tests:
         equal:
           path: spec.jwt.providers[0].audiences[0]
           value: my-api-audience
+
+  - it: should use an explicit remoteJWKSUri override
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          jwt:
+            enabled: true
+            issuer: https://czi.okta.com
+            remoteJWKSUri: https://czi.okta.com/oauth2/v1/keys
+            audiences:
+              - my-api-audience
+      services:
+        service1: {}
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].remoteJWKS.uri
+          value: https://czi.okta.com/oauth2/v1/keys
 
   - it: should render both oidc and jwt on one SecurityPolicy when both are enabled
     set:
@@ -834,9 +854,9 @@ tests:
           oidcProtected: true
           jwt:
             enabled: true
-            providers:
-              - name: okta
-                remoteJWKSUri: https://czi.okta.com/oauth2/aus123/v1/keys
+            issuer: https://czi.okta.com/oauth2/aus123
+            audiences:
+              - my-api-audience
         oidcProxyGateway:
           clientID: my-client-id
           provider:
@@ -856,7 +876,7 @@ tests:
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].name
-          value: okta
+          value: default
 
   - it: should not render jwt on a public (skipAuth) SecurityPolicy
     set:
@@ -872,9 +892,9 @@ tests:
             allowOrigins: ["*"]
           jwt:
             enabled: true
-            providers:
-              - name: okta
-                remoteJWKSUri: https://czi.okta.com/oauth2/aus123/v1/keys
+            issuer: https://czi.okta.com/oauth2/aus123
+            audiences:
+              - my-api-audience
         oidcProxyGateway:
           clientID: my-client-id
           provider:
@@ -898,7 +918,7 @@ tests:
         notExists:
           path: spec.oidc
 
-  - it: should derive remoteJWKS uri from issuer when remoteJWKSUri is omitted
+  - it: should fail when jwt is enabled without issuer or remoteJWKSUri
     set:
       global:
         ingress:
@@ -908,40 +928,15 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
-            providers:
-              - name: okta
-                issuer: https://czi.okta.com/oauth2/aus123
-      services:
-        service1: {}
-    asserts:
-      - documentIndex: 0
-        equal:
-          path: spec.jwt.providers[0].remoteJWKS.uri
-          value: https://czi.okta.com/oauth2/aus123/v1/keys
-      - documentIndex: 0
-        equal:
-          path: spec.jwt.providers[0].issuer
-          value: https://czi.okta.com/oauth2/aus123
-
-  - it: should fail when a provider has neither remoteJWKSUri nor issuer
-    set:
-      global:
-        ingress:
-          enabled: false
-        gateway:
-          enabled: true
-          host: api.example.com
-          jwt:
-            enabled: true
-            providers:
-              - name: okta
+            audiences:
+              - my-api-audience
       services:
         service1: {}
     asserts:
       - failedTemplate:
-          errorMessage: "gateway.jwt.providers[]: set remoteJWKSUri, or set issuer to derive it (<issuer>/v1/keys)"
+          errorMessage: "gateway.jwt.enabled requires gateway.jwt.issuer (or gateway.jwt.remoteJWKSUri)"
 
-  - it: should fail when gateway.jwt.enabled but providers is empty
+  - it: should fail when jwt is enabled without audiences
     set:
       global:
         ingress:
@@ -951,9 +946,9 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
-            providers: []
+            issuer: https://czi.okta.com/oauth2/aus123
       services:
         service1: {}
     asserts:
       - failedTemplate:
-          errorMessage: "gateway.jwt.enabled is true but gateway.jwt.providers is empty; add at least one provider"
+          errorMessage: "gateway.jwt.enabled requires gateway.jwt.audiences"

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -776,3 +776,141 @@ tests:
       - documentIndex: 2
         notExists:
           path: spec.oidc
+
+  - it: should render a jwt block when gateway.jwt.enabled with providers
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          jwt:
+            enabled: true
+            providers:
+              - name: okta
+                issuer: https://czi.okta.com/oauth2/aus123
+                remoteJWKSUri: https://czi.okta.com/oauth2/aus123/v1/keys
+                audiences:
+                  - my-api-audience
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        isKind:
+          of: SecurityPolicy
+      # jwt alone (no oidc) → the "-security" suffix
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-security
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].name
+          value: okta
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].issuer
+          value: https://czi.okta.com/oauth2/aus123
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].remoteJWKS.uri
+          value: https://czi.okta.com/oauth2/aus123/v1/keys
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].audiences[0]
+          value: my-api-audience
+
+  - it: should render both oidc and jwt on one SecurityPolicy when both are enabled
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          jwt:
+            enabled: true
+            providers:
+              - name: okta
+                remoteJWKSUri: https://czi.okta.com/oauth2/aus123/v1/keys
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+      services:
+        service1: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: release-name-stack-service1-oidc
+      - documentIndex: 0
+        isNotEmpty:
+          path: spec.oidc
+      - documentIndex: 0
+        equal:
+          path: spec.jwt.providers[0].name
+          value: okta
+
+  - it: should not render jwt on a public (skipAuth) SecurityPolicy
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          oidcProtected: true
+          cors:
+            enabled: true
+            allowOrigins: ["*"]
+          jwt:
+            enabled: true
+            providers:
+              - name: okta
+                remoteJWKSUri: https://czi.okta.com/oauth2/aus123/v1/keys
+        oidcProxyGateway:
+          clientID: my-client-id
+          provider:
+            issuer: https://auth.example.com
+          skipAuth:
+            - path: /healthz
+      services:
+        service1: {}
+    asserts:
+      # doc 0 is the gated route (oidc + jwt), doc 1 is the public/skipAuth route:
+      # it carries cors but never jwt or oidc
+      - hasDocuments:
+          count: 2
+      - documentIndex: 1
+        isNotEmpty:
+          path: spec.cors
+      - documentIndex: 1
+        notExists:
+          path: spec.jwt
+      - documentIndex: 1
+        notExists:
+          path: spec.oidc
+
+  - it: should fail when gateway.jwt.enabled but providers is empty
+    set:
+      global:
+        ingress:
+          enabled: false
+        gateway:
+          enabled: true
+          host: api.example.com
+          jwt:
+            enabled: true
+            providers: []
+      services:
+        service1: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.jwt.enabled is true but gateway.jwt.providers is empty; add at least one provider"

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -931,22 +931,3 @@ tests:
       - documentIndex: 1
         notExists:
           path: spec.oidc
-
-  - it: should fail when jwt is enabled and no issuer or JWKS can be resolved
-    set:
-      global:
-        ingress:
-          enabled: false
-        gateway:
-          enabled: true
-          host: api.example.com
-          jwt:
-            enabled: true
-        oidcProxyGateway:
-          provider:
-            issuer: ""
-      services:
-        service1: {}
-    asserts:
-      - failedTemplate:
-          errorMessage: "gateway.jwt.enabled needs an issuer: set gateway.jwt.issuer, oidcProxyGateway.provider.issuer, or gateway.jwt.remoteJWKSUri"

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -936,7 +936,7 @@ tests:
       - failedTemplate:
           errorMessage: "gateway.jwt.enabled requires gateway.jwt.issuer (or gateway.jwt.remoteJWKSUri)"
 
-  - it: should fail when jwt is enabled without audiences
+  - it: should omit audiences when not set (audiences is optional)
     set:
       global:
         ingress:
@@ -950,5 +950,9 @@ tests:
       services:
         service1: {}
     asserts:
-      - failedTemplate:
-          errorMessage: "gateway.jwt.enabled requires gateway.jwt.audiences"
+      - documentIndex: 0
+        isNotEmpty:
+          path: spec.jwt.providers[0].remoteJWKS.uri
+      - documentIndex: 0
+        notExists:
+          path: spec.jwt.providers[0].audiences

--- a/stack/tests/gateway_securitypolicy_test.yaml
+++ b/stack/tests/gateway_securitypolicy_test.yaml
@@ -777,7 +777,7 @@ tests:
         notExists:
           path: spec.oidc
 
-  - it: should enable jwt with just the flag (reuses the OIDC issuer, derives JWKS)
+  - it: should render jwt from remoteJWKSUri, defaulting the issuer to the OIDC issuer
     set:
       global:
         ingress:
@@ -787,6 +787,7 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
+            remoteJWKSUri: https://czi.okta.com/oauth2/v1/keys
       services:
         service1: {}
     asserts:
@@ -809,13 +810,12 @@ tests:
         equal:
           path: spec.jwt.providers[0].issuer
           value: https://czi.okta.com
-      # org-server JWKS lives under /oauth2/v1/keys
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].remoteJWKS.uri
           value: https://czi.okta.com/oauth2/v1/keys
 
-  - it: should derive the JWKS from a custom authorization-server issuer
+  - it: should use an explicit issuer for a custom authorization server
     set:
       global:
         ingress:
@@ -826,6 +826,7 @@ tests:
           jwt:
             enabled: true
             issuer: https://czi.okta.com/oauth2/aus123
+            remoteJWKSUri: https://czi.okta.com/oauth2/aus123/v1/keys
       services:
         service1: {}
     asserts:
@@ -833,13 +834,12 @@ tests:
         equal:
           path: spec.jwt.providers[0].issuer
           value: https://czi.okta.com/oauth2/aus123
-      # custom server: JWKS is <issuer>/v1/keys
       - documentIndex: 0
         equal:
           path: spec.jwt.providers[0].remoteJWKS.uri
           value: https://czi.okta.com/oauth2/aus123/v1/keys
 
-  - it: should use an explicit remoteJWKSUri override
+  - it: should fail when jwt is enabled without a remoteJWKSUri
     set:
       global:
         ingress:
@@ -849,14 +849,11 @@ tests:
           host: api.example.com
           jwt:
             enabled: true
-            remoteJWKSUri: https://idp.example.com/keys
       services:
         service1: {}
     asserts:
-      - documentIndex: 0
-        equal:
-          path: spec.jwt.providers[0].remoteJWKS.uri
-          value: https://idp.example.com/keys
+      - failedTemplate:
+          errorPattern: gateway.jwt.remoteJWKSUri is required when gateway.jwt.enabled is true
 
   - it: should render both oidc and jwt on one SecurityPolicy when both are enabled
     set:
@@ -869,6 +866,7 @@ tests:
           oidcProtected: true
           jwt:
             enabled: true
+            remoteJWKSUri: https://auth.example.com/keys
         oidcProxyGateway:
           clientID: my-client-id
           provider:
@@ -909,6 +907,7 @@ tests:
             allowOrigins: ["*"]
           jwt:
             enabled: true
+            remoteJWKSUri: https://auth.example.com/keys
         oidcProxyGateway:
           clientID: my-client-id
           provider:

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -365,7 +365,7 @@
                   "type": "boolean"
                 },
                 "providers": {
-                  "description": "JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})",
+                  "description": "JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as \u003cissuer\u003e/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)",
                   "type": "array"
                 }
               }

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -360,13 +360,25 @@
               "description": "JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent",
               "type": "object",
               "properties": {
+                "audiences": {
+                  "description": "Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps",
+                  "type": "array"
+                },
+                "claimToHeaders": {
+                  "description": "Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend",
+                  "type": "array"
+                },
                 "enabled": {
-                  "description": "Enable JWT bearer-token validation. Requires at least one entry in providers",
+                  "description": "Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri",
                   "type": "boolean"
                 },
-                "providers": {
-                  "description": "JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as \u003cissuer\u003e/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)",
-                  "type": "array"
+                "issuer": {
+                  "description": "Expected token issuer (iss claim), also used to derive the JWKS URI as \u003cissuer\u003e/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider",
+                  "type": "string"
+                },
+                "remoteJWKSUri": {
+                  "description": "Explicit JWKS URI, an optional override. Defaults to \u003cissuer\u003e/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider",
+                  "type": "string"
                 }
               }
             },

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -361,7 +361,7 @@
               "type": "object",
               "properties": {
                 "audiences": {
-                  "description": "Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps",
+                  "description": "Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API",
                   "type": "array"
                 },
                 "claimToHeaders": {
@@ -369,7 +369,7 @@
                   "type": "array"
                 },
                 "enabled": {
-                  "description": "Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri",
+                  "description": "Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri",
                   "type": "boolean"
                 },
                 "issuer": {

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -360,10 +360,6 @@
               "description": "JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent",
               "type": "object",
               "properties": {
-                "claimToHeaders": {
-                  "description": "Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend",
-                  "type": "array"
-                },
                 "enabled": {
                   "description": "Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case",
                   "type": "boolean"

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -360,24 +360,20 @@
               "description": "JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent",
               "type": "object",
               "properties": {
-                "audiences": {
-                  "description": "Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API",
-                  "type": "array"
-                },
                 "claimToHeaders": {
                   "description": "Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend",
                   "type": "array"
                 },
                 "enabled": {
-                  "description": "Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri",
+                  "description": "Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case",
                   "type": "boolean"
                 },
                 "issuer": {
-                  "description": "Expected token issuer (iss claim), also used to derive the JWKS URI as \u003cissuer\u003e/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider",
+                  "description": "Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login",
                   "type": "string"
                 },
                 "remoteJWKSUri": {
-                  "description": "Explicit JWKS URI, an optional override. Defaults to \u003cissuer\u003e/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider",
+                  "description": "Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server \u003cissuer\u003e/v1/keys). Set it for a non-Okta provider",
                   "type": "string"
                 }
               }

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -356,6 +356,20 @@
               "description": "Client IP allowlist of CIDRs that renders a SecurityPolicy authorization rule (defaultAction Deny). Empty disables it",
               "type": "array"
             },
+            "jwt": {
+              "description": "JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Enable JWT bearer-token validation. Requires at least one entry in providers",
+                  "type": "boolean"
+                },
+                "providers": {
+                  "description": "JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})",
+                  "type": "array"
+                }
+              }
+            },
             "oidcProtected": {
               "description": "Enable OIDC protection via Envoy Gateway SecurityPolicy. Works with no other configuration - the client id and secret default from the argus-global-oidc secret (shared confidential Okta app), with per-service overrides available via oidcProxyGateway",
               "type": "boolean"

--- a/stack/values.schema.json
+++ b/stack/values.schema.json
@@ -361,15 +361,15 @@
               "type": "object",
               "properties": {
                 "enabled": {
-                  "description": "Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case",
+                  "description": "Enable JWT bearer-token validation. Requires remoteJWKSUri",
                   "type": "boolean"
                 },
                 "issuer": {
-                  "description": "Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login",
+                  "description": "Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login",
                   "type": "string"
                 },
                 "remoteJWKSUri": {
-                  "description": "Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server \u003cissuer\u003e/v1/keys). Set it for a non-Okta provider",
+                  "description": "JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with `curl -s \u003cissuer\u003e/.well-known/openid-configuration | jq -r .jwks_uri` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys)",
                   "type": "string"
                 }
               }

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -247,6 +247,9 @@ global: # @schema description: Global configuration for the stack - this serves 
     basicAuth: # @schema description: HTTP basic auth via a SecurityPolicy. Mutually exclusive with gateway.oidcProtected
       enabled: false # @schema description: Enable basic auth
       secretName: "" # @schema description: Name of an Opaque Secret with a .htpasswd key
+    jwt: # @schema description: JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
+      enabled: false # @schema description: Enable JWT bearer-token validation. Requires at least one entry in providers
+      providers: [] # @schema description: JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
     cors: # @schema description: CORS via a SecurityPolicy
       enabled: false # @schema description: Enable CORS
       allowOrigins: [] # @schema description: Allowed origins (string patterns)

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -248,11 +248,15 @@ global: # @schema description: Global configuration for the stack - this serves 
       enabled: false # @schema description: Enable basic auth
       secretName: "" # @schema description: Name of an Opaque Secret with a .htpasswd key
     jwt: # @schema description: JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
-      enabled: false # @schema description: Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
-      issuer: "" # @schema description: Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
-      audiences: [] # @schema description: Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
-      remoteJWKSUri: "" # @schema description: Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
+      enabled: false # @schema description: Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
+      issuer: "" # @schema description: Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+      remoteJWKSUri: "" # @schema description: Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
       claimToHeaders: [] # @schema description: Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
+      # NOTE: token audience (aud) validation is intentionally not exposed. It would be good
+      # practice - it pins a token to this API so a token minted for another service (same
+      # issuer and signing keys) cannot be replayed here (RFC 8725) - but a specific audience
+      # requires a custom Okta authorization server, which is not self-service in Argus. Add
+      # an audiences field here (and in the provider block in _helpers.tpl) if that changes.
     cors: # @schema description: CORS via a SecurityPolicy
       enabled: false # @schema description: Enable CORS
       allowOrigins: [] # @schema description: Allowed origins (string patterns)

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -248,8 +248,11 @@ global: # @schema description: Global configuration for the stack - this serves 
       enabled: false # @schema description: Enable basic auth
       secretName: "" # @schema description: Name of an Opaque Secret with a .htpasswd key
     jwt: # @schema description: JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
-      enabled: false # @schema description: Enable JWT bearer-token validation. Requires at least one entry in providers
-      providers: [] # @schema description: JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
+      enabled: false # @schema description: Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+      issuer: "" # @schema description: Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
+      audiences: [] # @schema description: Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
+      remoteJWKSUri: "" # @schema description: Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
+      claimToHeaders: [] # @schema description: Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
     cors: # @schema description: CORS via a SecurityPolicy
       enabled: false # @schema description: Enable CORS
       allowOrigins: [] # @schema description: Allowed origins (string patterns)

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -251,7 +251,6 @@ global: # @schema description: Global configuration for the stack - this serves 
       enabled: false # @schema description: Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
       issuer: "" # @schema description: Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
       remoteJWKSUri: "" # @schema description: Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
-      claimToHeaders: [] # @schema description: Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
       # NOTE: token audience (aud) validation is intentionally not exposed. It would be good
       # practice - it pins a token to this API so a token minted for another service (same
       # issuer and signing keys) cannot be replayed here (RFC 8725) - but a specific audience

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -249,7 +249,7 @@ global: # @schema description: Global configuration for the stack - this serves 
       secretName: "" # @schema description: Name of an Opaque Secret with a .htpasswd key
     jwt: # @schema description: JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
       enabled: false # @schema description: Enable JWT bearer-token validation. Requires at least one entry in providers
-      providers: [] # @schema description: JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name, remoteJWKSUri, optional issuer, optional audiences (list), and optional claimToHeaders (list of {header, claim})
+      providers: [] # @schema description: JWT providers (Envoy Gateway SecurityPolicy jwt.providers). Each entry takes name plus either issuer (JWKS derived as <issuer>/v1/keys, the Okta custom-auth-server convention) or an explicit remoteJWKSUri. Optional audiences (list, the allowed aud claim) and claimToHeaders (list of {header, claim} to forward to the backend)
     cors: # @schema description: CORS via a SecurityPolicy
       enabled: false # @schema description: Enable CORS
       allowOrigins: [] # @schema description: Allowed origins (string patterns)

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -248,9 +248,9 @@ global: # @schema description: Global configuration for the stack - this serves 
       enabled: false # @schema description: Enable basic auth
       secretName: "" # @schema description: Name of an Opaque Secret with a .htpasswd key
     jwt: # @schema description: JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
-      enabled: false # @schema description: Enable JWT bearer-token validation. Requires audiences plus issuer or remoteJWKSUri
+      enabled: false # @schema description: Enable JWT bearer-token validation. Requires issuer or remoteJWKSUri
       issuer: "" # @schema description: Expected token issuer (iss claim), also used to derive the JWKS URI as <issuer>/v1/keys (the Okta custom-auth-server convention). Set to the shared CZI API authorization server, or override for the Okta org server or a non-Okta provider
-      audiences: [] # @schema description: Allowed aud claim values, required when enabled. Pins tokens minted for this API and rejects ones issued for other apps
+      audiences: [] # @schema description: Allowed aud claim values. Optional but recommended - without it any validly-signed token from the issuer is accepted, not only ones minted for this API
       remoteJWKSUri: "" # @schema description: Explicit JWKS URI, an optional override. Defaults to <issuer>/v1/keys. Set it for the Okta org server (/oauth2/v1/keys) or a non-Okta provider
       claimToHeaders: [] # @schema description: Optional list of {header, claim} pairs copying validated JWT claims into request headers for the backend
     cors: # @schema description: CORS via a SecurityPolicy

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -245,9 +245,9 @@ global: # @schema description: Global configuration for the stack - this serves 
       enabled: false # @schema description: Enable basic auth
       secretName: "" # @schema description: Name of an Opaque Secret with a .htpasswd key
     jwt: # @schema description: JWT bearer-token validation via a SecurityPolicy, for machine clients (CLIs, service-to-service) that send an Authorization: Bearer token. Independent of and combinable with oidcProtected - browsers keep the OIDC cookie flow while bearer requests are validated at the gateway against the provider JWKS. This is the Gateway API replacement for oauth2-proxy's --skip-jwt-bearer-tokens, which has no other gateway equivalent
-      enabled: false # @schema description: Enable JWT bearer-token validation. With just this flag it reuses the OIDC issuer (oidcProxyGateway.provider.issuer) and derives its JWKS, so no other config is needed for the common Okta case
-      issuer: "" # @schema description: Expected token issuer (iss claim), also used to derive the JWKS URI. Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
-      remoteJWKSUri: "" # @schema description: Explicit JWKS URI, an optional override. Defaults to the issuer's Okta JWKS endpoint (org server /oauth2/v1/keys, custom server <issuer>/v1/keys). Set it for a non-Okta provider
+      enabled: false # @schema description: Enable JWT bearer-token validation. Requires remoteJWKSUri
+      issuer: "" # @schema description: Expected token issuer (iss claim). Defaults to the OIDC issuer (oidcProxyGateway.provider.issuer). Override only if bearer tokens come from a different authorization server than browser login
+      remoteJWKSUri: "" # @schema description: JWKS URI the gateway fetches the provider's signing keys from. Required when enabled - find it with `curl -s <issuer>/.well-known/openid-configuration | jq -r .jwks_uri` (for the czi.okta.com org server that is https://czi.okta.com/oauth2/v1/keys)
       # NOTE: token audience (aud) validation is intentionally not exposed. It would be good
       # practice - it pins a token to this API so a token minted for another service (same
       # issuer and signing keys) cannot be replayed here (RFC 8725) - but a specific audience


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-7079

Adds a `jwt` section to the Envoy gateway's SecurityPolicy, allowing Argus apps to authenticate Okta via the `Authorization` header with value `Bearer <token>`. Roughly equivalent to oauth2-proxy's `--skip-jwt-bearer-tokens=true`, which apps can currently set via `oidcProxy.extraArgs` (until Envoy launches, at which point the OIDC proxy will be removed)

Needed for Biohub data CLI to access the internal all-data API as its backend.

#### Note this is a little more opinionated than the underlying Envoy API:

- We allow only a single provider (most common case, keeps the chart simple)
- The `issuer` is defaulted to the chart's global `oidcProxyGateway.provider.issuer` (that is: `https://czi.okta.com`) (but overrideable on the chart)
- `remoteJWKSUri` is required whenever `jwt.enabled` is true - the render fails with a message pointing at `<issuer>/.well-known/openid-configuration`. (An earlier revision derived it from `issuer`; per review that guesswork is gone.)
- Not exposing [`claimToHeaders`](https://gateway.envoyproxy.io/latest/api/extension_types/#jwtprovider) (forwards JWT claims as HTTP headers; not used)
- Not exposing [`audiences`](https://gateway.envoyproxy.io/latest/api/extension_types/#jwtprovider) (not used because it would require a custom Okta auth server, which is not self-service - **but this goes against best practices ([RFC 8725](https://datatracker.ietf.org/doc/html/rfc8725)) so we might want to add this later**)

#### Docs
chanzuckerberg/argus#2610 documents `gateway.jwt` in `stack_auth.md`, including how to find the JWKS URI, and fixes [the line](https://github.com/chanzuckerberg/argus/blob/main/docs/configuration/security/stack_auth.md?plain=1#L181-L182) saying `--skip-jwt-bearer-tokens` has no gateway equivalent.