### PR TITLE
feat(karpenter-nodepool): generic NodePool + EC2NodeClass chart for default pool ownership

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,5 +7,6 @@
   "basic-auth-secret": "0.4.0",
   "prom2parquet": "0.3.2",
   "karpenter-gpu-nodepool": "0.4.3",
-  "grafana-alloy": "0.10.1"
+  "grafana-alloy": "0.10.1",
+  "karpenter-nodepool": "0.0.1"
 }

--- a/karpenter-nodepool/Chart.yaml
+++ b/karpenter-nodepool/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: karpenter-nodepool
+description: A Helm chart for deploying a generic Karpenter NodePool and its
+  EC2NodeClass, defaulting to a cluster's default pool
+type: application
+version: 0.1.0
+appVersion: "1.0"
+keywords:
+  - karpenter
+  - nodepool
+  - ec2nodeclass
+home: https://github.com/chanzuckerberg/argo-helm-charts
+maintainers:
+  - name: CZI Platform Team

--- a/karpenter-nodepool/Makefile
+++ b/karpenter-nodepool/Makefile
@@ -1,0 +1,2 @@
+include ../common.mk
+include ../schema.mk

--- a/karpenter-nodepool/README.md
+++ b/karpenter-nodepool/README.md
@@ -29,17 +29,19 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                           | Pattern | Type            | Deprecated | Definition | Title/Description |
-| -------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ----------------- |
-| - [amiFamily](#nodeclass_amiFamily )               | No      | string          | No         | -          | -                 |
-| - [amiSelectorTerms](#nodeclass_amiSelectorTerms ) | No      | array of object | No         | -          | -                 |
-| - [annotations](#nodeclass_annotations )           | No      | object          | No         | -          | -                 |
-| - [enabled](#nodeclass_enabled )                   | No      | boolean         | No         | -          | -                 |
-| - [kubelet](#nodeclass_kubelet )                   | No      | object          | No         | -          | -                 |
-| - [name](#nodeclass_name )                         | No      | string          | No         | -          | -                 |
-| - [role](#nodeclass_role )                         | No      | string          | No         | -          | -                 |
-| - [tags](#nodeclass_tags )                         | No      | object          | No         | -          | -                 |
-| - [volumeSizeGi](#nodeclass_volumeSizeGi )         | No      | integer         | No         | -          | -                 |
+| Property                                                               | Pattern | Type            | Deprecated | Definition | Title/Description |
+| ---------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ----------------- |
+| - [amiFamily](#nodeclass_amiFamily )                                   | No      | string          | No         | -          | -                 |
+| - [amiSelectorTerms](#nodeclass_amiSelectorTerms )                     | No      | array of object | No         | -          | -                 |
+| - [annotations](#nodeclass_annotations )                               | No      | object          | No         | -          | -                 |
+| - [enabled](#nodeclass_enabled )                                       | No      | boolean         | No         | -          | -                 |
+| - [kubelet](#nodeclass_kubelet )                                       | No      | object          | No         | -          | -                 |
+| - [name](#nodeclass_name )                                             | No      | string          | No         | -          | -                 |
+| - [role](#nodeclass_role )                                             | No      | string          | No         | -          | -                 |
+| - [securityGroupSelectorTerms](#nodeclass_securityGroupSelectorTerms ) | No      | array           | No         | -          | -                 |
+| - [subnetSelectorTerms](#nodeclass_subnetSelectorTerms )               | No      | array           | No         | -          | -                 |
+| - [tags](#nodeclass_tags )                                             | No      | object          | No         | -          | -                 |
+| - [volumeSizeGi](#nodeclass_volumeSizeGi )                             | No      | integer         | No         | -          | -                 |
 
 ### <a name="nodeclass_amiFamily"></a>2.1. Property `karpenter-nodepool > nodeclass > amiFamily`
 
@@ -162,7 +164,37 @@
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="nodeclass_tags"></a>2.8. Property `karpenter-nodepool > nodeclass > tags`
+### <a name="nodeclass_securityGroupSelectorTerms"></a>2.8. Property `karpenter-nodepool > nodeclass > securityGroupSelectorTerms`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+### <a name="nodeclass_subnetSelectorTerms"></a>2.9. Property `karpenter-nodepool > nodeclass > subnetSelectorTerms`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+### <a name="nodeclass_tags"></a>2.10. Property `karpenter-nodepool > nodeclass > tags`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -170,7 +202,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-### <a name="nodeclass_volumeSizeGi"></a>2.9. Property `karpenter-nodepool > nodeclass > volumeSizeGi`
+### <a name="nodeclass_volumeSizeGi"></a>2.11. Property `karpenter-nodepool > nodeclass > volumeSizeGi`
 
 |              |           |
 | ------------ | --------- |

--- a/karpenter-nodepool/README.md
+++ b/karpenter-nodepool/README.md
@@ -1,0 +1,489 @@
+# karpenter-nodepool
+
+**Title:** karpenter-nodepool
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                       | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [clusterName](#clusterName ) | No      | string | No         | -          | -                 |
+| - [nodeclass](#nodeclass )     | No      | object | No         | -          | -                 |
+| - [nodepool](#nodepool )       | No      | object | No         | -          | -                 |
+
+## <a name="clusterName"></a>1. Property `karpenter-nodepool > clusterName`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="nodeclass"></a>2. Property `karpenter-nodepool > nodeclass`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                           | Pattern | Type            | Deprecated | Definition | Title/Description |
+| -------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ----------------- |
+| - [amiFamily](#nodeclass_amiFamily )               | No      | string          | No         | -          | -                 |
+| - [amiSelectorTerms](#nodeclass_amiSelectorTerms ) | No      | array of object | No         | -          | -                 |
+| - [annotations](#nodeclass_annotations )           | No      | object          | No         | -          | -                 |
+| - [enabled](#nodeclass_enabled )                   | No      | boolean         | No         | -          | -                 |
+| - [kubelet](#nodeclass_kubelet )                   | No      | object          | No         | -          | -                 |
+| - [name](#nodeclass_name )                         | No      | string          | No         | -          | -                 |
+| - [role](#nodeclass_role )                         | No      | string          | No         | -          | -                 |
+| - [tags](#nodeclass_tags )                         | No      | object          | No         | -          | -                 |
+| - [volumeSizeGi](#nodeclass_volumeSizeGi )         | No      | integer         | No         | -          | -                 |
+
+### <a name="nodeclass_amiFamily"></a>2.1. Property `karpenter-nodepool > nodeclass > amiFamily`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodeclass_amiSelectorTerms"></a>2.2. Property `karpenter-nodepool > nodeclass > amiSelectorTerms`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                             | Description |
+| ----------------------------------------------------------- | ----------- |
+| [amiSelectorTerms items](#nodeclass_amiSelectorTerms_items) | -           |
+
+#### <a name="nodeclass_amiSelectorTerms_items"></a>2.2.1. karpenter-nodepool > nodeclass > amiSelectorTerms > amiSelectorTerms items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                            | Pattern | Type   | Deprecated | Definition | Title/Description |
+| --------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [alias](#nodeclass_amiSelectorTerms_items_alias ) | No      | string | No         | -          | -                 |
+
+##### <a name="nodeclass_amiSelectorTerms_items_alias"></a>2.2.1.1. Property `karpenter-nodepool > nodeclass > amiSelectorTerms > amiSelectorTerms items > alias`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodeclass_annotations"></a>2.3. Property `karpenter-nodepool > nodeclass > annotations`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+### <a name="nodeclass_enabled"></a>2.4. Property `karpenter-nodepool > nodeclass > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+### <a name="nodeclass_kubelet"></a>2.5. Property `karpenter-nodepool > nodeclass > kubelet`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                               | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------ | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [podsPerCore](#nodeclass_kubelet_podsPerCore )       | No      | integer | No         | -          | -                 |
+| - [systemReserved](#nodeclass_kubelet_systemReserved ) | No      | object  | No         | -          | -                 |
+
+#### <a name="nodeclass_kubelet_podsPerCore"></a>2.5.1. Property `karpenter-nodepool > nodeclass > kubelet > podsPerCore`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+#### <a name="nodeclass_kubelet_systemReserved"></a>2.5.2. Property `karpenter-nodepool > nodeclass > kubelet > systemReserved`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [cpu](#nodeclass_kubelet_systemReserved_cpu )       | No      | string | No         | -          | -                 |
+| - [memory](#nodeclass_kubelet_systemReserved_memory ) | No      | string | No         | -          | -                 |
+
+##### <a name="nodeclass_kubelet_systemReserved_cpu"></a>2.5.2.1. Property `karpenter-nodepool > nodeclass > kubelet > systemReserved > cpu`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="nodeclass_kubelet_systemReserved_memory"></a>2.5.2.2. Property `karpenter-nodepool > nodeclass > kubelet > systemReserved > memory`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodeclass_name"></a>2.6. Property `karpenter-nodepool > nodeclass > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodeclass_role"></a>2.7. Property `karpenter-nodepool > nodeclass > role`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodeclass_tags"></a>2.8. Property `karpenter-nodepool > nodeclass > tags`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+### <a name="nodeclass_volumeSizeGi"></a>2.9. Property `karpenter-nodepool > nodeclass > volumeSizeGi`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+## <a name="nodepool"></a>3. Property `karpenter-nodepool > nodepool`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                | Pattern | Type    | Deprecated | Definition | Title/Description |
+| --------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [annotations](#nodepool_annotations ) | No      | object  | No         | -          | -                 |
+| - [disruption](#nodepool_disruption )   | No      | object  | No         | -          | -                 |
+| - [enabled](#nodepool_enabled )         | No      | boolean | No         | -          | -                 |
+| - [limits](#nodepool_limits )           | No      | object  | No         | -          | -                 |
+| - [name](#nodepool_name )               | No      | string  | No         | -          | -                 |
+| - [template](#nodepool_template )       | No      | object  | No         | -          | -                 |
+| - [weight](#nodepool_weight )           | No      | null    | No         | -          | -                 |
+
+### <a name="nodepool_annotations"></a>3.1. Property `karpenter-nodepool > nodepool > annotations`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+### <a name="nodepool_disruption"></a>3.2. Property `karpenter-nodepool > nodepool > disruption`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                           | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [budgets](#nodepool_disruption_budgets )                         | No      | array  | No         | -          | -                 |
+| - [consolidateAfter](#nodepool_disruption_consolidateAfter )       | No      | string | No         | -          | -                 |
+| - [consolidationPolicy](#nodepool_disruption_consolidationPolicy ) | No      | string | No         | -          | -                 |
+
+#### <a name="nodepool_disruption_budgets"></a>3.2.1. Property `karpenter-nodepool > nodepool > disruption > budgets`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+#### <a name="nodepool_disruption_consolidateAfter"></a>3.2.2. Property `karpenter-nodepool > nodepool > disruption > consolidateAfter`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+#### <a name="nodepool_disruption_consolidationPolicy"></a>3.2.3. Property `karpenter-nodepool > nodepool > disruption > consolidationPolicy`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodepool_enabled"></a>3.3. Property `karpenter-nodepool > nodepool > enabled`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+### <a name="nodepool_limits"></a>3.4. Property `karpenter-nodepool > nodepool > limits`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+### <a name="nodepool_name"></a>3.5. Property `karpenter-nodepool > nodepool > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodepool_template"></a>3.6. Property `karpenter-nodepool > nodepool > template`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                   | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [metadata](#nodepool_template_metadata ) | No      | object | No         | -          | -                 |
+| - [spec](#nodepool_template_spec )         | No      | object | No         | -          | -                 |
+
+#### <a name="nodepool_template_metadata"></a>3.6.1. Property `karpenter-nodepool > nodepool > template > metadata`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                  | Pattern | Type   | Deprecated | Definition | Title/Description |
+| --------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [annotations](#nodepool_template_metadata_annotations ) | No      | object | No         | -          | -                 |
+| - [labels](#nodepool_template_metadata_labels )           | No      | object | No         | -          | -                 |
+
+##### <a name="nodepool_template_metadata_annotations"></a>3.6.1.1. Property `karpenter-nodepool > nodepool > template > metadata > annotations`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+##### <a name="nodepool_template_metadata_labels"></a>3.6.1.2. Property `karpenter-nodepool > nodepool > template > metadata > labels`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+#### <a name="nodepool_template_spec"></a>3.6.2. Property `karpenter-nodepool > nodepool > template > spec`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                                    | Pattern | Type            | Deprecated | Definition | Title/Description |
+| --------------------------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ----------------- |
+| - [expireAfter](#nodepool_template_spec_expireAfter )                       | No      | string          | No         | -          | -                 |
+| - [nodeClassRef](#nodepool_template_spec_nodeClassRef )                     | No      | object          | No         | -          | -                 |
+| - [requirements](#nodepool_template_spec_requirements )                     | No      | array of object | No         | -          | -                 |
+| - [startupTaints](#nodepool_template_spec_startupTaints )                   | No      | array           | No         | -          | -                 |
+| - [taints](#nodepool_template_spec_taints )                                 | No      | array           | No         | -          | -                 |
+| - [terminationGracePeriod](#nodepool_template_spec_terminationGracePeriod ) | No      | string          | No         | -          | -                 |
+
+##### <a name="nodepool_template_spec_expireAfter"></a>3.6.2.1. Property `karpenter-nodepool > nodepool > template > spec > expireAfter`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="nodepool_template_spec_nodeClassRef"></a>3.6.2.2. Property `karpenter-nodepool > nodepool > template > spec > nodeClassRef`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                               | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| - [group](#nodepool_template_spec_nodeClassRef_group ) | No      | string | No         | -          | -                 |
+| - [kind](#nodepool_template_spec_nodeClassRef_kind )   | No      | string | No         | -          | -                 |
+| - [name](#nodepool_template_spec_nodeClassRef_name )   | No      | string | No         | -          | -                 |
+
+###### <a name="nodepool_template_spec_nodeClassRef_group"></a>3.6.2.2.1. Property `karpenter-nodepool > nodepool > template > spec > nodeClassRef > group`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="nodepool_template_spec_nodeClassRef_kind"></a>3.6.2.2.2. Property `karpenter-nodepool > nodepool > template > spec > nodeClassRef > kind`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="nodepool_template_spec_nodeClassRef_name"></a>3.6.2.2.3. Property `karpenter-nodepool > nodepool > template > spec > nodeClassRef > name`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="nodepool_template_spec_requirements"></a>3.6.2.3. Property `karpenter-nodepool > nodepool > template > spec > requirements`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                                  | Description |
+| ---------------------------------------------------------------- | ----------- |
+| [requirements items](#nodepool_template_spec_requirements_items) | -           |
+
+###### <a name="nodepool_template_spec_requirements_items"></a>3.6.2.3.1. karpenter-nodepool > nodepool > template > spec > requirements > requirements items
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+| Property                                                           | Pattern | Type            | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------ | ------- | --------------- | ---------- | ---------- | ----------------- |
+| - [key](#nodepool_template_spec_requirements_items_key )           | No      | string          | No         | -          | -                 |
+| - [operator](#nodepool_template_spec_requirements_items_operator ) | No      | string          | No         | -          | -                 |
+| - [values](#nodepool_template_spec_requirements_items_values )     | No      | array of string | No         | -          | -                 |
+
+###### <a name="nodepool_template_spec_requirements_items_key"></a>3.6.2.3.1.1. Property `karpenter-nodepool > nodepool > template > spec > requirements > requirements items > key`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="nodepool_template_spec_requirements_items_operator"></a>3.6.2.3.1.2. Property `karpenter-nodepool > nodepool > template > spec > requirements > requirements items > operator`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+###### <a name="nodepool_template_spec_requirements_items_values"></a>3.6.2.3.1.3. Property `karpenter-nodepool > nodepool > template > spec > requirements > requirements items > values`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of string` |
+| **Required** | No                |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                                         | Description |
+| ----------------------------------------------------------------------- | ----------- |
+| [values items](#nodepool_template_spec_requirements_items_values_items) | -           |
+
+###### <a name="nodepool_template_spec_requirements_items_values_items"></a>3.6.2.3.1.3.1. karpenter-nodepool > nodepool > template > spec > requirements > requirements items > values > values items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+##### <a name="nodepool_template_spec_startupTaints"></a>3.6.2.4. Property `karpenter-nodepool > nodepool > template > spec > startupTaints`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="nodepool_template_spec_taints"></a>3.6.2.5. Property `karpenter-nodepool > nodepool > template > spec > taints`
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | N/A                |
+
+##### <a name="nodepool_template_spec_terminationGracePeriod"></a>3.6.2.6. Property `karpenter-nodepool > nodepool > template > spec > terminationGracePeriod`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="nodepool_weight"></a>3.7. Property `karpenter-nodepool > nodepool > weight`
+
+|              |        |
+| ------------ | ------ |
+| **Type**     | `null` |
+| **Required** | No     |
+
+----------------------------------------------------------------------------------------------------------------------------

--- a/karpenter-nodepool/README.md
+++ b/karpenter-nodepool/README.md
@@ -185,15 +185,15 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                | Pattern | Type    | Deprecated | Definition | Title/Description |
-| --------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
-| - [annotations](#nodepool_annotations ) | No      | object  | No         | -          | -                 |
-| - [disruption](#nodepool_disruption )   | No      | object  | No         | -          | -                 |
-| - [enabled](#nodepool_enabled )         | No      | boolean | No         | -          | -                 |
-| - [limits](#nodepool_limits )           | No      | object  | No         | -          | -                 |
-| - [name](#nodepool_name )               | No      | string  | No         | -          | -                 |
-| - [template](#nodepool_template )       | No      | object  | No         | -          | -                 |
-| - [weight](#nodepool_weight )           | No      | null    | No         | -          | -                 |
+| Property                                | Pattern | Type            | Deprecated | Definition | Title/Description |
+| --------------------------------------- | ------- | --------------- | ---------- | ---------- | ----------------- |
+| - [annotations](#nodepool_annotations ) | No      | object          | No         | -          | -                 |
+| - [disruption](#nodepool_disruption )   | No      | object          | No         | -          | -                 |
+| - [enabled](#nodepool_enabled )         | No      | boolean         | No         | -          | -                 |
+| - [limits](#nodepool_limits )           | No      | object          | No         | -          | -                 |
+| - [name](#nodepool_name )               | No      | string          | No         | -          | -                 |
+| - [template](#nodepool_template )       | No      | object          | No         | -          | -                 |
+| - [weight](#nodepool_weight )           | No      | integer or null | No         | -          | -                 |
 
 ### <a name="nodepool_annotations"></a>3.1. Property `karpenter-nodepool > nodepool > annotations`
 
@@ -481,9 +481,14 @@
 
 ### <a name="nodepool_weight"></a>3.7. Property `karpenter-nodepool > nodepool > weight`
 
-|              |        |
-| ------------ | ------ |
-| **Type**     | `null` |
-| **Required** | No     |
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `integer or null` |
+| **Required** | No                |
+
+| Restrictions |          |
+| ------------ | -------- |
+| **Minimum**  | &ge; 1   |
+| **Maximum**  | &le; 100 |
 
 ----------------------------------------------------------------------------------------------------------------------------

--- a/karpenter-nodepool/ci/disabled-values.yaml
+++ b/karpenter-nodepool/ci/disabled-values.yaml
@@ -1,0 +1,5 @@
+clusterName: ci
+nodepool:
+  enabled: false
+nodeclass:
+  enabled: false

--- a/karpenter-nodepool/templates/_helpers.tpl
+++ b/karpenter-nodepool/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{- define "karpenter-nodepool.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "karpenter-nodepool.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "karpenter-nodepool.labels" -}}
+helm.sh/chart: {{ include "karpenter-nodepool.chart" . }}
+{{ include "karpenter-nodepool.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "karpenter-nodepool.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "karpenter-nodepool.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/karpenter-nodepool/templates/ec2nodeclass.yaml
+++ b/karpenter-nodepool/templates/ec2nodeclass.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.nodeclass.enabled }}
+{{- $clusterName := required "clusterName is required when nodeclass.enabled is true" .Values.clusterName }}
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: {{ .Values.nodeclass.name }}
+  labels:
+    {{- include "karpenter-nodepool.labels" . | nindent 4 }}
+  {{- with .Values.nodeclass.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  amiFamily: {{ .Values.nodeclass.amiFamily }}
+  amiSelectorTerms:
+    {{- toYaml .Values.nodeclass.amiSelectorTerms | nindent 4 }}
+  kubelet:
+    {{- toYaml .Values.nodeclass.kubelet | nindent 4 }}
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        deleteOnTermination: true
+        encrypted: true
+        volumeSize: {{ .Values.nodeclass.volumeSizeGi }}Gi
+        volumeType: gp3
+  role: {{ .Values.nodeclass.role | default (printf "karpenter-%s" $clusterName) }}
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: {{ $clusterName }}
+    - tags:
+        karpenter.sh/discovery/{{ $clusterName }}: {{ $clusterName }}
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: {{ $clusterName }}
+    - tags:
+        karpenter.sh/discovery/{{ $clusterName }}: {{ $clusterName }}
+  tags:
+    {{- toYaml (merge (dict "managedBy" "karpenter") .Values.nodeclass.tags (dict "env" $clusterName)) | nindent 4 }}
+{{- end }}

--- a/karpenter-nodepool/templates/ec2nodeclass.yaml
+++ b/karpenter-nodepool/templates/ec2nodeclass.yaml
@@ -25,15 +25,23 @@ spec:
         volumeType: gp3
   role: {{ .Values.nodeclass.role | default (printf "karpenter-%s" $clusterName) }}
   securityGroupSelectorTerms:
+    {{- if .Values.nodeclass.securityGroupSelectorTerms }}
+    {{- toYaml .Values.nodeclass.securityGroupSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ $clusterName }}
     - tags:
         karpenter.sh/discovery/{{ $clusterName }}: {{ $clusterName }}
+    {{- end }}
   subnetSelectorTerms:
+    {{- if .Values.nodeclass.subnetSelectorTerms }}
+    {{- toYaml .Values.nodeclass.subnetSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ $clusterName }}
     - tags:
         karpenter.sh/discovery/{{ $clusterName }}: {{ $clusterName }}
+    {{- end }}
   tags:
     {{- toYaml (merge (dict "managedBy" "karpenter") .Values.nodeclass.tags (dict "env" $clusterName)) | nindent 4 }}
 {{- end }}

--- a/karpenter-nodepool/templates/nodepool.yaml
+++ b/karpenter-nodepool/templates/nodepool.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.nodepool.enabled }}
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: {{ .Values.nodepool.name }}
+  labels:
+    {{- include "karpenter-nodepool.labels" . | nindent 4 }}
+  {{- with .Values.nodepool.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.nodepool.weight }}
+  weight: {{ . }}
+  {{- end }}
+  disruption:
+    consolidationPolicy: {{ .Values.nodepool.disruption.consolidationPolicy }}
+    consolidateAfter: {{ .Values.nodepool.disruption.consolidateAfter }}
+    {{- with .Values.nodepool.disruption.budgets }}
+    budgets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- with .Values.nodepool.limits }}
+  limits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    {{- if or .Values.nodepool.template.metadata.labels .Values.nodepool.template.metadata.annotations }}
+    metadata:
+      {{- with .Values.nodepool.template.metadata.labels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodepool.template.metadata.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    spec:
+      terminationGracePeriod: {{ .Values.nodepool.template.spec.terminationGracePeriod }}
+      expireAfter: {{ .Values.nodepool.template.spec.expireAfter }}
+      nodeClassRef:
+        group: {{ .Values.nodepool.template.spec.nodeClassRef.group }}
+        kind: {{ .Values.nodepool.template.spec.nodeClassRef.kind }}
+        name: {{ .Values.nodepool.template.spec.nodeClassRef.name }}
+      {{- with .Values.nodepool.template.spec.startupTaints }}
+      startupTaints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodepool.template.spec.taints }}
+      taints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      requirements:
+        {{- toYaml .Values.nodepool.template.spec.requirements | nindent 8 }}
+{{- end }}

--- a/karpenter-nodepool/tests/ec2nodeclass_test.yaml
+++ b/karpenter-nodepool/tests/ec2nodeclass_test.yaml
@@ -1,0 +1,99 @@
+suite: ec2nodeclass
+templates:
+  - ec2nodeclass.yaml
+values:
+  - ../ci/disabled-values.yaml
+tests:
+  - it: renders nothing when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the baseline default EC2NodeClass
+    set:
+      clusterName: test-cluster
+      nodeclass.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: EC2NodeClass
+      - equal:
+          path: metadata.name
+          value: default
+      - equal:
+          path: spec.amiFamily
+          value: AL2023
+      - equal:
+          path: spec.amiSelectorTerms[0].alias
+          value: al2023@latest
+      - equal:
+          path: spec.role
+          value: karpenter-test-cluster
+      - equal:
+          path: spec.blockDeviceMappings[0].ebs.volumeSize
+          value: 100Gi
+      - equal:
+          path: spec.kubelet.podsPerCore
+          value: 14
+      - equal:
+          path: spec.kubelet.systemReserved.cpu
+          value: 100m
+      - equal:
+          path: spec.securityGroupSelectorTerms[0].tags["karpenter.sh/discovery"]
+          value: test-cluster
+      - equal:
+          path: spec.securityGroupSelectorTerms[1].tags["karpenter.sh/discovery/test-cluster"]
+          value: test-cluster
+      - equal:
+          path: spec.subnetSelectorTerms[0].tags["karpenter.sh/discovery"]
+          value: test-cluster
+      - equal:
+          path: spec.tags.managedBy
+          value: karpenter
+      - equal:
+          path: spec.tags.env
+          value: test-cluster
+
+  - it: merges custom tags with managedBy and env defaults
+    set:
+      clusterName: test-cluster
+      nodeclass.enabled: true
+      nodeclass.tags:
+        project: argus-infra-stacks
+        service: eks
+        owner: infra-eng
+        env: custom-env
+        managedBy: overridden
+    asserts:
+      - equal:
+          path: spec.tags.project
+          value: argus-infra-stacks
+      - equal:
+          path: spec.tags.env
+          value: custom-env
+      - equal:
+          path: spec.tags.managedBy
+          value: karpenter
+
+  - it: honors role and volume size overrides
+    set:
+      clusterName: test-cluster
+      nodeclass.enabled: true
+      nodeclass.role: custom-role
+      nodeclass.volumeSizeGi: 150
+    asserts:
+      - equal:
+          path: spec.role
+          value: custom-role
+      - equal:
+          path: spec.blockDeviceMappings[0].ebs.volumeSize
+          value: 150Gi
+
+  - it: fails without clusterName
+    set:
+      nodeclass.enabled: true
+      clusterName: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: clusterName is required when nodeclass.enabled is true

--- a/karpenter-nodepool/tests/ec2nodeclass_test.yaml
+++ b/karpenter-nodepool/tests/ec2nodeclass_test.yaml
@@ -76,6 +76,27 @@ tests:
           path: spec.tags.managedBy
           value: karpenter
 
+  - it: honors explicit selector-term overrides
+    set:
+      clusterName: in-cluster
+      nodeclass.enabled: true
+      nodeclass.securityGroupSelectorTerms:
+        - tags:
+            karpenter.sh/discovery: real-cluster
+      nodeclass.subnetSelectorTerms:
+        - tags:
+            karpenter.sh/discovery: real-cluster
+    asserts:
+      - lengthEqual:
+          path: spec.securityGroupSelectorTerms
+          count: 1
+      - equal:
+          path: spec.securityGroupSelectorTerms[0].tags["karpenter.sh/discovery"]
+          value: real-cluster
+      - equal:
+          path: spec.subnetSelectorTerms[0].tags["karpenter.sh/discovery"]
+          value: real-cluster
+
   - it: honors role and volume size overrides
     set:
       clusterName: test-cluster

--- a/karpenter-nodepool/tests/nodepool_test.yaml
+++ b/karpenter-nodepool/tests/nodepool_test.yaml
@@ -1,0 +1,90 @@
+suite: nodepool
+templates:
+  - nodepool.yaml
+values:
+  - ../ci/disabled-values.yaml
+tests:
+  - it: renders nothing when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the baseline default NodePool
+    set:
+      clusterName: test-cluster
+      nodepool.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NodePool
+      - equal:
+          path: metadata.name
+          value: default
+      - equal:
+          path: spec.disruption.consolidationPolicy
+          value: WhenEmptyOrUnderutilized
+      - equal:
+          path: spec.disruption.consolidateAfter
+          value: 24h
+      - equal:
+          path: spec.template.spec.terminationGracePeriod
+          value: 1h
+      - equal:
+          path: spec.template.spec.expireAfter
+          value: 360h
+      - equal:
+          path: spec.template.spec.nodeClassRef.name
+          value: default
+      - lengthEqual:
+          path: spec.template.spec.requirements
+          count: 6
+      - notExists:
+          path: spec.template.spec.startupTaints
+      - notExists:
+          path: spec.template.spec.taints
+      - notExists:
+          path: spec.weight
+      - notExists:
+          path: spec.limits
+      - notExists:
+          path: spec.disruption.budgets
+      - notExists:
+          path: spec.template.metadata
+
+  - it: renders startupTaints, budgets, and weight when set
+    set:
+      clusterName: test-cluster
+      nodepool.enabled: true
+      nodepool.weight: 10
+      nodepool.disruption.budgets:
+        - nodes: "10%"
+      nodepool.template.spec.startupTaints:
+        - key: node.cilium.io/agent-not-ready
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.weight
+          value: 10
+      - equal:
+          path: spec.disruption.budgets[0].nodes
+          value: "10%"
+      - equal:
+          path: spec.template.spec.startupTaints[0].key
+          value: node.cilium.io/agent-not-ready
+
+  - it: renders template metadata labels and annotations when set
+    set:
+      clusterName: test-cluster
+      nodepool.enabled: true
+      nodepool.template.metadata.labels:
+        workload.type: general
+      nodepool.template.metadata.annotations:
+        example.com/note: value
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["workload.type"]
+          value: general
+      - equal:
+          path: spec.template.metadata.annotations["example.com/note"]
+          value: value

--- a/karpenter-nodepool/values.schema.json
+++ b/karpenter-nodepool/values.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "argo.helm.charts/karpenter-nodepool",
+  "title": "karpenter-nodepool",
+  "type": "object",
+  "properties": {
+    "clusterName": {
+      "type": "string"
+    },
+    "nodeclass": {
+      "type": "object",
+      "properties": {
+        "amiFamily": {
+          "type": "string"
+        },
+        "amiSelectorTerms": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "kubelet": {
+          "type": "object",
+          "properties": {
+            "podsPerCore": {
+              "type": "integer"
+            },
+            "systemReserved": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object"
+        },
+        "volumeSizeGi": {
+          "type": "integer"
+        }
+      }
+    },
+    "nodepool": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "disruption": {
+          "type": "object",
+          "properties": {
+            "budgets": {
+              "type": "array"
+            },
+            "consolidateAfter": {
+              "type": "string"
+            },
+            "consolidationPolicy": {
+              "type": "string"
+            }
+          }
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "limits": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "template": {
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "labels": {
+                  "type": "object"
+                }
+              }
+            },
+            "spec": {
+              "type": "object",
+              "properties": {
+                "expireAfter": {
+                  "type": "string"
+                },
+                "nodeClassRef": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "requirements": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "values": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "startupTaints": {
+                  "type": "array"
+                },
+                "taints": {
+                  "type": "array"
+                },
+                "terminationGracePeriod": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "weight": {
+          "type": "null"
+        }
+      }
+    }
+  }
+}

--- a/karpenter-nodepool/values.schema.json
+++ b/karpenter-nodepool/values.schema.json
@@ -55,6 +55,12 @@
         "role": {
           "type": "string"
         },
+        "securityGroupSelectorTerms": {
+          "type": "array"
+        },
+        "subnetSelectorTerms": {
+          "type": "array"
+        },
         "tags": {
           "type": "object"
         },

--- a/karpenter-nodepool/values.schema.json
+++ b/karpenter-nodepool/values.schema.json
@@ -160,7 +160,12 @@
           }
         },
         "weight": {
-          "type": "null"
+          "type": [
+            "integer",
+            "null"
+          ],
+          "maximum": 100,
+          "minimum": 1
         }
       }
     }

--- a/karpenter-nodepool/values.yaml
+++ b/karpenter-nodepool/values.yaml
@@ -83,6 +83,9 @@ nodeclass:
   amiSelectorTerms:
     - alias: al2023@latest
 
+  securityGroupSelectorTerms: []
+  subnetSelectorTerms: []
+
   kubelet:
     systemReserved:
       cpu: 100m

--- a/karpenter-nodepool/values.yaml
+++ b/karpenter-nodepool/values.yaml
@@ -1,0 +1,93 @@
+clusterName: ""
+
+nodepool:
+  enabled: true
+  name: default
+  annotations: {}
+  weight: null
+  limits: {}
+
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 24h
+    budgets: []
+
+  template:
+    metadata:
+      labels: {}
+      annotations: {}
+
+    spec:
+      terminationGracePeriod: 1h
+      expireAfter: 360h
+
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+
+      startupTaints: []
+      taints: []
+
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+            - arm64
+            - amd64
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+            - spot
+            - on-demand
+        - key: kubernetes.io/os
+          operator: In
+          values:
+            - linux
+        - key: karpenter.k8s.aws/instance-size
+          operator: NotIn
+          values:
+            - nano
+            - micro
+            - small
+        - key: karpenter.k8s.aws/instance-cpu
+          operator: Gt
+          values:
+            - "8"
+        - key: karpenter.k8s.aws/instance-family
+          operator: NotIn
+          values:
+            - a1
+            - c1
+            - cc1
+            - cc2
+            - cg1
+            - cg2
+            - cr1
+            - g1
+            - g2
+            - hi1
+            - hs1
+            - m1
+            - m2
+            - m3
+            - t1
+
+nodeclass:
+  enabled: true
+  name: default
+  annotations: {}
+  role: ""
+  amiFamily: AL2023
+
+  amiSelectorTerms:
+    - alias: al2023@latest
+
+  kubelet:
+    systemReserved:
+      cpu: 100m
+      memory: 100Mi
+    podsPerCore: 14
+
+  volumeSizeGi: 100
+  tags: {}

--- a/karpenter-nodepool/values.yaml
+++ b/karpenter-nodepool/values.yaml
@@ -4,7 +4,7 @@ nodepool:
   enabled: true
   name: default
   annotations: {}
-  weight: null
+  weight: null # @schema type:[integer, null]; minimum: 1; maximum: 100
   limits: {}
 
   disruption:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,6 +47,9 @@
     },
     "grafana-alloy": {
       "package-name": "grafana-alloy"
+    },
+    "karpenter-nodepool": {
+      "package-name": "karpenter-nodepool"
     }
   }
 }


### PR DESCRIPTION
## Summary

New generic `karpenter-nodepool` chart rendering a Karpenter NodePool (name defaults to `default`) and its EC2NodeClass — the ArgoCD half of chanzuckerberg/cztack#914, where the cztack module creates these objects once at cluster bootstrap and permanently releases ownership. ArgoCD adopts the same-named objects on first sync and owns all subsequent updates, so spec changes drift-reconcile through Karpenter instead of Terraform's replace-the-pool-and-drain-everything model.

- Chart defaults reproduce the cztack baseline spec exactly, so one common values file covers the fleet and per-cluster values carry only deviations.
- Closes the NodePool field gaps `karpenter-gpu-nodepool` can't express (`terminationGracePeriod`, `disruption.budgets`, `weight`, annotations) with optional fields properly guarded; gpu/binder-design convergence onto this chart is a follow-up.
- EC2NodeClass derives the IAM role (`karpenter-<clusterName>`) and both discovery-tag selectors from `clusterName`; instance cost tags merge with `managedBy: karpenter` always winning and `env` defaulting to the cluster name.
- `ci/disabled-values.yaml` keeps `ct install` green on a kind cluster without Karpenter CRDs.

## Review focus

- Tag-merge precedence in `templates/ec2nodeclass.yaml`: `managedBy` must beat user tags, while `env` must lose to them.
- Baseline parity in `values.yaml` (requirements/disruption/kubelet): an unintended diff here becomes a fleet-wide change at adoption.
- `clusterName` is only `required` when the nodeclass renders — a NodePool-only install works without it, deliberately.
- The `@schema type:[integer, null]` annotation on `nodepool.weight` — the schema bot otherwise types a `null` default as only-null, which broke schema validation for any real value.

## Test plan

- 9 helm-unittest cases: baseline rendering, optional fields, tag merging, overrides, missing-clusterName failure.
- Rendered output diffed against live objects on dev-katamari (baseline) and prod-bhp (deviation cluster): NodePool `disruption` and `template.spec` byte-identical; EC2NodeClass differs only in server-defaulted `metadataOptions`, which neither Terraform nor the chart sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
