### PR TITLE
feat(grafana): accept Grafana Cloud and czi.team URLs for centralGrafana.url (CCIE-7170)

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -74,7 +74,7 @@ Must be one of:
 | - [enabled](#centralGrafana_enabled )                 | No      | boolean         | No         | -          | Enable the resource provisioning into the Central Grafana workspace.                                                                                                                                                                                         |
 | - [grafanaName](#centralGrafana_grafanaName )         | No      | string          | No         | -          | Name of the Grafana instance to create.                                                                                                                                                                                                                      |
 | - [tenantNamespace](#centralGrafana_tenantNamespace ) | No      | string          | No         | -          | Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance.                                                                                                                                             |
-| - [url](#centralGrafana_url )                         | No      | string          | No         | -          | URL of the Central Grafana instance (Argus Metrics Gateway). Must be a valid AWS Managed Grafana workspace URL.                                                                                                                                              |
+| - [url](#centralGrafana_url )                         | No      | string          | No         | -          | URL of the Central Grafana instance. Must be an AWS Managed Grafana workspace URL, a Grafana Cloud stack URL (*.grafana.net), or a CZI custom domain (*.czi.team).                                                                                           |
 
 ### <a name="centralGrafana_apiKeySecret"></a>4.1. Property `grafana > centralGrafana > apiKeySecret`
 
@@ -154,11 +154,11 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** URL of the Central Grafana instance (Argus Metrics Gateway). Must be a valid AWS Managed Grafana workspace URL.
+**Description:** URL of the Central Grafana instance. Must be an AWS Managed Grafana workspace URL, a Grafana Cloud stack URL (*.grafana.net), or a CZI custom domain (*.czi.team).
 
-| Restrictions                      |                                                                                                                                                                                                                                                       |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Must match regular expression** | ```^https://g-[a-f0-9]+\.grafana-workspace\.[a-z0-9]+(-[a-z0-9]+)*\.amazonaws\.com$``` [Test](https://regex101.com/?regex=%5Ehttps%3A%2F%2Fg-%5Ba-f0-9%5D%2B%5C.grafana-workspace%5C.%5Ba-z0-9%5D%2B%28-%5Ba-z0-9%5D%2B%29%2A%5C.amazonaws%5C.com%24) |
+| Restrictions                      |                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Must match regular expression** | ```^https://(g-[a-f0-9]+\.grafana-workspace\.[a-z0-9]+(-[a-z0-9]+)*\.amazonaws\.com\|[a-z0-9-]+(\.[a-z0-9-]+)*\.czi\.team\|[a-z0-9-]+\.grafana\.net)$``` [Test](https://regex101.com/?regex=%5Ehttps%3A%2F%2F%28g-%5Ba-f0-9%5D%2B%5C.grafana-workspace%5C.%5Ba-z0-9%5D%2B%28-%5Ba-z0-9%5D%2B%29%2A%5C.amazonaws%5C.com%7C%5Ba-z0-9-%5D%2B%28%5C.%5Ba-z0-9-%5D%2B%29%2A%5C.czi%5C.team%7C%5Ba-z0-9-%5D%2B%5C.grafana%5C.net%29%24) |
 
 ## <a name="clusterName"></a>5. Property `grafana > clusterName`
 

--- a/grafana/tests/central-grafana_test.yaml
+++ b/grafana/tests/central-grafana_test.yaml
@@ -176,3 +176,25 @@ tests:
           path: spec.external.apiKey
       - isNotEmpty:
           path: spec.external.url
+
+  - it: should accept a Grafana Cloud custom-domain url
+    set:
+      enabled: true
+      centralGrafana:
+        enabled: true
+        url: https://grafana.prod.czi.team
+    asserts:
+      - equal:
+          path: spec.external.url
+          value: "https://grafana.prod.czi.team"
+
+  - it: should accept a grafana.net stack url
+    set:
+      enabled: true
+      centralGrafana:
+        enabled: true
+        url: https://biohub.grafana.net
+    asserts:
+      - equal:
+          path: spec.external.url
+          value: "https://biohub.grafana.net"

--- a/grafana/values.schema.json
+++ b/grafana/values.schema.json
@@ -59,9 +59,9 @@
           "type": "string"
         },
         "url": {
-          "description": "URL of the Central Grafana instance (Argus Metrics Gateway). Must be a valid AWS Managed Grafana workspace URL.",
+          "description": "URL of the Central Grafana instance. Must be an AWS Managed Grafana workspace URL, a Grafana Cloud stack URL (*.grafana.net), or a CZI custom domain (*.czi.team).",
           "type": "string",
-          "pattern": "^https://g-[a-f0-9]+\\.grafana-workspace\\.[a-z0-9]+(-[a-z0-9]+)*\\.amazonaws\\.com$"
+          "pattern": "^https://(g-[a-f0-9]+\\.grafana-workspace\\.[a-z0-9]+(-[a-z0-9]+)*\\.amazonaws\\.com|[a-z0-9-]+(\\.[a-z0-9-]+)*\\.czi\\.team|[a-z0-9-]+\\.grafana\\.net)$"
         }
       }
     },

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -64,6 +64,6 @@ centralGrafana:
   apiKeySecret:
     name: central-grafana-admin-api-key # @schema description: Name of the secret containing the Admin API key for the Central Grafana instance.
     key: GF_SECURITY_ADMIN_APIKEY # @schema description: Key of the secret containing the Admin API key for the Central Grafana instance.
-  url: https://g-0000000000.grafana-workspace.us-west-2.amazonaws.com # @schema description: URL of the Central Grafana instance (Argus Metrics Gateway). Must be a valid AWS Managed Grafana workspace URL.; pattern: ^https://g-[a-f0-9]+\.grafana-workspace\.[a-z0-9]+(-[a-z0-9]+)*\.amazonaws\.com$
+  url: https://g-0000000000.grafana-workspace.us-west-2.amazonaws.com # @schema description: URL of the Central Grafana instance. Must be an AWS Managed Grafana workspace URL, a Grafana Cloud stack URL (*.grafana.net), or a CZI custom domain (*.czi.team).; pattern: ^https://(g-[a-f0-9]+\.grafana-workspace\.[a-z0-9]+(-[a-z0-9]+)*\.amazonaws\.com|[a-z0-9-]+(\.[a-z0-9-]+)*\.czi\.team|[a-z0-9-]+\.grafana\.net)$
   tenantNamespace: default # @schema description: Namespace used by the Grafana operator for reconciling resources associated with this external Grafana instance.
   clientTimeout: null # @schema description: HTTP client timeout in seconds for the grafana-operator when talking to the Central Grafana workspace. When null (default), the operator uses its built-in default of 10s. Increase (e.g. 120) if folder finalization times out against AWS Managed Grafana.; type: ["integer", "null"]; minimum: 1


### PR DESCRIPTION
## Summary

Widens the `centralGrafana.url` schema pattern to accept Grafana Cloud stack URLs (`*.grafana.net`) and CZI custom domains (`*.czi.team`) alongside AWS Managed Grafana workspace URLs. Groundwork for the central Grafana → Grafana Cloud migration ([RFC](https://github.com/chanzuckerberg/infra-proposals/pull/6), CCIE-7170) — today's pattern structurally rejects any non-AMG URL, which blocks re-pointing the fleet's external Grafana CR at https://grafana.prod.czi.team.

No rendered-output change for any existing values: this only widens what validates.

## Review focus

- Pattern anchors: still fully anchored (`^https://(...)$`), no scheme/host wildcards beyond the three allowed shapes.
- `values.schema.json` is generated (`make update-schema`), not hand-edited.

## Test plan

- `helm unittest .` — 68/68 pass (adds cases asserting grafana.prod.czi.team and biohub.grafana.net render).
- Schema gate exercised via `helm template`: czi.team ✅ accepted, AMG ✅ accepted, `https://evil.example.com` ❌ rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)