### PR TITLE
feat: IDT-170 make the datasource resync period configurable

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -8,26 +8,27 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                     | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                                    |
-| -------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| - [accessMode](#accessMode )                 | No      | enum (of string) | No         | -          | Access mode for Grafana. Options: "sso" (SSO with ingress, production), "anonymous" (anonymous access without ingress, development).                                                 |
-| - [allow_embedding](#allow_embedding )       | No      | string           | No         | -          | Allow embedding of Grafana dashboards in other applications.                                                                                                                         |
-| - [baseDomain](#baseDomain )                 | No      | string           | No         | -          | -                                                                                                                                                                                    |
-| - [centralGrafana](#centralGrafana )         | No      | object           | No         | -          | -                                                                                                                                                                                    |
-| + [clusterName](#clusterName )               | No      | string           | No         | -          | Name of the cluster to configure the platform Grafana for. This value is required.                                                                                                   |
-| - [datasources](#datasources )               | No      | object           | No         | -          | List of datasources to configure for the Grafana instance.                                                                                                                           |
-| - [enabled](#enabled )                       | No      | boolean          | No         | -          | Enable the Grafana instance.                                                                                                                                                         |
-| - [env](#env )                               | No      | object           | No         | -          | Environment variables to set in the Grafana instance. This can be used to set custom environment variables for Grafana.                                                              |
-| - [extraSecretVolumes](#extraSecretVolumes ) | No      | array            | No         | -          | List of extra secret volumes to mount in the Grafana instance. Each entry should be a map with the following keys:                                                                   |
-| - [grafanaAnnotations](#grafanaAnnotations ) | No      | object           | No         | -          | Annotations to add to the Grafana instance.                                                                                                                                          |
-| - [grafanaBaseImage](#grafanaBaseImage )     | No      | string           | No         | -          | Base image for the Grafana instance.                                                                                                                                                 |
-| - [grafanaName](#grafanaName )               | No      | string           | No         | -          | Name of the Grafana instance to create.                                                                                                                                              |
-| - [grafanaSubdomain](#grafanaSubdomain )     | No      | string           | No         | -          | Subdomain to use for the Grafana instance.                                                                                                                                           |
-| - [replicas](#replicas )                     | No      | integer          | No         | -          | Number of Grafana replicas to create. When greater than 1, database persistence is required (not supported yet), as well as session affinity.                                        |
-| - [resources](#resources )                   | No      | object           | No         | -          | Resource requests and limits for the Grafana container. When empty, the grafana-operator applies its own defaults (requests 100m CPU / 256Mi memory, limits 1Gi memory).             |
-| - [roleAttributePath](#roleAttributePath )   | No      | string           | No         | -          | JMESPath expression to use to determine the role of the user. See https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/ . |
-| - [secretStoreRef](#secretStoreRef )         | No      | string           | No         | -          | Name of the secret store to use for external secrets.                                                                                                                                |
-| - [serviceAccount](#serviceAccount )         | No      | object           | No         | -          | -                                                                                                                                                                                    |
+| Property                                             | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------------------------------------------- | ------- | ---------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| - [accessMode](#accessMode )                         | No      | enum (of string) | No         | -          | Access mode for Grafana. Options: "sso" (SSO with ingress, production), "anonymous" (anonymous access without ingress, development).                                                                                                                                                                                                                                                                                                                                                                               |
+| - [allow_embedding](#allow_embedding )               | No      | string           | No         | -          | Allow embedding of Grafana dashboards in other applications.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| - [baseDomain](#baseDomain )                         | No      | string           | No         | -          | -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| - [centralGrafana](#centralGrafana )                 | No      | object           | No         | -          | -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| + [clusterName](#clusterName )                       | No      | string           | No         | -          | Name of the cluster to configure the platform Grafana for. This value is required.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [datasourceResyncPeriod](#datasourceResyncPeriod ) | No      | string           | No         | -          | How often grafana-operator re-pushes GrafanaDatasource CRs. This is the recovery clock after a Grafana restart: until the DB is persistent, datasources are missing for up to this long after every pod replacement. Seconds are permitted - these CRs select instanceSelector name:<grafanaName>, the cluster-local instance, so they place no load on an external AMG workspace (which is a separate Grafana CR, typically central-grafana). Lower it on clusters where Grafana runs without persistent storage. |
+| - [datasources](#datasources )                       | No      | object           | No         | -          | List of datasources to configure for the Grafana instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [enabled](#enabled )                               | No      | boolean          | No         | -          | Enable the Grafana instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| - [env](#env )                                       | No      | object           | No         | -          | Environment variables to set in the Grafana instance. This can be used to set custom environment variables for Grafana.                                                                                                                                                                                                                                                                                                                                                                                            |
+| - [extraSecretVolumes](#extraSecretVolumes )         | No      | array            | No         | -          | List of extra secret volumes to mount in the Grafana instance. Each entry should be a map with the following keys:                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - [grafanaAnnotations](#grafanaAnnotations )         | No      | object           | No         | -          | Annotations to add to the Grafana instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| - [grafanaBaseImage](#grafanaBaseImage )             | No      | string           | No         | -          | Base image for the Grafana instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| - [grafanaName](#grafanaName )                       | No      | string           | No         | -          | Name of the Grafana instance to create.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| - [grafanaSubdomain](#grafanaSubdomain )             | No      | string           | No         | -          | Subdomain to use for the Grafana instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| - [replicas](#replicas )                             | No      | integer          | No         | -          | Number of Grafana replicas to create. When greater than 1, database persistence is required (not supported yet), as well as session affinity.                                                                                                                                                                                                                                                                                                                                                                      |
+| - [resources](#resources )                           | No      | object           | No         | -          | Resource requests and limits for the Grafana container. When empty, the grafana-operator applies its own defaults (requests 100m CPU / 256Mi memory, limits 1Gi memory).                                                                                                                                                                                                                                                                                                                                           |
+| - [roleAttributePath](#roleAttributePath )           | No      | string           | No         | -          | JMESPath expression to use to determine the role of the user. See https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/ .                                                                                                                                                                                                                                                                                                                               |
+| - [secretStoreRef](#secretStoreRef )                 | No      | string           | No         | -          | Name of the secret store to use for external secrets.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| - [serviceAccount](#serviceAccount )                 | No      | object           | No         | -          | -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ## <a name="accessMode"></a>1. Property `grafana > accessMode`
 
@@ -168,7 +169,20 @@ Must be one of:
 
 **Description:** Name of the cluster to configure the platform Grafana for. This value is required.
 
-## <a name="datasources"></a>6. Property `grafana > datasources`
+## <a name="datasourceResyncPeriod"></a>6. Property `grafana > datasourceResyncPeriod`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** How often grafana-operator re-pushes GrafanaDatasource CRs. This is the recovery clock after a Grafana restart: until the DB is persistent, datasources are missing for up to this long after every pod replacement. Seconds are permitted - these CRs select instanceSelector name:<grafanaName>, the cluster-local instance, so they place no load on an external AMG workspace (which is a separate Grafana CR, typically central-grafana). Lower it on clusters where Grafana runs without persistent storage.
+
+| Restrictions                      |                                                                                               |
+| --------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Must match regular expression** | ```^[0-9]+(s\|m\|h)$``` [Test](https://regex101.com/?regex=%5E%5B0-9%5D%2B%28s%7Cm%7Ch%29%24) |
+
+## <a name="datasources"></a>7. Property `grafana > datasources`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -185,7 +199,7 @@ Must be one of:
 | - [prometheus](#datasources_prometheus ) | No      | object | No         | -          | Prometheus datasource configuration. |
 | - [tempo](#datasources_tempo )           | No      | object | No         | -          | Tempo datasource configuration.      |
 
-### <a name="datasources_cloudwatch"></a>6.1. Property `grafana > datasources > cloudwatch`
+### <a name="datasources_cloudwatch"></a>7.1. Property `grafana > datasources > cloudwatch`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -200,7 +214,7 @@ Must be one of:
 | - [enabled](#datasources_cloudwatch_enabled ) | No      | boolean | No         | -          | Enable the CloudWatch datasource.         |
 | - [region](#datasources_cloudwatch_region )   | No      | string  | No         | -          | AWS region for the CloudWatch datasource. |
 
-#### <a name="datasources_cloudwatch_enabled"></a>6.1.1. Property `grafana > datasources > cloudwatch > enabled`
+#### <a name="datasources_cloudwatch_enabled"></a>7.1.1. Property `grafana > datasources > cloudwatch > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -209,7 +223,7 @@ Must be one of:
 
 **Description:** Enable the CloudWatch datasource.
 
-#### <a name="datasources_cloudwatch_region"></a>6.1.2. Property `grafana > datasources > cloudwatch > region`
+#### <a name="datasources_cloudwatch_region"></a>7.1.2. Property `grafana > datasources > cloudwatch > region`
 
 |              |          |
 | ------------ | -------- |
@@ -218,7 +232,7 @@ Must be one of:
 
 **Description:** AWS region for the CloudWatch datasource.
 
-### <a name="datasources_loki"></a>6.2. Property `grafana > datasources > loki`
+### <a name="datasources_loki"></a>7.2. Property `grafana > datasources > loki`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -233,7 +247,7 @@ Must be one of:
 | - [enabled](#datasources_loki_enabled ) | No      | boolean | No         | -          | Enable the Loki datasource. |
 | - [url](#datasources_loki_url )         | No      | string  | No         | -          | URL of the Loki datasource. |
 
-#### <a name="datasources_loki_enabled"></a>6.2.1. Property `grafana > datasources > loki > enabled`
+#### <a name="datasources_loki_enabled"></a>7.2.1. Property `grafana > datasources > loki > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -242,7 +256,7 @@ Must be one of:
 
 **Description:** Enable the Loki datasource.
 
-#### <a name="datasources_loki_url"></a>6.2.2. Property `grafana > datasources > loki > url`
+#### <a name="datasources_loki_url"></a>7.2.2. Property `grafana > datasources > loki > url`
 
 |              |          |
 | ------------ | -------- |
@@ -251,7 +265,7 @@ Must be one of:
 
 **Description:** URL of the Loki datasource.
 
-### <a name="datasources_prometheus"></a>6.3. Property `grafana > datasources > prometheus`
+### <a name="datasources_prometheus"></a>7.3. Property `grafana > datasources > prometheus`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -266,7 +280,7 @@ Must be one of:
 | - [enabled](#datasources_prometheus_enabled ) | No      | boolean | No         | -          | Enable the Prometheus datasource. |
 | - [url](#datasources_prometheus_url )         | No      | string  | No         | -          | URL of the Prometheus datasource. |
 
-#### <a name="datasources_prometheus_enabled"></a>6.3.1. Property `grafana > datasources > prometheus > enabled`
+#### <a name="datasources_prometheus_enabled"></a>7.3.1. Property `grafana > datasources > prometheus > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -275,7 +289,7 @@ Must be one of:
 
 **Description:** Enable the Prometheus datasource.
 
-#### <a name="datasources_prometheus_url"></a>6.3.2. Property `grafana > datasources > prometheus > url`
+#### <a name="datasources_prometheus_url"></a>7.3.2. Property `grafana > datasources > prometheus > url`
 
 |              |          |
 | ------------ | -------- |
@@ -284,7 +298,7 @@ Must be one of:
 
 **Description:** URL of the Prometheus datasource.
 
-### <a name="datasources_tempo"></a>6.4. Property `grafana > datasources > tempo`
+### <a name="datasources_tempo"></a>7.4. Property `grafana > datasources > tempo`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -299,7 +313,7 @@ Must be one of:
 | - [enabled](#datasources_tempo_enabled ) | No      | boolean | No         | -          | Enable the Tempo datasource. |
 | - [url](#datasources_tempo_url )         | No      | string  | No         | -          | URL of the Tempo datasource. |
 
-#### <a name="datasources_tempo_enabled"></a>6.4.1. Property `grafana > datasources > tempo > enabled`
+#### <a name="datasources_tempo_enabled"></a>7.4.1. Property `grafana > datasources > tempo > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -308,7 +322,7 @@ Must be one of:
 
 **Description:** Enable the Tempo datasource.
 
-#### <a name="datasources_tempo_url"></a>6.4.2. Property `grafana > datasources > tempo > url`
+#### <a name="datasources_tempo_url"></a>7.4.2. Property `grafana > datasources > tempo > url`
 
 |              |          |
 | ------------ | -------- |
@@ -317,7 +331,7 @@ Must be one of:
 
 **Description:** URL of the Tempo datasource.
 
-## <a name="enabled"></a>7. Property `grafana > enabled`
+## <a name="enabled"></a>8. Property `grafana > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -326,7 +340,7 @@ Must be one of:
 
 **Description:** Enable the Grafana instance.
 
-## <a name="env"></a>8. Property `grafana > env`
+## <a name="env"></a>9. Property `grafana > env`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -340,7 +354,7 @@ Must be one of:
 | ------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [^.*$](#env_pattern1 ) | Yes     | string | No         | -          | -                 |
 
-### <a name="env_pattern1"></a>8.1. Pattern Property `grafana > env > ^.*$`
+### <a name="env_pattern1"></a>9.1. Pattern Property `grafana > env > ^.*$`
 > All properties whose name matches the regular expression
 ```^.*$``` ([Test](https://regex101.com/?regex=%5E.%2A%24))
 must respect the following conditions
@@ -350,7 +364,7 @@ must respect the following conditions
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="extraSecretVolumes"></a>9. Property `grafana > extraSecretVolumes`
+## <a name="extraSecretVolumes"></a>10. Property `grafana > extraSecretVolumes`
 
 |              |         |
 | ------------ | ------- |
@@ -367,7 +381,7 @@ must respect the following conditions
 | **Additional items** | False              |
 | **Tuple validation** | N/A                |
 
-## <a name="grafanaAnnotations"></a>10. Property `grafana > grafanaAnnotations`
+## <a name="grafanaAnnotations"></a>11. Property `grafana > grafanaAnnotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -381,7 +395,7 @@ must respect the following conditions
 | --------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [^.*$](#grafanaAnnotations_pattern1 ) | Yes     | string | No         | -          | -                 |
 
-### <a name="grafanaAnnotations_pattern1"></a>10.1. Pattern Property `grafana > grafanaAnnotations > ^.*$`
+### <a name="grafanaAnnotations_pattern1"></a>11.1. Pattern Property `grafana > grafanaAnnotations > ^.*$`
 > All properties whose name matches the regular expression
 ```^.*$``` ([Test](https://regex101.com/?regex=%5E.%2A%24))
 must respect the following conditions
@@ -391,7 +405,7 @@ must respect the following conditions
 | **Type**     | `string` |
 | **Required** | No       |
 
-## <a name="grafanaBaseImage"></a>11. Property `grafana > grafanaBaseImage`
+## <a name="grafanaBaseImage"></a>12. Property `grafana > grafanaBaseImage`
 
 |              |          |
 | ------------ | -------- |
@@ -400,7 +414,7 @@ must respect the following conditions
 
 **Description:** Base image for the Grafana instance.
 
-## <a name="grafanaName"></a>12. Property `grafana > grafanaName`
+## <a name="grafanaName"></a>13. Property `grafana > grafanaName`
 
 |              |          |
 | ------------ | -------- |
@@ -409,7 +423,7 @@ must respect the following conditions
 
 **Description:** Name of the Grafana instance to create.
 
-## <a name="grafanaSubdomain"></a>13. Property `grafana > grafanaSubdomain`
+## <a name="grafanaSubdomain"></a>14. Property `grafana > grafanaSubdomain`
 
 |              |          |
 | ------------ | -------- |
@@ -418,7 +432,7 @@ must respect the following conditions
 
 **Description:** Subdomain to use for the Grafana instance.
 
-## <a name="replicas"></a>14. Property `grafana > replicas`
+## <a name="replicas"></a>15. Property `grafana > replicas`
 
 |              |           |
 | ------------ | --------- |
@@ -431,7 +445,7 @@ must respect the following conditions
 | ------------ | ------ |
 | **Maximum**  | &le; 1 |
 
-## <a name="resources"></a>15. Property `grafana > resources`
+## <a name="resources"></a>16. Property `grafana > resources`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -441,7 +455,7 @@ must respect the following conditions
 
 **Description:** Resource requests and limits for the Grafana container. When empty, the grafana-operator applies its own defaults (requests 100m CPU / 256Mi memory, limits 1Gi memory).
 
-## <a name="roleAttributePath"></a>16. Property `grafana > roleAttributePath`
+## <a name="roleAttributePath"></a>17. Property `grafana > roleAttributePath`
 
 |              |          |
 | ------------ | -------- |
@@ -450,7 +464,7 @@ must respect the following conditions
 
 **Description:** JMESPath expression to use to determine the role of the user. See https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/ .
 
-## <a name="secretStoreRef"></a>17. Property `grafana > secretStoreRef`
+## <a name="secretStoreRef"></a>18. Property `grafana > secretStoreRef`
 
 |              |          |
 | ------------ | -------- |
@@ -459,7 +473,7 @@ must respect the following conditions
 
 **Description:** Name of the secret store to use for external secrets.
 
-## <a name="serviceAccount"></a>18. Property `grafana > serviceAccount`
+## <a name="serviceAccount"></a>19. Property `grafana > serviceAccount`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -471,7 +485,7 @@ must respect the following conditions
 | --------------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------------------ |
 | - [annotations](#serviceAccount_annotations ) | No      | object | No         | -          | Annotations to add to the service account. |
 
-### <a name="serviceAccount_annotations"></a>18.1. Property `grafana > serviceAccount > annotations`
+### <a name="serviceAccount_annotations"></a>19.1. Property `grafana > serviceAccount > annotations`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -485,7 +499,7 @@ must respect the following conditions
 | ----------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [^.*$](#serviceAccount_annotations_pattern1 ) | Yes     | string | No         | -          | -                 |
 
-#### <a name="serviceAccount_annotations_pattern1"></a>18.1.1. Pattern Property `grafana > serviceAccount > annotations > ^.*$`
+#### <a name="serviceAccount_annotations_pattern1"></a>19.1.1. Pattern Property `grafana > serviceAccount > annotations > ^.*$`
 > All properties whose name matches the regular expression
 ```^.*$``` ([Test](https://regex101.com/?regex=%5E.%2A%24))
 must respect the following conditions

--- a/grafana/templates/datasources.yaml
+++ b/grafana/templates/datasources.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -30,7 +30,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -51,7 +51,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}
@@ -73,7 +73,7 @@ metadata:
   labels:
     grafana_name: {{ .Values.grafanaName }}
 spec:
-  resyncPeriod: 30m
+  resyncPeriod: {{ .Values.datasourceResyncPeriod }}
   instanceSelector:
     matchLabels:
       name: {{ .Values.grafanaName }}

--- a/grafana/tests/datasources_test.yaml
+++ b/grafana/tests/datasources_test.yaml
@@ -26,6 +26,14 @@ tests:
           path: spec.resyncPeriod
           value: 30m
 
+  - it: should honor a datasourceResyncPeriod override
+    set:
+      datasourceResyncPeriod: 30s
+    asserts:
+      - equal:
+          path: spec.resyncPeriod
+          value: 30s
+
   - it: should have an instance selector
     asserts:
       - isNotEmpty:

--- a/grafana/values.schema.json
+++ b/grafana/values.schema.json
@@ -70,7 +70,7 @@
       "type": "string"
     },
     "datasourceResyncPeriod": {
-      "description": "How often grafana-operator re-pushes GrafanaDatasource CRs. This is the recovery clock after a Grafana restart: until the DB is persistent, datasources are missing for up to this long after every pod replacement. Seconds are permitted - these CRs select instanceSelector name:<grafanaName>, the cluster-local instance, so they place no load on an external AMG workspace (which is a separate Grafana CR, typically central-grafana). Lower it on clusters where Grafana runs without persistent storage.",
+      "description": "How often grafana-operator re-pushes GrafanaDatasource CRs. This is the recovery clock after a Grafana restart: until the DB is persistent, datasources are missing for up to this long after every pod replacement. Seconds are permitted - these CRs select instanceSelector name:\u003cgrafanaName\u003e, the cluster-local instance, so they place no load on an external AMG workspace (which is a separate Grafana CR, typically central-grafana). Lower it on clusters where Grafana runs without persistent storage.",
       "type": "string",
       "pattern": "^[0-9]+(s|m|h)$"
     },

--- a/grafana/values.schema.json
+++ b/grafana/values.schema.json
@@ -69,6 +69,11 @@
       "description": "Name of the cluster to configure the platform Grafana for. This value is required.",
       "type": "string"
     },
+    "datasourceResyncPeriod": {
+      "description": "How often grafana-operator re-pushes GrafanaDatasource CRs. This is the recovery clock after a Grafana restart: until the DB is persistent, datasources are missing for up to this long after every pod replacement. Seconds are permitted - these CRs select instanceSelector name:<grafanaName>, the cluster-local instance, so they place no load on an external AMG workspace (which is a separate Grafana CR, typically central-grafana). Lower it on clusters where Grafana runs without persistent storage.",
+      "type": "string",
+      "pattern": "^[0-9]+(s|m|h)$"
+    },
     "datasources": {
       "description": "List of datasources to configure for the Grafana instance.",
       "type": "object",

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -18,6 +18,8 @@ roleAttributePath: "contains(groups[*], 'team-central-czi-admin') && 'Admin' || 
 
 resources: {} # @schema description: Resource requests and limits for the Grafana container. When empty, the grafana-operator applies its own defaults (requests 100m CPU / 256Mi memory, limits 1Gi memory).; type: object
 
+datasourceResyncPeriod: 30m # @schema type: string; pattern: ^[0-9]+(s|m|h)$; description: How often grafana-operator re-pushes GrafanaDatasource CRs. This is the recovery clock after a Grafana restart: until the DB is persistent, datasources are missing for up to this long after every pod replacement. Seconds are permitted - these CRs select instanceSelector name:<grafanaName>, the cluster-local instance, so they place no load on an external AMG workspace (which is a separate Grafana CR, typically central-grafana). Lower it on clusters where Grafana runs without persistent storage.
+
 grafanaAnnotations: {} # @schema description: Annotations to add to the Grafana instance.; patternProperties: { "^.*$": { "type": "string" } }
 
 grafanaSubdomain: "grafana" # @schema description: Subdomain to use for the Grafana instance.


### PR DESCRIPTION
Grafana's DB is an `emptyDir`, so a pod replacement erases every datasource and `resyncPeriod` becomes the recovery clock, not a refresh interval. Grafana restarted 10 times in the last 24 days on `prod-edu-platform`, and each move costs a datasource outage of up to `resyncPeriod`. Measured: 62s on July 17, ~30 min on July 24.

IDT-161 has since raised `consolidateAfter` from 24h to 168h on that cluster, which cuts the consolidation-driven cadence but does not remove it. `expireAfter: 360h` still force-replaces every node on a 15-day clock — the current fleet expires 2026-08-14 — and AMI drift replaces it whenever a new AL2023 image ships. The pod will keep moving; this PR makes each move cheap.

This extends the pattern from #508, which made `grafanaDashboard.resyncPeriod` configurable in the `stack` chart under CCIE-6793. Same idea, applied to the one chart that didn't get it.

On CCIE-6793: the AMG budget is real, but these CRs don't touch it. This cluster runs two Grafana CRs — `grafana` (`app=grafana`, `name=grafana`) and `central-grafana` (`name=central-grafana`). The four `GrafanaDatasource` CRs select `name=grafana`, the cluster-local pod. Verified live: `kubectl get grafanadatasources -A` returns exactly four, all `resyncPeriod: 30m`, all selecting `name: grafana`. The separate `grafana-aps-datasource` CR that CCIE-6793 raised to 30m is not deployed to this cluster.

Not proposing a PVC — measured, a volume makes availability worse here (18s to Ready without, 78s with).

Defaults to `30m`, so no cluster's rendered output changes until it opts in. Applying it is also non-disruptive: the rendered diff is four scalar lines inside the `GrafanaDatasource` objects, the Grafana CR and Deployment are byte-identical, so no pod restart.

Consumer: chanzuckerberg/argus-infra-stacks#2872 sets `datasourceResyncPeriod: 30s` for `prod-edu-platform`. That repo pins the chart at `targetRevision: HEAD`, so this merges first and no version bump is needed.

Replaces #521, which was raised from a fork before I had push access.