### PR TITLE
feat: IDT-170 make the datasource resync period configurable

### DIFF
--- a/grafana/templates/datasources.yaml
+++ b/grafana/templates/datasources.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -30,7 +30,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -51,7 +51,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -73,7 +73,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}

--- a/grafana/tests/datasources_test.yaml
+++ b/grafana/tests/datasources_test.yaml
@@ -26,6 +26,14 @@ tests:
           path: spec.resyncPeriod
           value: 30m
 
+  - it: should honor a datasourceResyncPeriod override
+    set:
+      datasourceResyncPeriod: 30s
+    asserts:
+      - equal:
+          path: spec.resyncPeriod
+          value: 30s
+
   - it: should have an instance selector
     asserts:
       - isNotEmpty:

--- a/grafana/values.schema.json
+++ b/grafana/values.schema.json
@@ -69,6 +69,11 @@
       "description": "Name of the cluster to configure the platform Grafana for. This value is required.",
       "type": "string"
     },
+    "datasourceResyncPeriod": {
+      "description": "How often grafana-operator re-pushes GrafanaDatasource CRs. Seconds are permitted: these CRs select instanceSelector name:<grafanaName>, the cluster-local instance, so they place no load on an external AMG workspace (a separate Grafana CR, typically central-grafana).",
+      "type": "string",
+      "pattern": "^[0-9]+(s|m|h)$"
+    },
     "datasources": {
       "description": "List of datasources to configure for the Grafana instance.",
       "type": "object",

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -16,6 +16,8 @@ secretStoreRef: "aws-secretsmanager" # @schema description: Name of the secret s
 
 roleAttributePath: "contains(groups[*], 'team-central-czi-admin') && 'Admin' || 'Viewer'" # @schema description: JMESPath expression to use to determine the role of the user. See https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/ .
 
+datasourceResyncPeriod: 30m # @schema type: string; pattern: ^[0-9]+(s|m|h)$; description: How often grafana-operator re-pushes GrafanaDatasource CRs. This is the recovery clock after a Grafana restart: until the DB is persistent, datasources are missing for up to this long after every pod replacement. Seconds are permitted - these CRs select instanceSelector name:<grafanaName>, the cluster-local instance, so they place no load on an external AMG workspace (which is a separate Grafana CR, typically central-grafana). Lower it on clusters where Grafana runs without persistent storage.
+
 grafanaAnnotations: {} # @schema description: Annotations to add to the Grafana instance.; patternProperties: { "^.*$": { "type": "string" } }
 
 grafanaSubdomain: "grafana" # @schema description: Subdomain to use for the Grafana instance.


### PR DESCRIPTION
Grafana's DB is an `emptyDir`, so a pod replacement erases every datasource and `resyncPeriod` becomes the recovery clock, not a refresh interval. With `consolidateAfter: 24h` the pod moves every two to three days — Grafana restarted 10 times in the last 24 days — so we're getting a ~30 minute datasource outage on roughly that cadence. Measured on `prod-edu-platform`: 62s on July 17, ~30 min on July 24.

This extends the pattern from #508, which made `grafanaDashboard.resyncPeriod` a configurable value in the `stack` chart under the same ticket. Same idea, applied to the one chart that didn't get it.

On CCIE-6793: the AMG budget is real, but these CRs don't touch it. This cluster runs two Grafana CRs — `grafana` (`app=grafana`, `name=grafana`) and `central-grafana` (`name=central-grafana`). The four `GrafanaDatasource` CRs select `name=grafana`, the cluster-local pod. Verified live.

Not proposing a PVC — measured, a volume makes availability worse here (18s to Ready without, 78s with).

Defaults to `30m`, so no cluster's rendered output changes until it opts in. The `archived-repo-scan` failure is the fork-PR secret restriction (`Generate GitHub App token` can't read secrets from a fork), not this change.
