### PR TITLE
fix(karpenter-gpu-nodepool): pin device plugin to GPU nodes and right-size requests

### DIFF
--- a/karpenter-gpu-nodepool/README.md
+++ b/karpenter-gpu-nodepool/README.md
@@ -1157,11 +1157,19 @@ must respect the following conditions
 
 **Description:** Node selector for the DaemonSet. Can be used to target specific nodes.
 
-| Property                                       | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ---------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [^.*$](#nvidiaDriver_nodeSelector_pattern1 ) | Yes     | string | No         | -          | -                 |
+| Property                                                                                                               | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ---------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [karpenter.k8s.aws/instance-gpu-manufacturer](#nvidiaDriver_nodeSelector_karpenterk8saws/instance-gpu-manufacturer ) | No      | string | No         | -          | -                 |
+| - [^.*$](#nvidiaDriver_nodeSelector_pattern1 )                                                                         | Yes     | string | No         | -          | -                 |
 
-#### <a name="nvidiaDriver_nodeSelector_pattern1"></a>4.8.1. Pattern Property `karpenter-gpu-nodepool > nvidiaDriver > nodeSelector > ^.*$`
+#### <a name="nvidiaDriver_nodeSelector_karpenterk8saws/instance-gpu-manufacturer"></a>4.8.1. Property `karpenter-gpu-nodepool > nvidiaDriver > nodeSelector > karpenter.k8s.aws/instance-gpu-manufacturer`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+#### <a name="nvidiaDriver_nodeSelector_pattern1"></a>4.8.2. Pattern Property `karpenter-gpu-nodepool > nvidiaDriver > nodeSelector > ^.*$`
 > All properties whose name matches the regular expression
 ```^.*$``` ([Test](https://regex101.com/?regex=%5E.%2A%24))
 must respect the following conditions
@@ -1221,6 +1229,37 @@ must respect the following conditions
 | **Additional properties** | Any type allowed |
 
 **Description:** Resources for the NVIDIA device plugin container. Can be used to set limits and requests.
+
+| Property                                        | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [requests](#nvidiaDriver_resources_requests ) | No      | object | No         | -          | -                 |
+
+#### <a name="nvidiaDriver_resources_requests"></a>4.11.1. Property `karpenter-gpu-nodepool > nvidiaDriver > resources > requests`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                             | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ---------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [cpu](#nvidiaDriver_resources_requests_cpu )       | No      | string | No         | -          | -                 |
+| - [memory](#nvidiaDriver_resources_requests_memory ) | No      | string | No         | -          | -                 |
+
+##### <a name="nvidiaDriver_resources_requests_cpu"></a>4.11.1.1. Property `karpenter-gpu-nodepool > nvidiaDriver > resources > requests > cpu`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="nvidiaDriver_resources_requests_memory"></a>4.11.1.2. Property `karpenter-gpu-nodepool > nvidiaDriver > resources > requests > memory`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
 ### <a name="nvidiaDriver_securityContext"></a>4.12. Property `karpenter-gpu-nodepool > nvidiaDriver > securityContext`
 

--- a/karpenter-gpu-nodepool/values.schema.json
+++ b/karpenter-gpu-nodepool/values.schema.json
@@ -414,6 +414,11 @@
         "nodeSelector": {
           "description": "Node selector for the DaemonSet. Can be used to target specific nodes.",
           "type": "object",
+          "properties": {
+            "karpenter.k8s.aws/instance-gpu-manufacturer": {
+              "type": "string"
+            }
+          },
           "patternProperties": {
             "^.*$": {
               "type": "string"
@@ -440,7 +445,20 @@
         },
         "resources": {
           "description": "Resources for the NVIDIA device plugin container. Can be used to set limits and requests.",
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         },
         "securityContext": {
           "description": "Security context for the container to run with minimal privileges.",

--- a/karpenter-gpu-nodepool/values.yaml
+++ b/karpenter-gpu-nodepool/values.yaml
@@ -102,7 +102,8 @@ nvidiaDriver:
       value: "true"
       effect: "NoSchedule"
   
-  nodeSelector: {} # @schema description: Node selector for the DaemonSet. Can be used to target specific nodes.; patternProperties: { "^.*$": { "type": "string" } }
+  nodeSelector: # @schema description: Node selector for the DaemonSet. Can be used to target specific nodes.; patternProperties: { "^.*$": { "type": "string" } }
+    karpenter.k8s.aws/instance-gpu-manufacturer: nvidia
   
   affinity: {} # @schema description: Affinity rules for the DaemonSet pods. Can be used for advanced scheduling like avoiding Fargate nodes.
     # nodeAffinity:
@@ -129,7 +130,10 @@ nvidiaDriver:
       hostPath:
         path: /var/lib/kubelet/device-plugins
   
-  resources: {} # @schema description: Resources for the NVIDIA device plugin container. Can be used to set limits and requests.
+  resources: # @schema description: Resources for the NVIDIA device plugin container. Can be used to set limits and requests.
+    requests:
+      cpu: 50m
+      memory: 64Mi
     # limits:
     #   memory: 128Mi
     # requests:
@@ -192,7 +196,7 @@ dcgmExporter:
       cpu: 500m
       memory: 1Gi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 512Mi
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## Summary

Chart-default promotion of values proven on the CCIE-7131 canary + 72h pilot, including fresh-GPU-launch validation on two clusters (plugin lands → GPU allocatable → startup taints clear).

- **nvidia device plugin defaults to the nvidia manufacturer nodeSelector** — the selector dcgm and node-readiness already use. Today it schedules onto 0-GPU nodes on every consuming cluster (karpenter-lens `ds-phantom-pods`, 14 clusters).
- **Device plugin gains its first requests (50m/64Mi)** — currently BestEffort and invisible to bin-packing.
- **dcgm: CPU 100m→50m, memory deliberately unchanged at 512Mi** — the pilot caught a 128Mi memory cut as under-requested within an hour (real usage ~420Mi P95); only CPU was fat.

Consumers track chart HEAD, so merge = fleet rollout to enabled clusters. The pilots' identical per-cluster values become redundant and get removed in a follow-up.

## Review focus

- The nodeSelector drops the plugin from any **non-Karpenter** GPU node (managed node groups). Fleet GPU is all Karpenter today — flag exceptions.
- Requests changed inside existing maps; limits untouched — verify the schema diff matches (`make update-schema` output committed).

## Test plan

- 104 chart unittests pass; schema regenerated.
- Post-merge: `ds-phantom-pods` and nvidia `ds-zero-request` go to zero fleet-wide; no dcgm under-request findings reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)