### PR TITLE
fix(stack): dedupe rendered env entries by name, later holders win

### DIFF
--- a/stack/templates/_helpers.tpl
+++ b/stack/templates/_helpers.tpl
@@ -166,13 +166,25 @@ true
 {{- end -}}
 
 {{- define "service.nonsensitiveEnvVars" -}}
-{{- $envs := list }}
+{{- $all := list }}
 {{- range $i, $envHolder := . -}}
-{{ $envs = concat $envs (default (list) $envHolder.env) }}
+{{- $all = concat $all (default (list) $envHolder.env) }}
+{{- end -}}
+{{- $latest := dict }}
+{{- range $e := $all -}}
+{{- $_ := set $latest $e.name $e }}
+{{- end -}}
+{{- $envs := list }}
+{{- $emitted := dict }}
+{{- range $e := $all -}}
+{{- if not (hasKey $emitted $e.name) }}
+{{- $_ := set $emitted $e.name true }}
+{{- $envs = append $envs (get $latest $e.name) }}
+{{- end }}
 {{- end -}}
 {{- if ne (len $envs) 0 -}}
 env:
-{{ toYaml (uniq $envs) }}
+{{ toYaml $envs }}
 {{- else -}}
 env: []
 {{- end }}

--- a/stack/tests/deployment_test.yaml
+++ b/stack/tests/deployment_test.yaml
@@ -312,3 +312,52 @@ tests:
       - equal:
           path: spec.template.spec.volumes[0].configMap.name
           value: "otel-collector-config-literal-str"
+  - it: service env overrides global env entry with the same name
+    set:
+      global:
+        env:
+          - name: SHARED_VAR
+            value: "global value"
+          - name: GLOBAL_ONLY
+            value: "global only"
+      services:
+        service1:
+          env:
+            - name: SHARED_VAR
+              value: "service value"
+            - name: SERVICE_ONLY
+              value: "service only"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: SHARED_VAR
+              value: "service value"
+            - name: GLOBAL_ONLY
+              value: "global only"
+            - name: SERVICE_ONLY
+              value: "service only"
+
+  - it: sidecar env overrides service and global env entries with the same name
+    set:
+      global:
+        env:
+          - name: SHARED_VAR
+            value: "global value"
+      services:
+        service1:
+          env:
+            - name: SHARED_VAR
+              value: "service value"
+          sidecars:
+            - name: sidecar1
+              image: "sidecar1:latest"
+              env:
+                - name: SHARED_VAR
+                  value: "sidecar value"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env
+          value:
+            - name: SHARED_VAR
+              value: "sidecar value"


### PR DESCRIPTION
## Problem

`service.nonsensitiveEnvVars` concatenates the `global`, service, and container `env` lists and runs Sprig `uniq`, which only drops entries identical in **both name and value**. Defining a var at the global level and overriding it with a different value at the service level renders the var twice in the container spec:

```yaml
env:
  - name: USE_IAM_AUTH
    value: "true"    # from global.env
  - name: USE_IAM_AUTH
    value: "false"   # from services.<name>.env
```

`env` is a `listType=map` keyed by `name`, so the apiserver rejects this under server-side apply — which every Argus-managed Application uses (`ServerSideApply=true`):

```
failed to create typed patch object (...): .spec.template.spec.containers[name="stack"].env:
duplicate entries for key [name="USE_IAM_AUTH"]
```

This contradicts the [Argus env_vars docs](https://chanzuckerberg.github.io/argus/configuration/env_vars.html#combining-commonyaml-and-prod-valuesyaml-service-specific-env), which have always documented service-level env overriding a same-named global entry. Hit in the wild by edu-platform-grant-system rdev stacks (global `USE_IAM_AUTH=true` in `common.yaml`, per-service `"false"` in `rdev/values.yaml`).

## Fix

Dedupe rendered env entries by `name`. The last holder to define a name wins, i.e. container > service > global — the precedence the docs describe. Deduped entries keep the position of their **first** occurrence, so:

- rendering is byte-identical for any stack with no same-name overrides (all 232 existing tests and 3 snapshots pass unchanged), and
- `$(VAR)` dependent-interpolation order is preserved (an overridden global var stays ahead of later vars that reference it).

Backward-compatibility note: stacks with same-name/different-value entries could not sync at all (SSA rejects the manifest), and same-name/same-value duplicates were already collapsed by `uniq` — so no currently-syncing stack changes behavior.

## Testing

- New helm-unittest cases: service-over-global override and sidecar-over-service-over-global override (both fail on `main`, pass here).
- `helm unittest stack`: 232/232 pass, 3/3 snapshots.
- Rendered edu-platform-grant-system's real `.infra/common.yaml` + `rdev/values.yaml` against this chart: `grant-api`/`grant-api-admin` each get a single `USE_IAM_AUTH="false"`, `grant-db` inherits the global `"true"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)